### PR TITLE
Decouple the yum repo definition from the package.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,11 @@
 #   $use_mount
 #       Allow overriding default of tracking disks by device path instead of mountpoint
 #       Valid values here are: true or false.
+#   $pkg_ensure
+#       Ensure for the datadog package. A version, 'latest', 'present'
+#   $manage_repo
+#       Boolean to indicate whether this module should attempt to manage
+#       the package repo. Default true.
 #   $proxy_host
 #       Set value of 'proxy_host' variable. Default is blank.
 #   $proxy_port
@@ -85,6 +90,8 @@ class datadog_agent(
   $log_to_syslog = true,
   $service_ensure = 'running',
   $service_enable = true,
+  $pkg_ensure = 'latest',
+  $manage_repo = true,
   $use_mount = false,
   $proxy_host = '',
   $proxy_port = '',
@@ -106,6 +113,7 @@ class datadog_agent(
   validate_string($puppetmaster_user)
   validate_bool($non_local_traffic)
   validate_bool($log_to_syslog)
+  validate_bool($manage_repo)
   validate_string($log_level)
   validate_string($proxy_host)
   validate_string($proxy_port)
@@ -130,7 +138,12 @@ class datadog_agent(
 
   case $::operatingsystem {
     'Ubuntu','Debian' : { include datadog_agent::ubuntu }
-    'RedHat','CentOS','Fedora','Amazon','Scientific' : { include datadog_agent::redhat }
+    'RedHat','CentOS','Fedora','Amazon','Scientific' : {
+      class { 'datadog_agent::redhat':
+        manage_repo => $manage_repo,
+        ensure      => 'latest',
+      }
+    }
     default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
   }
 

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -14,16 +14,23 @@
 # Sample Usage:
 #
 class datadog_agent::redhat(
-  $baseurl = "http://yum.datadoghq.com/rpm/${::architecture}/"
+  $baseurl     = "http://yum.datadoghq.com/rpm/${::architecture}/",
+  $manage_repo = true,
+  $ensure      = 'latest'
 ) {
 
-  validate_string($baseurl)
+  validate_bool($manage_repo)
+  if $manage_repo {
+    validate_string($baseurl)
 
-  yumrepo {'datadog':
-    enabled  => 1,
-    gpgcheck => 0,
-    descr    => 'Datadog, Inc.',
-    baseurl  => $baseurl,
+      yumrepo {'datadog':
+        enabled  => 1,
+        gpgcheck => 0,
+        descr    => 'Datadog, Inc.',
+        baseurl  => $baseurl,
+      }
+
+    Package['datadog-agent'] -> Yumrepo['datadog-agent']
   }
 
   package { 'datadog-agent-base':
@@ -33,7 +40,6 @@ class datadog_agent::redhat(
 
   package { 'datadog-agent':
     ensure  => latest,
-    require => Yumrepo['datadog'],
   }
 
   service { 'datadog-agent':


### PR DESCRIPTION
Control management via the manage_repo parameter.

This allows for private repos in the case where there might
be a network issue between the host and datadog's yum repo.

It also allows setting of the ensure to provide better control
over which version to install

This should be mostly backwards compatible, my only concern is realizing the class vs include in the redhat block.