### PR TITLE
Adding proxy support for puppet configs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,10 +83,10 @@ class datadog_agent(
   validate_bool($non_local_traffic)
   validate_bool($log_to_syslog)
   validate_string($log_level)
-  validate_string($proxy_url)
-  validate_string($proxy_port)
-  validate_string($proxy_user)
-  validate_string($proxy_password)
+  validate_string($::proxy_host)
+  validate_string($::proxy_port)
+  validate_string($::proxy_user)
+  validate_string($::proxy_password)
 
   include datadog_agent::params
   case upcase($log_level) {
@@ -116,13 +116,13 @@ class datadog_agent(
 
   # main agent config file
   file { '/etc/dd-agent/datadog.conf':
-    ensure          => file,
-    content         => template('datadog_agent/datadog.conf.erb'),
-    owner           => $datadog_agent::params::dd_user,
-    group           => $datadog_agent::params::dd_group,
-    mode            => '0640',
-    notify          => Service[$datadog_agent::params::service_name],
-    require         => File['/etc/dd-agent'],
+    ensure  => file,
+    content => template('datadog_agent/datadog.conf.erb'),
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0640',
+    notify  => Service[$datadog_agent::params::service_name],
+    require => File['/etc/dd-agent'],
   }
 
   if $puppet_run_reports {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,14 @@
 #   $log_to_syslog
 #       Set value of 'log_to_syslog' variable. Default is true -> yes as in dd-agent.
 #       Valid values here are: true or false.
-#
+#   $proxy_host
+#       Set value of 'proxy_host' variable. Default is blank.
+#   $proxy_port
+#       Set value of 'proxy_port' variable. Default is blank.
+#   $proxy_user
+#       Set value of 'proxy_user' variable. Default is blank.
+#   $proxy_password
+#       Set value of 'proxy_password' variable. Default is blank.
 # Actions:
 #
 # Requires:
@@ -59,7 +66,11 @@ class datadog_agent(
   $log_level = 'info',
   $log_to_syslog = true,
   $service_ensure = 'running',
-  $service_enable = true
+  $service_enable = true,
+  $proxy_host = $datadog::params::proxy_host,
+  $proxy_port = $datadog::params::proxy_port,
+  $proxy_user = $datadog::params::proxy_user,
+  $proxy_password = $datadog::params::proxy_password
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)
@@ -72,6 +83,10 @@ class datadog_agent(
   validate_bool($non_local_traffic)
   validate_bool($log_to_syslog)
   validate_string($log_level)
+  validate_string($proxy_url)
+  validate_string($proxy_port)
+  validate_string($proxy_user)
+  validate_string($proxy_password)
 
   include datadog_agent::params
   case upcase($log_level) {
@@ -101,13 +116,13 @@ class datadog_agent(
 
   # main agent config file
   file { '/etc/dd-agent/datadog.conf':
-    ensure  => file,
-    content => template('datadog_agent/datadog.conf.erb'),
-    owner   => $datadog_agent::params::dd_user,
-    group   => $datadog_agent::params::dd_group,
-    mode    => '0640',
-    notify  => Service[$datadog_agent::params::service_name],
-    require => File['/etc/dd-agent'],
+    ensure          => file,
+    content         => template('datadog_agent/datadog.conf.erb'),
+    owner           => $datadog_agent::params::dd_user,
+    group           => $datadog_agent::params::dd_group,
+    mode            => '0640',
+    notify          => Service[$datadog_agent::params::service_name],
+    require         => File['/etc/dd-agent'],
   }
 
   if $puppet_run_reports {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,14 +15,14 @@
 # Sample Usage:
 #
 class datadog_agent::params {
-  $conf_dir     = '/etc/dd-agent/conf.d'
-  $dd_user      = 'dd-agent'
-  $dd_group     = 'root'
-  $package_name = 'datadog-agent'
-  $service_name = 'datadog-agent'
-  $proxy_host = ''
-  $proxy_port = ''
-  $proxy_user = ''
+  $conf_dir       = '/etc/dd-agent/conf.d'
+  $dd_user        = 'dd-agent'
+  $dd_group       = 'root'
+  $package_name   = 'datadog-agent'
+  $service_name   = 'datadog-agent'
+  $proxy_host     = ''
+  $proxy_port     = ''
+  $proxy_user     = ''
   $proxy_password = ''
 
   case $::operatingsystem {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,10 @@ class datadog_agent::params {
   $dd_group     = 'root'
   $package_name = 'datadog-agent'
   $service_name = 'datadog-agent'
+  $proxy_host = ''
+  $proxy_port = ''
+  $proxy_user = ''
+  $proxy_password = ''
 
   case $::operatingsystem {
     'Ubuntu','Debian' : {

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -7,10 +7,26 @@
 dd_url: <%= @dd_url %>
 
 # If you need a proxy to connect to the Internet, provide the settings here
-# proxy_host: my-proxy.com
-# proxy_port: 3128
-# proxy_user: user
-# proxy_password: password
+<% if @proxy_host -%>
+proxy_host: <%= @proxy_host %>
+<% else -%>
+# proxy_host:
+<% end -%>
+<% if @proxy_port -%>
+proxy_port: <%= @proxy_port %>
+<% else -%>
+# proxy_port:
+<% end -%>
+<% if @proxy_user -%>
+proxy_user: <%= @proxy_user %>
+<% else -%>
+# proxy_user:
+<% end -%>
+<% if @proxy_password -%>
+proxy_password: <%= @proxy_password %>
+<% else -%>
+# proxy_password:
+<% end -%>
 
 # If you run the agent behind haproxy, you might want to set this to yes
 # skip_ssl_validation: no


### PR DESCRIPTION
This adds proxy support (host, port, user, password) for the datadog agent config file