### PR TITLE
Adds support for optional params in ntp integration

### DIFF
--- a/manifests/integrations/ntp.pp
+++ b/manifests/integrations/ntp.pp
@@ -6,15 +6,29 @@
 #   $offset_threshold:
 #        Offset threshold for a critical alert. Defaults to 600.
 #
+#   $host:
+#        ntp server to use for ntp check
+#
+#   $port
+#
+#   $version
+#
+#   $timeout
+#
 # Sample Usage:
 #
 #  class { 'datadog_agent::integrations::ntp' :
 #    offset_threshold     => 60,
+#    host                 => 'pool.ntp.org',
 #  }
 #
 
 class datadog_agent::integrations::ntp(
   $offset_threshold = 60,
+  $host             = undef,
+  $port             = undef,
+  $version          = undef,
+  $timeout          = undef,
 ) inherits datadog_agent::params {
 
   file { "${datadog_agent::params::conf_dir}/ntp.yaml":

--- a/templates/agent-conf.d/ntp.yaml.erb
+++ b/templates/agent-conf.d/ntp.yaml.erb
@@ -6,11 +6,21 @@ init_config:
 
 instances:
   - offset_threshold: <%= @offset_threshold %>
-
+<% if @host -%>
+  - host: <%= @host %>
+<% end -%>
+<% if @port -%>
+  - port: <%= @port %>
+<% end -%>
+<% if @version -%>
+  - version: <%= @version %>
+<% end -%>
+<% if @timeout -%>
+  - timeout: <%= @timeout %>
+<% end -%>
     # Optional params:
     #
     # host: pool.ntp.org
     # port: ntp
     # version: 3
     # timeout: 5
-


### PR DESCRIPTION
# What's this PR do?

Allows the configuration of:
* host
* port
* version
* timeout

# Motivation
In case your servers can't access datadogs ntp servers this allows you to set your own ntp server. 