### PR TITLE
Enabling graphite listener port to be defined via class declaration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,8 @@
 #       Set value of 'proxy_user' variable. Default is blank.
 #   $proxy_password
 #       Set value of 'proxy_password' variable. Default is blank.
+#   $graphite_listen_port
+#       Set graphite listener port
 # Actions:
 #
 # Requires:
@@ -74,7 +76,8 @@ class datadog_agent(
   $proxy_host = '',
   $proxy_port = '',
   $proxy_user = '',
-  $proxy_password = ''
+  $proxy_password = '',
+  $graphite_listen_port = ''
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)
@@ -91,6 +94,7 @@ class datadog_agent(
   validate_string($proxy_port)
   validate_string($proxy_user)
   validate_string($proxy_password)
+  validate_string($graphite_listen_port)
 
   include datadog_agent::params
   case upcase($log_level) {

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -82,7 +82,11 @@ use_mount: <%= @use_mount %>
 # listen_port: 17123
 
 # Start a graphite listener on this port
+<% if @graphite_listen_port.empty? -%>
 # graphite_listen_port: 17124
+<% else -%>
+graphite_listen_port: <%= @graphite_listen_port %>
+<% end -%>
 
 # Additional directory to look for Datadog checks
 # additional_checksd: /etc/dd-agent/checks.d/


### PR DESCRIPTION
Allow for graphite listener port to be configured via class declaration

example:

class { "datadog_agent":
    api_key                    => "API_KEY",
    graphite_listen_port => '17124'
}