### PR TITLE
[apt] Add apt-transport-https to the repo install

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -14,6 +14,11 @@ class datadog_agent::ubuntu(
   $apt_key = 'C7A7DA52'
 ) {
 
+  package { 'apt-transport-https':
+    ensure => latest,
+    before => File['/etc/apt/sources.list.d/datadog.list'],
+  }
+
   exec { 'datadog_key':
     command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${apt_key}",
     unless  => "/usr/bin/apt-key list | grep ${apt_key} | grep expires",

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -18,6 +18,10 @@ describe 'datadog_agent::ubuntu' do
 
   # it should install the packages
   it do
+    should contain_package('apt-transport-https')\
+      .that_comes_before('File[/etc/apt/sources.list.d/datadog.list]')
+  end
+  it do
     should contain_package('datadog-agent-base')\
       .with_ensure('absent')\
       .that_comes_before('Package[datadog-agent]')


### PR DESCRIPTION
In preparation for HTTPS repo.

See https://github.com/DataDog/dd-agent/pull/1779