### PR TITLE
add service_enable and service_ensure as class parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,9 @@ class datadog_agent(
   $puppet_run_reports = false,
   $puppetmaster_user = 'puppet',
   $non_local_traffic = false,
-  $log_level = 'info'
+  $log_level = 'info',
+  $service_ensure = 'running',
+  $service_enable = true
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -30,8 +30,8 @@ class datadog_agent::redhat {
     }
 
     service { "datadog-agent":
-      ensure    => running,
-      enable    => true,
+      ensure    => $::datadog_agent::service_ensure,
+      enable    => $::datadog_agent::service_enable,
       hasstatus => false,
       pattern   => 'dd-agent',
       require   => Package["datadog-agent"],

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -43,8 +43,8 @@ class datadog_agent::ubuntu(
     }
 
     service { "datadog-agent":
-      ensure    => running,
-      enable    => true,
+      ensure    => $::datadog_agent::service_ensure,
+      enable    => $::datadog_agent::service_enable,
       hasstatus => false,
       pattern   => 'dd-agent',
       require   => Package["datadog-agent"],


### PR DESCRIPTION
Allows external control of when to start datadog agent.

This is an important feature when building machine images with datadog, to stop it from connecting to the API and registering an agent during the build process.
