### PR TITLE
Add generic integration

### DIFF
--- a/manifests/integrations/generic.pp
+++ b/manifests/integrations/generic.pp
@@ -1,36 +1,36 @@
 # Class: datadog_agent::integrations::generic
 #
-# This class will install a configuration file for a integration
+# This class will install a configuration file for an integration
 #
 # Parameters:
 #   $integration_name:
-#       This will be used for to build the filename, it must correspond to an
+#       This will be used to build the filename. It must correspond to an
 #         integration that is supported by dd-agent, see the dd-agent for
 #         a current list.
-#   $integration_template:
-#       A string containing a rendered template.
+#   $integration_contents:
+#       String containing a rendered template.
 #
 # Sample Usage:
 #
 # class { 'datadog_agent::integrations::generic':
 #   integration_name     => 'custom',
-#   integration_template => template(my_custom_template),
+#   integration_contents => template(my_custom_template),
 # }
 #
 class datadog_agent::integrations::generic(
   $integration_name     = undef,
-  $integration_template = undef,
+  $integration_contents = undef,
 ) inherits datadog_agent::params {
 
   validate_string($integration_name)
-  validate_string($integration_template)
+  validate_string($integration_contents)
 
   file { "${datadog_agent::params::conf_dir}/${integration_name}.yaml":
     ensure  => file,
     owner   => $datadog_agent::params::dd_user,
     group   => $datadog_agent::params::dd_group,
     mode    => '0600',
-    content => $integration_template,
+    content => $integration_contents,
     require => Package[$datadog_agent::params::package_name],
     notify  => Service[$datadog_agent::params::service_name]
   }

--- a/manifests/integrations/generic.pp
+++ b/manifests/integrations/generic.pp
@@ -1,0 +1,37 @@
+# Class: datadog_agent::integrations::generic
+#
+# This class will install a configuration file for a integration
+#
+# Parameters:
+#   $integration_name:
+#       This will be used for to build the filename, it must correspond to an
+#         integration that is supported by dd-agent, see the dd-agent for
+#         a current list.
+#   $integration_template:
+#       A string containing a rendered template.
+#
+# Sample Usage:
+#
+# class { 'datadog_agent::integrations::generic':
+#   integration_name     => 'custom',
+#   integration_template => template(my_custom_template),
+# }
+#
+class datadog_agent::integrations::generic(
+  $integration_name     = undef,
+  $integration_template = undef,
+) inherits datadog_agent::params {
+
+  validate_string($integration_name)
+  validate_string($integration_template)
+
+  file { "${datadog_agent::params::conf_dir}/${integration_name}.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0600',
+    content => $integration_template,
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}


### PR DESCRIPTION
Adding a generic integration manifest. This allows us to pass larger, more complicated configuration files to integrations that need to be rendered with many variables, and are too site specific.