### PR TITLE
Fix discrepency in process module w/ agent default

### DIFF
--- a/manifests/integrations/process.pp
+++ b/manifests/integrations/process.pp
@@ -12,7 +12,7 @@
 #       return the counter of all the processes that contain the string
 #
 #   exact_match
-#       True/False, default to False, if you want to look for an arbitrary
+#       True/False, default to True, if you want to look for an arbitrary
 #       string, use exact_match: False, unless use the exact base name of the process
 #
 #   cpu_check_interval


### PR DESCRIPTION
dd-agent, in absence of having exact_match set, will default to True rather than False.
https://github.com/DataDog/dd-agent/blob/master/checks.d/process.py#L165