### PR TITLE
Adding the ability for dogstreams to be defined via class declaration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,7 +77,7 @@ class datadog_agent(
   $proxy_port = '',
   $proxy_user = '',
   $proxy_password = '',
-  $dogstreams = ''.
+  $dogstreams = ''
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,8 @@
 #       Set value of 'proxy_user' variable. Default is blank.
 #   $proxy_password
 #       Set value of 'proxy_password' variable. Default is blank.
+#   $dogstreams
+#       Comma-separated list of logs to parse and optionally custom parsers to use.
 # Actions:
 #
 # Requires:
@@ -74,7 +76,8 @@ class datadog_agent(
   $proxy_host = '',
   $proxy_port = '',
   $proxy_user = '',
-  $proxy_password = ''
+  $proxy_password = '',
+  $dogstreams = ''.
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)
@@ -91,6 +94,7 @@ class datadog_agent(
   validate_string($proxy_port)
   validate_string($proxy_user)
   validate_string($proxy_password)
+  validate_string($dogstreams)
 
   include datadog_agent::params
   case upcase($log_level) {

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -202,6 +202,11 @@ non_local_traffic: <%= @non_local_traffic %>
 # If this value isn't specified, the default parser assumes this log format:
 #     metric timestamp value key0=val0 key1=val1 ...
 #
+<% if @dogstreams.empty? -%>
+# dogstreams:
+<% else -%>
+dogstreams: <%= @dogstreams %>
+<% end -%>
 
 # ========================================================================== #
 # Custom Emitters                                                            #


### PR DESCRIPTION
Dogstream can be declared via class declaration on a per node  basis..

Provide a comma-separated list of logs to parse and optionally custom parsers to use.

class { 'datadog_agent':
     api_key   => 'your key',
     dogstreams => "/var/log/messages, /var/log/syslog",
 }