### PR TITLE
Pin rspec-puppet to 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"
   gem "rake"
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "rspec-puppet", '2.2.0'
 end
 
 group :development do


### PR DESCRIPTION
we're seeing regressions on the tip of [rodjek/spec-puppet](https://github.com/rodjek/rspec-puppet). Let's pin to the last working release