### PR TITLE
Removed datadog-agent-base block

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -19,11 +19,6 @@ class datadog_agent::redhat {
       baseurl   => "http://yum.datadoghq.com/rpm/${::architecture}/",
     }
 
-    package { "datadog-agent-base":
-      ensure => absent,
-      before => Package['datadog-agent'],
-    }
-
     package { 'datadog-agent':
       ensure  => latest,
       require => Yumrepo['datadog'],


### PR DESCRIPTION
This block seems to trick my system into uninstalling the datadog-agent rpm and failing subsequent puppet runs
