### PR TITLE
puppet-lint no-autoloader-format in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ end
 
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.send('disable_autoloader_layout')
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
 


### PR DESCRIPTION
Most manifests fail the autoloader format lint check, including init.pp
http://puppet-lint.com/checks/autoloader_layout/

Naming conventions seem to be something that we want to keep, so I'm
disabling this check so that testing can complete successfully.