### PR TITLE
This PR fixes the ability to add vhosts and queues into the

### DIFF
--- a/manifests/integrations/rabbitmq.pp
+++ b/manifests/integrations/rabbitmq.pp
@@ -25,6 +25,8 @@ class datadog_agent::integrations::rabbitmq (
   $url       = undef,
   $username  = undef,
   $password  = undef,
+  $queues    = undef,
+  $vhosts    = undef,
 ) inherits datadog_agent::params {
 
   file { "${datadog_agent::params::conf_dir}/rabbitmq.yaml":

--- a/templates/agent-conf.d/rabbitmq.yaml.erb
+++ b/templates/agent-conf.d/rabbitmq.yaml.erb
@@ -8,3 +8,18 @@ instances:
 <% if @password -%>
        rabbitmq_pass: <%= @password %>
 <% end -%>
+
+<% if @queues  -%>
+       queues:
+<% @queues.each do |x| -%>
+         - <%= x %>
+<% end -%>
+<% end -%>
+
+
+<% if @vhosts -%>
+       vhosts:
+<% @vhosts.each do |x| -%>
+         - <%= x %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
integration of rabbitmq metrics.



Rabbbitmq integration respects queues and vhosts. The way the module and template was written it did not give you that functionality. I can add exchanges and brokers if thats something thats needed also, I'm running this code in prod right now, also just talked to support (Martin) giving him the heads up this PR was coming your way. Hope this helps. 