### PR TITLE
Make a generic define for creating integrations

### DIFF
--- a/lib/puppet/parser/functions/to_instances_yaml.rb
+++ b/lib/puppet/parser/functions/to_instances_yaml.rb
@@ -1,0 +1,13 @@
+require 'yaml'
+
+module Puppet::Parser::Functions
+    newfunction(:to_instances_yaml, :type => :rvalue) do |args|
+        init_config = args[0]
+        instances = args[1]
+        default_values = {
+            'init_config'  => init_config.is_a?(String) ? nil: init_config,
+            'instances' => instances
+        }
+        YAML::dump(default_values)
+    end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -228,6 +228,11 @@ class datadog_agent(
   $pup_log_file = '',
   $syslog_host  = '',
   $syslog_port  = '',
+  $conf_dir = $datadog_agent::params::conf_dir,
+  $service_name = $datadog_agent::params::service_name,
+  $package_name = $datadog_agent::params::package_name,
+  $dd_user = $datadog_agent::params::dd_user,
+  $dd_group = $datadog_agent::params::dd_group,
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)

--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -1,0 +1,24 @@
+define datadog_agent::integration (
+  $instances,
+  $init_config = undef,
+  $integration = $title,
+){
+
+  include datadog_agent
+
+  validate_array($instances)
+  if $init_config != undef {
+    validate_hash($init_config)
+  }
+  validate_string($integration)
+
+  file { "${datadog_agent::conf_dir}/${integration}.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::dd_user,
+    group   => $datadog_agent::dd_group,
+    mode    => '0600',
+    content => to_instances_yaml($init_config, $instances),
+    notify  => Service[$datadog_agent::service_name]
+  }
+
+}

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe "datadog_agent::integration" do
+    let (:title) { "test" }
+    let(:facts) do
+      {
+        operatingsystem: 'CentOS',
+        osfamily: 'redhat'
+      }
+    end
+    let (:params) {{
+        :instances => [
+            { 'one' => "two" }
+        ]
+    }}
+    it { should compile }
+    it { should contain_file('/etc/dd-agent/conf.d/test.yaml').with_content(/init_config: /) }
+    it { should contain_file('/etc/dd-agent/conf.d/test.yaml').with_content(/---\ninit_config: \ninstances:\n- one: two\n/) }
+    it { should contain_file('/etc/dd-agent/conf.d/test.yaml').that_notifies("Service[datadog-agent]") }
+end


### PR DESCRIPTION
This is a additional feature to add support of a generic define and then use yaml to convert the ruby data to a yaml format. This should make it so each integration is dynamic and allows for a full feature rich integration. A addition would be to make a $integartions argument in the main class to use hiera to declare integrations