### PR TITLE
Add some more options!

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,8 +59,18 @@
 #   $extra_template
 #       Optional, append this extra template file at the end of
 #       the default datadog.conf template
+#   $package_version
+#       Optional, allows specifying the version of the datadog agent to
+#       install. Defaults to "latest"
+#   $skip_apt_key_trusting
+#       Skip trusting the apt key. Default is false. Useful if you have a
+#       separate way of adding keys.
 #   $skip_ssl_validation
 #       Skip SSL validation.
+#   $ca_certs
+#       Specify the CA cert to use with the forwarder.
+#   $use_curl_http_client
+#       Uses the curl HTTP client for the forwarder
 # Actions:
 #
 # Requires:
@@ -99,15 +109,20 @@ class datadog_agent(
   $dogstatsd_port = 8125,
   $statsd_forward_host = '',
   $statsd_forward_port = 8125,
+  $statsd_histogram_percentiles = '0.95',
   $proxy_host = '',
   $proxy_port = '',
   $proxy_user = '',
   $proxy_password = '',
   $graphite_listen_port = '',
   $extra_template = '',
+  $package_version = 'latest',
   $ganglia_host = '',
   $ganglia_port = 8651,
-  $skip_ssl_validation = false
+  $skip_ssl_validation = false,
+  $ca_certs = '',
+  $skip_apt_key_trusting = false,
+  $use_curl_http_client = false
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)
@@ -122,15 +137,20 @@ class datadog_agent(
   validate_bool($log_to_syslog)
   validate_string($log_level)
   validate_integer($dogstatsd_port)
+  validate_string($statsd_histogram_percentiles)
   validate_string($proxy_host)
   validate_string($proxy_port)
   validate_string($proxy_user)
   validate_string($proxy_password)
   validate_string($graphite_listen_port)
   validate_string($extra_template)
+  validate_string($package_version)
   validate_string($ganglia_host)
   validate_integer($ganglia_port)
   validate_bool($skip_ssl_validation)
+  validate_string($ca_certs)
+  validate_bool($skip_apt_key_trusting)
+  validate_bool($use_curl_http_client)
 
   include datadog_agent::params
   case upcase($log_level) {

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -19,10 +19,12 @@ class datadog_agent::ubuntu(
     before => File['/etc/apt/sources.list.d/datadog.list'],
   }
 
-  exec { 'datadog_key':
-    command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${apt_key}",
-    unless  => "/usr/bin/apt-key list | grep ${apt_key} | grep expires",
-    before  => File['/etc/apt/sources.list.d/datadog.list'],
+  if $::datadog_agent::skip_apt_key_trusting {
+    exec { 'datadog_key':
+      command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${apt_key}",
+      unless  => "/usr/bin/apt-key list | grep ${apt_key} | grep expires",
+      before  => File['/etc/apt/sources.list.d/datadog.list'],
+    }
   }
 
   file { '/etc/apt/sources.list.d/datadog.list':

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -19,7 +19,7 @@ class datadog_agent::ubuntu(
     before => File['/etc/apt/sources.list.d/datadog.list'],
   }
 
-  if $::datadog_agent::skip_apt_key_trusting {
+  if !$::datadog_agent::skip_apt_key_trusting {
     exec { 'datadog_key':
       command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${apt_key}",
       unless  => "/usr/bin/apt-key list | grep ${apt_key} | grep expires",

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -35,6 +35,10 @@ skip_ssl_validation: <%= @skip_ssl_validation %>
 # skip_ssl_validation: no
 <% end -%>
 
+<% if !@ca_certs.empty? -%>
+ca_certs: <%= @ca_certs %>
+<% end -%>
+
 # The Datadog api key to associate your Agent's data with your organization.
 # Can be found here:
 # https://app.datadoghq.com/account/settings
@@ -104,7 +108,7 @@ non_local_traffic: <%= @non_local_traffic %>
 
 # Select the Tornado HTTP Client in the forwarder
 # Default to the simple http client
-# use_curl_http_client: False
+use_curl_http_client: <%= @use_curl_http_client %>
 
 # The loopback address the Forwarder and Dogstatsd will bind.
 # Optional, it is mainly used when running the agent on Openshift
@@ -151,6 +155,8 @@ dogstatsd_port : <%= @dogstatsd_port %>
 ## If 'yes', counters and rates will be normalized to 1 second (that is divided
 ## by the dogstatsd_interval) before being sent to the server. Defaults to 'yes'
 # dogstatsd_normalize : yes
+
+histogram_percentiles: <%= @statsd_histogram_percentiles %>
 
 # If you want to forward every packet received by the dogstatsd server
 # to another statsd server, uncomment these lines.


### PR DESCRIPTION
# What's this PR do?

Adds more options to configure the behavior of the datadog agent.

# Motivation

The options I've added are things we change locally. Having them configurable here means we have less to change in our vendored version. Share the wealth!

# Notes

I did not include the `latest` change since that caused problems in the last PR.