### PR TITLE
[redhat] Check the RPM signature

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -14,14 +14,15 @@
 # Sample Usage:
 #
 class datadog_agent::redhat(
-  $baseurl = "http://yum.datadoghq.com/rpm/${::architecture}/"
+  $baseurl = "https://yum.datadoghq.com/rpm/${::architecture}/"
 ) {
 
   validate_string($baseurl)
 
   yumrepo {'datadog':
     enabled  => 1,
-    gpgcheck => 0,
+    gpgcheck => 1,
+    gpgkey   => 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
     descr    => 'Datadog, Inc.',
     baseurl  => $baseurl,
   }

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -13,8 +13,9 @@ describe 'datadog_agent::redhat' do
   it do
     should contain_yumrepo('datadog')
       .with_enabled(1)\
-      .with_gpgcheck(0)\
-      .with_baseurl('http://yum.datadoghq.com/rpm/x86_64/')
+      .with_gpgcheck(1)\
+      .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+      .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
   end
 
   # it should install the packages


### PR DESCRIPTION
The puppet recipe now sets up our RPM repository so that it checks for
the signature of the package before installing it. It works with agent
5.5 and above (only).