### PR TITLE
Add consul integration.

### DIFF
--- a/manifests/integrations/consul.pp
+++ b/manifests/integrations/consul.pp
@@ -12,6 +12,7 @@
 #     url  => 'http://localhost:8500',
 #     catalog_checks => true,
 #     new_leader_checks => true,
+#     service_whitelist = []
 #   }
 #
 class datadog_agent::integrations::consul(

--- a/manifests/integrations/consul.pp
+++ b/manifests/integrations/consul.pp
@@ -1,0 +1,33 @@
+# Class: datadog_agent::integrations::consul
+#
+# This class will install the necessary configuration for the consul integration
+#
+# Parameters:
+#   $url:
+#     The URL for communicating with consul
+#
+# Sample Usage:
+#
+#   class { 'datadog_agent::integrations::consul' :
+#     url  => 'http://localhost:8500',
+#     catalog_checks => true,
+#     new_leader_checks => true,
+#   }
+#
+class datadog_agent::integrations::consul(
+  $url = 'http://localhost:8500',
+  $catalog_checks = true,
+  $new_leader_checks = true,
+  $service_whitelist = []
+) inherits datadog_agent::params {
+
+  file { "${datadog_agent::params::conf_dir}/consul.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0644',
+    content => template('datadog_agent/agent-conf.d/consul.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/templates/agent-conf.d/consul.yaml.erb
+++ b/templates/agent-conf.d/consul.yaml.erb
@@ -1,0 +1,25 @@
+# This check takes no init_config
+init_config:
+
+instances:
+    # Where your Consul HTTP Server Lives
+    - url: <%= @url %>
+
+      # Whether to perform checks against the Consul service Catalog
+      catalog_checks: <%= @catalog_checks %>
+
+      # Whether to enable new leader checks from this agent
+      # Note: if this is set on multiple agents in the same cluster
+      # you will receive one event per leader change per agent
+      new_leader_checks: <%= @new_leader_checks %>
+
+      # Services to restrict catalog querying to
+      # The default settings query up to 50 services. So if you have more than
+      # this many in your Consul service catalog, you will want to fill in the
+      # whitelist
+      <% if @service_whitelist and ! @service_whitelist.empty? -%>
+      service_whitelist:
+      <%- Array(@service_whitelist).each do |service| -%>
+        - <%= service %>
+      <% end %>
+      <% end %>


### PR DESCRIPTION
# What's this PR do?

Adds puppet support for the consul integration.

# Motivation

Cuz we wanna use it! :smile: 

# Notes

I've used this locally and it looks to be working! It doesn't enable the StatsD setting in Consul, of course. That's out of scope!