### PR TITLE
Add mesos/marathon/docker classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 before_install: rm -f Gemfile.lock
+sudo: false
+cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/manifests/integrations/docker.pp
+++ b/manifests/integrations/docker.pp
@@ -9,6 +9,9 @@
 #   $url:
 #     The URL for docker API
 #
+#   $tags:
+#     optional array of tags
+#
 # Sample Usage:
 #
 #   class { 'datadog_agent::integrations::docker' :
@@ -19,6 +22,7 @@
 class datadog_agent::integrations::docker(
   $new_tag_names = true,
   $url = 'unix://var/run/docker.sock',
+  $tags = [],
 ) inherits datadog_agent::params {
 
   file { "${datadog_agent::params::conf_dir}/docker.yaml":

--- a/manifests/integrations/docker.pp
+++ b/manifests/integrations/docker.pp
@@ -3,19 +3,23 @@
 # This class will install the necessary configuration for the docker integration
 #
 # Parameters:
-#   $tags
-#       Optional array of tags
+#   $new_tag_names:
+#     Update docker new tags
+#
+#   $url:
+#     The URL for docker API
 #
 # Sample Usage:
 #
 #   class { 'datadog_agent::integrations::docker' :
+#     new_tag_names => true,
+#     url           => 'unix://var/run/docker.sock',
 #   }
 #
 class datadog_agent::integrations::docker(
-  $tags      = []
+  $new_tag_names = true,
+  $url = 'unix://var/run/docker.sock',
 ) inherits datadog_agent::params {
-
-  validate_array($tags)
 
   file { "${datadog_agent::params::conf_dir}/docker.yaml":
     ensure  => file,

--- a/manifests/integrations/marathon.pp
+++ b/manifests/integrations/marathon.pp
@@ -1,0 +1,29 @@
+# Class: datadog_agent::integrations::marathon
+#
+# This class will install the necessary configuration for the Marathon integration
+#
+# Parameters:
+#   $url:
+#     The URL for Marathon
+#
+# Sample Usage:
+#
+#   class { 'datadog_agent::integrations::marathon' :
+#     url  => "http://localhost:8080"
+#   }
+#
+class datadog_agent::integrations::marathon(
+  $marathon_timeout = 5,
+  $url = 'http://localhost:8080'
+) inherits datadog_agent::params {
+
+  file { "${datadog_agent::params::conf_dir}/marathon.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0644',
+    content => template('datadog_agent/agent-conf.d/marathon.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/manifests/integrations/mesos.pp
+++ b/manifests/integrations/mesos.pp
@@ -1,0 +1,29 @@
+# Class: datadog_agent::integrations::mesos
+#
+# This class will install the necessary configuration for the mesos integration
+#
+# Parameters:
+#   $url:
+#     The URL for Mesos master
+#
+# Sample Usage:
+#
+#   class { 'datadog_agent::integrations::mesos' :
+#     url  => "http://localhost:5050"
+#   }
+#
+class datadog_agent::integrations::mesos(
+  $mesos_timeout = 5,
+  $url = 'http://localhost:5050'
+) inherits datadog_agent::params {
+
+  file { "${datadog_agent::params::conf_dir}/mesos.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0644',
+    content => template('datadog_agent/agent-conf.d/mesos.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/templates/agent-conf.d/docker.yaml.erb
+++ b/templates/agent-conf.d/docker.yaml.erb
@@ -2,82 +2,8 @@
 # MANAGED BY PUPPET
 #
 
-# Warning
-# The user running the Datadog Agent (usually "dd-agent") must be part of the "docker" group
-
 init_config:
-    # Change the root directory to look at to get cgroup statistics. Useful when running inside a
-    # container with host directories mounted on a different folder. Default: /.
-    # Example for the docker-dd-agent container:
-    # docker_root: /host
-    #
-    #docker_root: /
-
-    # Timeout on Docker socket connection. You may have to increase it if you have many containers.
-    #
-    #socket_timeout: 5
 
 instances:
-      # URL of the Docker daemon socket to reach the Docker API. HTTP also works.
-      #
-    - url: "unix://var/run/docker.sock"
-
-      # Use tag names that don't conflict.
-      # Keep it false if you have old dashboard using the old tag names. Default: false.
-      new_tag_names: true
-
-      # Tag metrics with the command running inside the container.
-      #tag_by_command: false
-
-      # You can add extra tags to your Docker metrics with the tags list option. Default: [].
-      # Examples:
-      # tags: ["extra_tag", "env:example"]
-      #
-      #tags: []
-<% if @tags and ! @tags.empty? -%>
-        tags:
-  <%- Array(@tags).each do |tag| -%>
-    <%- if tag != '' -%>
-            - <%= tag %>
-    <%- end -%>
-  <%- end -%>
-<% end -%>
-
-
-
-      # To include or exclude containers based on their tags, use the include and
-      # exclude keys in your instance.
-      # The reasoning is: if a tag matches an exclude rule, it won't be included
-      # unless it also matches an include rule.
-      #
-      # Examples:
-      #
-      # exclude all, except ubuntu and debian.
-      # include:
-      #   - "image:ubuntu"
-      #   - "image:debian"
-      # exclude:
-      #   - ".*"
-      #
-      # include all, except ubuntu and debian.
-      # include: []
-      # exclude:
-      #   - "image:ubuntu"
-      #   - "image:debian"
-      #
-      #include: []
-      #exclude: []
-
-      # Create events whenever a container status change.
-      #
-      #collect_events: true
-
-      # Collect disk usage per container with docker.disk.size metric.
-      # Warning: Some bugs in Docker (especially Docker 1.2) can break it, use with caution.
-      #
-      #collect_container_size: false
-
-      # Collect uncommon metrics from cgroups.
-      # Collect all the available cgroups metrics. All the relevant metrics are collected by default.
-      #
-      #collect_all_metrics: false
+    - url: <%= @url %>
+      new_tag_names: <%= @new_tag_names %>

--- a/templates/agent-conf.d/docker.yaml.erb
+++ b/templates/agent-conf.d/docker.yaml.erb
@@ -5,5 +5,13 @@
 init_config:
 
 instances:
-    - url: <%= @url %>
-      new_tag_names: <%= @new_tag_names %>
+  - url: <%= @url %>
+    new_tag_names: <%= @new_tag_names %>
+<% if @tags and ! @tags.empty? -%>
+    tags:
+  <%- Array(@tags).each do |tag| -%>
+    <%- if tag != '' -%>
+      - <%= tag %>
+    <%- end -%>
+  <%- end -%>
+<% end -%>

--- a/templates/agent-conf.d/marathon.yaml.erb
+++ b/templates/agent-conf.d/marathon.yaml.erb
@@ -1,0 +1,8 @@
+#
+# MANAGED BY PUPPET
+#
+
+init_config:
+  default_timeout: <%= @marathon_timeout %>
+instances:
+    - url: <%= @url %>

--- a/templates/agent-conf.d/mesos.yaml.erb
+++ b/templates/agent-conf.d/mesos.yaml.erb
@@ -1,0 +1,8 @@
+#
+# MANAGED BY PUPPET
+#
+
+init_config:
+  default_timeout: <%= @mesos_timeout %>
+instances:
+    - url: <%= @url %>


### PR DESCRIPTION
Rebased version of #94. Just re-added the optional tags array to the docker integration. It's not covering all the configurations options but it's good enough for now. We'll tackle that for 2.0.