### PR TITLE
adding the apt key should happen before apt-get update

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -17,6 +17,7 @@ class datadog_agent::ubuntu(
     exec { 'datadog_key':
       command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${apt_key}",
       unless  => "/usr/bin/apt-key list | grep ${apt_key} | grep expires",
+      before  => File['/etc/apt/sources.list.d/datadog.list'],
     }
 
     file { '/etc/apt/sources.list.d/datadog.list':


### PR DESCRIPTION
fixing some ordering issues with apt management