### PR TITLE
fixing a syntax error

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -16,7 +16,7 @@ class datadog::ubuntu(
 
     exec { "datadog_key":
       command => "/usr/bin/apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $apt_key",
-      unless  => "/usr/bin/apt-key list | grep $apt_key | grep expires"
+      unless  => "/usr/bin/apt-key list | grep $apt_key | grep expires",
       notify  => Exec['datadog_apt-get_update'],
     }
 


### PR DESCRIPTION
I get a syntax error warning when running this module under Ubuntu. This is caused by a missing comma in the Ubuntu manifest.

```
Error: Syntax error at 'notify'; expected '}' at /etc/puppet/modules/datadog/manifests/ubuntu.pp:20 on node local
```
