### PR TITLE
Add specs to cover all base manifests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
   symlinks:
     datadog_agent: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.6.0'
   gem "puppet-lint"
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"
+  gem "rake"
+  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
 end
 
 group :development do

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -19,6 +19,11 @@ class datadog_agent::redhat {
       baseurl  => "http://yum.datadoghq.com/rpm/${::architecture}/",
     }
 
+    package { 'datadog-agent-base':
+      ensure => absent,
+      before => Package['datadog-agent'],
+    }
+
     package { 'datadog-agent':
       ensure  => latest,
       require => Yumrepo['datadog'],

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -17,7 +17,6 @@ class datadog_agent::ubuntu(
     exec { 'datadog_key':
       command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${apt_key}",
       unless  => "/usr/bin/apt-key list | grep ${apt_key} | grep expires",
-      notify  => Exec['datadog_apt-get_update'],
     }
 
     file { '/etc/apt/sources.list.d/datadog.list':

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'datadog_agent::redhat' do
+  let(:facts) do
+    {
+      osfamily: 'redhat',
+      operatingsystem: 'Fedora',
+      architecture: 'x86_64'
+    }
+  end
+
+  # it should install the mirror
+  it do
+    should contain_yumrepo('datadog')
+      .with_enabled(1)\
+      .with_gpgcheck(0)\
+      .with_baseurl('http://yum.datadoghq.com/rpm/x86_64/')
+  end
+
+  # it should install the packages
+  it do
+    should contain_package('datadog-agent-base')\
+      .with_ensure('absent')\
+      .that_comes_before('Package[datadog-agent]')
+  end
+  it do
+    should contain_package('datadog-agent')\
+      .with_ensure('latest')
+  end
+
+  # it should be able to start the service and enable the service by default
+  it do
+    should contain_service('datadog-agent')\
+      .that_requires('Package[datadog-agent]')
+  end
+end

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'datadog_agent::reports' do
+  let(:params) do
+    {
+      api_key: 'notanapikey',
+      puppetmaster_user: 'puppet'
+    }
+  end
+
+  context 'all supported operating systems' do
+    ALL_OS.each do |operatingsystem|
+      describe "datadog_agent class common actions on #{operatingsystem}" do
+        let(:facts) do
+          {
+            operatingsystem: operatingsystem,
+            osfamily: DEBIAN_OS.include?(operatingsystem) ? 'debian' : 'redhat'
+          }
+        end
+
+        it { should contain_class('ruby').with_rubygems_update(false) }
+        it { should contain_class('ruby::params') }
+        it { should contain_package('ruby').with_ensure('installed') }
+        it { should contain_package('rubygems').with_ensure('installed') }
+
+        if DEBIAN_OS.include?(operatingsystem)
+          it do
+            should contain_package('ruby-dev')\
+              .with_ensure('installed')\
+              .that_comes_before('Package[dogapi]')
+          end
+        elsif REDHAT_OS.include?(operatingsystem)
+          it do
+            should contain_package('ruby-devel')\
+              .with_ensure('installed')\
+              .that_comes_before('Package[dogapi]')
+          end
+        end
+
+        it do
+          should contain_package('dogapi')\
+            .with_ensure('installed')
+            .with_provider('gem')
+        end
+
+        it do
+          should contain_file('/etc/dd-agent/datadog.yaml')\
+            .with_owner('puppet')\
+            .with_group('root')
+        end
+
+      end
+    end
+  end
+end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -1,40 +1,54 @@
 require 'spec_helper'
 
 describe 'datadog_agent' do
-
-  context 'Debian based supported operating systems' do
-    ['Ubuntu', 'Debian'].each do |operatingsystem|
-      describe "datadog_agent class without any parameters on #{operatingsystem}" do
-        let(:params) {{ }}
-        let(:facts) {{
-          :operatingsystem => operatingsystem,
-        }}
-
-        it { should contain_class('datadog_agent::ubuntu') }
-      end
-    end
-  end
-
-  context 'Yum based supported operating systems' do
-      ['RedHat', 'CentOS', 'Fedora', 'Amazon', 'Scientific'].each do |operatingsystem|
-      describe "datadog_agent class without any parameters on #{operatingsystem}" do
-        let(:params) {{ }}
-        let(:facts) {{
-          :operatingsystem => operatingsystem,
-        }}
-
-        it { should contain_class('datadog_agent::redhat') }
-      end
-    end
-  end
   context 'unsupported operating system' do
     describe 'datadog_agent class without any parameters on Solaris/Nexenta' do
-      let(:facts) {{
-        :osfamily        => 'Solaris',
-        :operatingsystem => 'Nexenta',
-      }}
+      let(:facts) do
+        {
+          osfamily:         'Solaris',
+          operatingsystem:  'Nexenta'
+        }
+      end
 
-      it { expect { should contain_package('module') }.to raise_error(Puppet::Error, /Unsupported operatingsystem: Nexenta/) }
+      it do
+        expect {
+          should contain_package('module')
+        }.to raise_error(Puppet::Error, /Unsupported operatingsystem: Nexenta/)
+      end
+    end
+  end
+
+  # Test all supported OSes
+  context 'all supported operating systems' do
+    ALL_OS.each do |operatingsystem|
+      describe "datadog_agent class common actions on #{operatingsystem}" do
+        let(:params) { { puppet_run_reports: true } }
+        let(:facts) do
+          {
+            operatingsystem: operatingsystem,
+            osfamily: DEBIAN_OS.include?(operatingsystem) ? 'debian' : 'redhat'
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        it { should contain_class('datadog_agent') }
+
+        describe 'datadog_agent imports the default params' do
+          it { should contain_class('datadog_agent::params') }
+        end
+
+        it { should contain_file('/etc/dd-agent') }
+        it { should contain_file('/etc/dd-agent/datadog.conf') }
+
+        it { should contain_class('datadog_agent::reports') }
+
+        if DEBIAN_OS.include?(operatingsystem)
+          it { should contain_class('datadog_agent::ubuntu') }
+        elsif REDHAT_OS.include?(operatingsystem)
+          it { should contain_class('datadog_agent::redhat') }
+        end
+      end
     end
   end
 end

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'datadog_agent::ubuntu' do
+  let(:facts) do
+    {
+      osfamily: 'debian',
+      operatingsystem: 'Ubuntu'
+    }
+  end
+
+  # it should install the mirror
+  it { should contain_exec('datadog_key') }
+  it do
+    should contain_file('/etc/apt/sources.list.d/datadog.list')\
+      .that_notifies('Exec[datadog_apt-get_update]')
+  end
+  it { should contain_exec('datadog_apt-get_update') }
+
+  # it should install the packages
+  it do
+    should contain_package('datadog-agent-base')\
+      .with_ensure('absent')\
+      .that_comes_before('Package[datadog-agent]')
+  end
+  it do
+    should contain_package('datadog-agent')\
+      .that_requires('File[/etc/apt/sources.list.d/datadog.list]')\
+      .that_requires('Exec[datadog_apt-get_update]')
+  end
+
+  # it should be able to start the service and enable the service by default
+  it do
+    should contain_service('datadog-agent')\
+      .that_requires('Package[datadog-agent]')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+DEBIAN_OS = %w(Ubuntu Debian)
+REDHAT_OS = %w(RedHat CentOS Fedora Amazon Scientific)
+ALL_OS = DEBIAN_OS + REDHAT_OS
+


### PR DESCRIPTION
Plus a few improvements in the manifests that were easy to catch
with the specs:
* no need to run apt-get update after adding the repo key
* the redhat manifest should uninstall datadog-agent-base