### PR TITLE
[process/nginx] fixes #43 by ordering hashes

### DIFF
--- a/templates/agent-conf.d/nginx.yaml.erb
+++ b/templates/agent-conf.d/nginx.yaml.erb
@@ -16,4 +16,32 @@
 #         tags:
 #             -   instance:bar
 
-<%= require 'yaml'; {'init_config'=>nil, 'instances'=>@instances}.to_yaml %>
+<%
+
+require 'yaml'
+
+if RUBY_VERSION < "1.9"
+# Hack to avoid ruby 1.8 always reordering the hashes and
+# changing this template resource at every run
+#
+# Taken from http://www.dzone.com/snippets/generating-yaml-hashes-sorted
+class Hash
+  # Replacing the to_yaml function so it'll serialize hashes sorted (by their keys)
+  #
+  # Original function is in /usr/lib/ruby/1.8/yaml/rubytypes.rb
+  def to_yaml( opts = {} )
+    YAML::quick_emit( object_id, opts ) do |out|
+      out.map( taguri, to_yaml_style ) do |map|
+        sort.each do |k, v|   # <-- here's my addition (the 'sort')
+          map.add( k, v )
+        end
+      end
+    end
+  end
+end
+end
+
+
+%>
+
+<%= {'init_config'=>nil, 'instances'=>@instances}.to_yaml %>

--- a/templates/agent-conf.d/process.yaml.erb
+++ b/templates/agent-conf.d/process.yaml.erb
@@ -16,4 +16,29 @@
 # - name: All
 #   search_string: ['All']
 
-<%= require 'yaml'; {'init_config'=>nil, 'instances'=>@processes}.to_yaml %>
+<%
+require 'yaml'
+
+if RUBY_VERSION < "1.9"
+# Hack to avoid ruby 1.8 always reordering the hashes and
+# changing this template resource at every run
+# See https://github.com/DataDog/puppet-datadog-agent/issues/43
+# Taken from http://www.dzone.com/snippets/generating-yaml-hashes-sorted
+class Hash
+  # Replacing the to_yaml function so it'll serialize hashes sorted (by their keys)
+  #
+  # Original function is in /usr/lib/ruby/1.8/yaml/rubytypes.rb
+  def to_yaml( opts = {} )
+    YAML::quick_emit( object_id, opts ) do |out|
+      out.map( taguri, to_yaml_style ) do |map|
+        sort.each do |k, v|   # <-- here's my addition (the 'sort')
+          map.add( k, v )
+        end
+      end
+    end
+  end
+end
+end
+%>
+
+<%= {'init_config'=>nil, 'instances'=>@processes}.to_yaml %>


### PR DESCRIPTION
Puppet 2.7 that we support runs on ruby 1.8.5 or 1.8.7
:crying_cat_face:
As a consequence, the hash when serialized by the .to_yaml function
can go in any order in the rendered string.
To avoid that we monkey patch the to_yaml function to sort the hash
by key every time if the ruby we are using is < 1.9.
It should avoid puppet to regenerate the same resource over and over
just because of some stupid ordering issues.