### PR TITLE
only define  package 'rubygems' when not already defined.

### DIFF
--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -29,9 +29,11 @@ class datadog_agent::reports(
     }
   }
 
-  # Ensure rubygems is installed
-  class { 'ruby':
-    rubygems_update => false
+  if (! defined(Package['rubygems'])) {
+    # Ensure rubygems is installed
+    class { 'ruby':
+      rubygems_update => false
+    }
   }
 
   file { '/etc/dd-agent/datadog.yaml':


### PR DESCRIPTION
When I tried to include datadog reports on our puppet master node, I've got the following error cause by our own codebase defining the same snippet. 

```
==> puppet: Error: Duplicate declaration: Package[rubygems] is already declared in file /tmp/vagrant-puppet/buildeng-modules/atlassiansoe/manifests/install.pp:51; cannot redeclare at /tmp/vagrant-puppet/modules/ruby/manifests/init.pp:180 on node AAA.atlassian.com
==> puppet: Error: Duplicate declaration: Package[rubygems] is already declared in file /tmp/vagrant-puppet/buildeng-modules/atlassiansoe/manifests/install.pp:51; cannot redeclare at /tmp/vagrant-puppet/modules/ruby/manifests/init.pp:180 on node AAA.atlassian.com
```

the created PR fixes the problem.