### PR TITLE
Add "sock" parameter to Datadog mysql integration

### DIFF
--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -9,6 +9,8 @@
 #       The mysql password for the datadog user
 #   $user
 #       The mysql user for the datadog user
+#   $sock
+#       Connect mysql via unix socket
 #   $tags
 #       Optional array of tags
 #   $replication
@@ -29,6 +31,7 @@ class datadog_agent::integrations::mysql(
   $host = 'localhost',
   $password,
   $user = 'datadog',
+  $sock = undef,
   $tags = [],
   $replication = '0',
   $galera_cluster = '0'

--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -8,6 +8,9 @@ instances:
   - server: <%= @host %>
     user: <%= @user %>
     pass: <%= @password %>
+<% if @sock -%>
+    sock: <%= @sock %>
+<% end -%>
 #    port: 3306             # Optional
 #    defaults_file: my.cnf  # Alternate configuration mechanism
 <% if !@tags.empty? -%>


### PR DESCRIPTION
In my opinion, it could be useful when you manage an "all in one" machine.