### PR TITLE
Allow configuration of more things.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,8 @@ class datadog_agent(
   $extra_template = '',
   $skip_ssl_validation = false,
   $ganglia_host = '',
-  $ganglia_port = 8651
+  $ganglia_port = 8651,
+  $package_version = 'latest'
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)
@@ -130,6 +131,7 @@ class datadog_agent(
   validate_bool($skip_ssl_validation)
   validate_string($ganglia_host)
   validate_integer($ganglia_port)
+  validate_string($package_version)
 
   include datadog_agent::params
   case upcase($log_level) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,7 @@ class datadog_agent(
   validate_bool($non_local_traffic)
   validate_bool($log_to_syslog)
   validate_string($log_level)
+  validate_integer($dogstatsd_port)
   validate_string($proxy_host)
   validate_string($proxy_port)
   validate_string($proxy_user)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,7 @@ class datadog_agent(
   $graphite_listen_port = '',
   $extra_template = '',
   $skip_ssl_validation = false,
+  $ca_certs = '',
   $ganglia_host = '',
   $ganglia_port = 8651,
   $package_version = 'latest'
@@ -130,6 +131,7 @@ class datadog_agent(
   validate_string($graphite_listen_port)
   validate_string($extra_template)
   validate_bool($skip_ssl_validation)
+  validate_string($ca_certs)
   validate_string($ganglia_host)
   validate_integer($ganglia_port)
   validate_string($package_version)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,12 @@
 #       Valid values here are: true or false.
 #   $dogstatsd_port
 #       Set value of the 'dogstatsd_port' variable. Defaultis 8125.
+#   $statsd_forward_host
+#       Set the value of the statsd_forward_host varable. Used to forward all
+#       statsd metrics to another host.
+#   $statsd_forward_port
+#       Set the value of the statsd_forward_port varable. Used to forward all
+#       statsd metrics to another host.
 #   $proxy_host
 #       Set value of 'proxy_host' variable. Default is blank.
 #   $proxy_port
@@ -91,6 +97,8 @@ class datadog_agent(
   $service_enable = true,
   $use_mount = false,
   $dogstatsd_port = 8125,
+  $statsd_forward_host = '',
+  $statsd_forward_port = 8125,
   $proxy_host = '',
   $proxy_port = '',
   $proxy_user = '',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@
 #   $use_mount
 #       Allow overriding default of tracking disks by device path instead of mountpoint
 #       Valid values here are: true or false.
+#   $dogstatsd_port
+#       Set value of the 'dogstatsd_port' variable. Defaultis 8125.
 #   $proxy_host
 #       Set value of 'proxy_host' variable. Default is blank.
 #   $proxy_port
@@ -86,6 +88,7 @@ class datadog_agent(
   $service_ensure = 'running',
   $service_enable = true,
   $use_mount = false,
+  $dogstatsd_port = 8125,
   $proxy_host = '',
   $proxy_port = '',
   $proxy_user = '',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,8 @@
 #   $extra_template
 #       Optional, append this extra template file at the end of
 #       the default datadog.conf template
+#   $skip_ssl_validation
+#       Skip SSL validation.
 # Actions:
 #
 # Requires:
@@ -95,6 +97,7 @@ class datadog_agent(
   $proxy_password = '',
   $graphite_listen_port = '',
   $extra_template = '',
+  $skip_ssl_validation = false
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)
@@ -114,6 +117,7 @@ class datadog_agent(
   validate_string($proxy_password)
   validate_string($graphite_listen_port)
   validate_string($extra_template)
+  validate_bool($skip_ssl_validation)
 
   include datadog_agent::params
   case upcase($log_level) {

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -32,7 +32,7 @@ class datadog_agent::redhat(
   }
 
   package { 'datadog-agent':
-    ensure  => latest,
+    ensure  => $package_version,
     require => Yumrepo['datadog'],
   }
 

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -32,7 +32,7 @@ class datadog_agent::redhat(
   }
 
   package { 'datadog-agent':
-    ensure  => $package_version,
+    ensure  => $::datadog_agent::package_version,
     require => Yumrepo['datadog'],
   }
 

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -38,7 +38,7 @@ class datadog_agent::ubuntu(
   }
 
   package { 'datadog-agent':
-    ensure  => latest,
+    ensure  => $package_version,
     require => [File['/etc/apt/sources.list.d/datadog.list'],
                 Exec['datadog_apt-get_update']],
   }

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -38,7 +38,7 @@ class datadog_agent::ubuntu(
   }
 
   package { 'datadog-agent':
-    ensure  => $package_version,
+    ensure  => $::datadog_agent::package_version,
     require => [File['/etc/apt/sources.list.d/datadog.list'],
                 Exec['datadog_apt-get_update']],
   }

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -20,7 +20,6 @@ describe 'datadog_agent::redhat' do
   # it should install the packages
   it do
     should contain_package('datadog-agent-base')\
-      .with_ensure('absent')\
       .that_comes_before('Package[datadog-agent]')
   end
   it do

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -29,10 +29,10 @@ proxy_password: <%= @proxy_password %>
 <% end -%>
 
 # If you run the agent behind haproxy, you might want to set this to yes
-<% if @skip_ssl_validation.empty? -%>
-# skip_ssl_validation: no
-<% else -%>
+<% if @skip_ssl_validation -%>
 skip_ssl_validation: <%= @skip_ssl_validation %>
+<% else -%>
+# skip_ssl_validation: no
 <% end -%>
 
 # The Datadog api key to associate your Agent's data with your organization.

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -29,7 +29,11 @@ proxy_password: <%= @proxy_password %>
 <% end -%>
 
 # If you run the agent behind haproxy, you might want to set this to yes
+<% if @skip_ssl_validation.empty? -%>
 # skip_ssl_validation: no
+<% else -%>
+skip_ssl_validation: <%= @skip_ssl_validation %>
+<% end -%>
 
 # The Datadog api key to associate your Agent's data with your organization.
 # Can be found here:

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -130,7 +130,11 @@ non_local_traffic: <%= @non_local_traffic %>
 # usage information, check out http://api.datadoghq.com
 
 #  Make sure your client is sending to the same port.
-# dogstatsd_port : 8125
+<% if @dogstatsd_port.empty? -%>
+# dogstatsd_port : @dogstatsd_port
+<% else -%>
+dogstatsd_port : @dogstatsd_port
+<% end -%>
 
 # By default dogstatsd will post aggregate metrics to the Agent (which handles
 # errors/timeouts/retries/etc). To send directly to the datadog api, set this

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -34,6 +34,12 @@ skip_ssl_validation: <%= @skip_ssl_validation %>
 <% else -%>
 # skip_ssl_validation: no
 <% end -%>
+# If you'd like to override the CA certs path, you might want to set this
+<% if @ca_certs.empty? -%>
+# ca_certs: /some/path
+<% else -%>
+ca_certs: <%= @ca_certs %>
+<% end -%>
 
 # The Datadog api key to associate your Agent's data with your organization.
 # Can be found here:

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -137,7 +137,7 @@ non_local_traffic: <%= @non_local_traffic %>
 <% if @dogstatsd_port.empty? -%>
 # dogstatsd_port : @dogstatsd_port
 <% else -%>
-dogstatsd_port : @dogstatsd_port
+dogstatsd_port : <%= @dogstatsd_port %>
 <% end -%>
 
 # By default dogstatsd will post aggregate metrics to the Agent (which handles
@@ -156,8 +156,16 @@ dogstatsd_port : @dogstatsd_port
 # to another statsd server, uncomment these lines.
 # WARNING: Make sure that forwarded packets are regular statsd packets and not "dogstatsd" packets,
 # as your other statsd server might not be able to handle them.
+<% if @statsd_forward_host.empty? -%>
 # statsd_forward_host: address_of_own_statsd_server
+<% else -%>
+statsd_forward_host: <%= @statsd_forward_host %>
+<% end -%>
+<% if @statsd_forward_port.empty? -%>
 # statsd_forward_port: 8125
+<% else -%>
+statsd_forward_port: <%= @statsd_forward_port %>
+<% end -%>
 
 # ========================================================================== #
 # Service-specific configuration                                             #


### PR DESCRIPTION
# What's this PR do?

Allows the configuration of: 
* the DogstatsD port
* the forwarder's SSL validation.
* statsd forwarding host and port

# Motivation

Some customers — such as me! — run existing StatsD and proxies. Being able to configure these things without having to make vendored changed would be great!