### PR TITLE
tests for integration classes

### DIFF
--- a/manifests/integrations/apache.pp
+++ b/manifests/integrations/apache.pp
@@ -32,6 +32,7 @@ class datadog_agent::integrations::apache (
   $password  = undef,
   $tags      = []
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   validate_string($url)
   validate_array($tags)

--- a/manifests/integrations/docker.pp
+++ b/manifests/integrations/docker.pp
@@ -24,6 +24,7 @@ class datadog_agent::integrations::docker(
   $url = 'unix://var/run/docker.sock',
   $tags = [],
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/docker.yaml":
     ensure  => file,

--- a/manifests/integrations/elasticsearch.pp
+++ b/manifests/integrations/elasticsearch.pp
@@ -15,6 +15,7 @@
 class datadog_agent::integrations::elasticsearch(
   $url = 'http://localhost:9200'
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/elastic.yaml":
     ensure  => file,

--- a/manifests/integrations/haproxy.pp
+++ b/manifests/integrations/haproxy.pp
@@ -19,6 +19,7 @@ class datadog_agent::integrations::haproxy(
   $creds = {},
   $url   = "http://${::ipaddress}:8080",
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file {
     "${datadog_agent::params::conf_dir}/haproxy.yaml":

--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -87,6 +87,7 @@ class datadog_agent::integrations::http_check (
   $tags      = [],
   $contact   = [],
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/http_check.yaml":
     ensure  => file,

--- a/manifests/integrations/jenkins.pp
+++ b/manifests/integrations/jenkins.pp
@@ -16,6 +16,7 @@
 class datadog_agent::integrations::jenkins(
   $path = '/var/lib/jenkins'
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/jenkins.yaml":
     ensure  => file,

--- a/manifests/integrations/marathon.pp
+++ b/manifests/integrations/marathon.pp
@@ -16,6 +16,7 @@ class datadog_agent::integrations::marathon(
   $marathon_timeout = 5,
   $url = 'http://localhost:8080'
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/marathon.yaml":
     ensure  => file,

--- a/manifests/integrations/mesos.pp
+++ b/manifests/integrations/mesos.pp
@@ -16,6 +16,7 @@ class datadog_agent::integrations::mesos(
   $mesos_timeout = 5,
   $url = 'http://localhost:5050'
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/mesos.yaml":
     ensure  => file,

--- a/manifests/integrations/mongo.pp
+++ b/manifests/integrations/mongo.pp
@@ -30,6 +30,7 @@
 class datadog_agent::integrations::mongo(
   $servers = [{'host' => 'localhost', 'port' => '27017'}]
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   validate_array($servers)
 

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -36,6 +36,7 @@ class datadog_agent::integrations::mysql(
   $replication = '0',
   $galera_cluster = '0'
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   validate_array($tags)
 

--- a/manifests/integrations/nginx.pp
+++ b/manifests/integrations/nginx.pp
@@ -25,6 +25,7 @@
 class datadog_agent::integrations::nginx(
   $instances = [],
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   validate_array($instances)
 

--- a/manifests/integrations/ntp.pp
+++ b/manifests/integrations/ntp.pp
@@ -16,6 +16,7 @@
 class datadog_agent::integrations::ntp(
   $offset_threshold = 60,
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/ntp.yaml":
     ensure  => file,

--- a/manifests/integrations/postgres.pp
+++ b/manifests/integrations/postgres.pp
@@ -39,6 +39,7 @@ class datadog_agent::integrations::postgres(
   $tags = [],
   $tables = []
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   validate_array($tags)
   validate_array($tables)

--- a/manifests/integrations/process.pp
+++ b/manifests/integrations/process.pp
@@ -41,6 +41,7 @@
 class datadog_agent::integrations::process(
   $processes = [],
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   validate_array( $processes )
 

--- a/manifests/integrations/rabbitmq.pp
+++ b/manifests/integrations/rabbitmq.pp
@@ -28,6 +28,7 @@ class datadog_agent::integrations::rabbitmq (
   $queues    = undef,
   $vhosts    = undef,
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/rabbitmq.yaml":
     ensure  => file,

--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -32,6 +32,7 @@ class datadog_agent::integrations::redis(
   $keys = [],
   $warn_on_missing_keys = true,
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   validate_re($port, '^\d+$')
   validate_array($tags)

--- a/manifests/integrations/solr.pp
+++ b/manifests/integrations/solr.pp
@@ -34,7 +34,9 @@ class datadog_agent::integrations::solr(
   $java_bin_path        = undef,
   $trust_store_path     = undef,
   $trust_store_password = undef,
-  $tags                 = {})inherits datadog_agent::params {
+  $tags                 = {},
+) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/solr.yaml":
     ensure  => file,

--- a/manifests/integrations/tomcat.pp
+++ b/manifests/integrations/tomcat.pp
@@ -34,7 +34,10 @@ class datadog_agent::integrations::tomcat(
   $java_bin_path        = undef,
   $trust_store_path     = undef,
   $trust_store_password = undef,
-  $tags                 = {}) inherits datadog_agent::params {
+  $tags                 = {},
+) inherits datadog_agent::params {
+  include datadog_agent
+
 
   file { "${datadog_agent::params::conf_dir}/tomcat.yaml":
     ensure  => file,

--- a/manifests/integrations/varnish.pp
+++ b/manifests/integrations/varnish.pp
@@ -22,6 +22,7 @@ class datadog_agent::integrations::varnish (
   $varnishstat = '/usr/bin/varnishstat',
   $tags      = [],
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   file { "${datadog_agent::params::conf_dir}/varnish.yaml":
     ensure  => file,

--- a/manifests/integrations/zk.pp
+++ b/manifests/integrations/zk.pp
@@ -30,6 +30,7 @@
 class datadog_agent::integrations::zk (
   $servers = [{'host' => 'localhost', 'port' => '2181'}]
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   validate_array($servers)
 

--- a/spec/classes/datadog_agent_integrations_apache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_apache_spec.rb
@@ -57,9 +57,6 @@ describe 'datadog_agent::integrations::apache' do
     it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
   end
 
-  context 'with tags parameter with an empty tag' do
-  end
-
   context 'with tags parameter empty values' do
     context 'mixed in with other tags' do
       let(:params) {{

--- a/spec/classes/datadog_agent_integrations_apache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_apache_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::apache' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/apache.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{apache_status_url: http://localhost/server-status\?auto}) }
+    it { should contain_file(conf_file).without_content(/tags:/) }
+    it { should contain_file(conf_file).without_content(/apache_user:/) }
+    it { should contain_file(conf_file).without_content(/apache_password:/) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      url: 'http://foobar',
+      username: 'userfoo',
+      password: 'passfoo',
+      tags: %w{foo bar baz},
+    }}
+    it { should contain_file(conf_file).with_content(%r{apache_status_url: http://foobar}) }
+    it { should contain_file(conf_file).with_content(/apache_user: userfoo/) }
+    it { should contain_file(conf_file).with_content(/apache_password: passfoo/) }
+  end
+
+  context 'with tags parameter single value' do
+    let(:params) {{
+      tags: 'foo',
+    }}
+    it { should_not compile }
+
+    skip "this is currently unimplemented behavior" do
+      it { should contain_file(conf_file).with_content(/tags:\s+- foo\s*?[^-]/m) }
+    end
+  end
+
+  context 'with tags parameter array' do
+    let(:params) {{
+      tags: %w{ foo bar baz },
+    }}
+    it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+  end
+
+  context 'with tags parameter with an empty tag' do
+  end
+
+  context 'with tags parameter empty values' do
+    context 'mixed in with other tags' do
+      let(:params) {{
+        tags: [ 'foo', '', 'baz' ]
+      }}
+
+      it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+    end
+
+    context 'single element array of an empty string' do
+      let(:params) {{
+        tags: [''],
+      }}
+
+      skip("undefined behavior")
+    end
+
+    context 'single value empty string' do
+      let(:params) {{
+        tags: '',
+      }}
+
+      skip("doubly undefined behavior")
+    end
+  end
+end

--- a/spec/classes/datadog_agent_integrations_docker_spec.rb
+++ b/spec/classes/datadog_agent_integrations_docker_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::docker' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/docker.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0644',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{url: unix://var/run/docker.sock}) }
+    it { should contain_file(conf_file).with_content(/new_tag_names: true/) }
+    it { should contain_file(conf_file).without_content(/tags: /) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      url: 'unix://foo/bar/baz.sock',
+      new_tag_names: false,
+    }}
+    it { should contain_file(conf_file).with_content(%r{url: unix://foo/bar/baz.sock}) }
+    it { should contain_file(conf_file).with_content(/new_tag_names: false/) }
+  end
+
+  context 'with tags parameter array' do
+    let(:params) {{
+      tags: %w{ foo bar baz },
+    }}
+    it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+  end
+
+  context 'with tags parameter with an empty tag' do
+  end
+
+  context 'with tags parameter empty values' do
+    context 'mixed in with other tags' do
+      let(:params) {{
+        tags: [ 'foo', '', 'baz' ]
+      }}
+
+      it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+    end
+
+    context 'single element array of an empty string' do
+      let(:params) {{
+        tags: [''],
+      }}
+
+      skip("undefined behavior")
+    end
+
+    context 'single value empty string' do
+      let(:params) {{
+        tags: '',
+      }}
+
+      skip("doubly undefined behavior")
+    end
+  end
+
+end

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::elasticsearch' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/elastic.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0644',
+  )}
+
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{url: http://localhost:9200}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      url: 'http://foo:4242',
+    }}
+    it { should contain_file(conf_file).with_content(%r{http://foo:4242}) }
+  end
+
+end

--- a/spec/classes/datadog_agent_integrations_haproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_haproxy_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::haproxy' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+    ipaddress: '1.2.3.4',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/haproxy.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0644',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{url: http://1.2.3.4:8080}) }
+    it { should contain_file(conf_file).without_content(%r{username: }) }
+    it { should contain_file(conf_file).without_content(%r{password: }) }
+  end
+
+  context 'with url set' do
+    let(:params) {{
+      url: 'http://foo.bar:8421',
+    }}
+    it { should contain_file(conf_file).with_content(%r{url: http://foo.bar:8421}) }
+  end
+
+  context 'with creds set correctly' do
+    let(:params) {{
+      creds: {
+        'username' => 'foo',
+        'password' => 'bar',
+      },
+    }}
+    it { should contain_file(conf_file).with_content(%r{username: foo}) }
+    it { should contain_file(conf_file).with_content(%r{password: bar}) }
+  end
+
+  context 'with creds set incorrectly' do
+    let(:params) {{
+      'invalid' => 'is this real life',
+    }}
+
+    skip 'functionality not yet implemented' do
+      it { should contain_file(conf_file).without_content(/invalid: is this real life/) }
+    end
+  end
+end

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -125,4 +125,15 @@ describe 'datadog_agent::integrations::http_check' do
       skip("doubly undefined behavior")
     end
   end
+
+  context 'with contact set' do
+    let(:params) {{
+      contact: %r{alice bob carlo}
+    }}
+
+    # the parameter is '$contact' and the template uses '@contacts', so neither is used
+    skip "this functionality appears to not be functional" do
+      it { should contain_file(conf_file).with_content(%r{notify:\s+- alice\s+bob\s+carlo}) }
+    end
+  end
 end

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::http_check' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/http_check.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+  it { should contain_file(conf_file).with_content(%r{name: datadog_agent::integrations::http_check}) }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{url: }) }
+    it { should contain_file(conf_file).without_content(%r{username: }) }
+    it { should contain_file(conf_file).without_content(%r{password: }) }
+    it { should contain_file(conf_file).with_content(%r{timeout: 1}) }
+    it { should contain_file(conf_file).without_content(%{threshold: }) }
+    it { should contain_file(conf_file).without_content(%r{window: }) }
+    it { should contain_file(conf_file).without_content(%r{include_content: true}) }
+    it { should contain_file(conf_file).with_content(%r{collect_response_time: true}) }
+    it { should contain_file(conf_file).with_content(%r{disable_ssl_validation: false}) }
+    it { should contain_file(conf_file).without_content(%r{headers: }) }
+    it { should contain_file(conf_file).without_content(%r{tags: }) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      url: 'http://foo.bar.baz:4096',
+      username: 'foouser',
+      password: 'barpassword',
+      timeout: 123,
+      threshold: 456,
+      window: 789,
+      include_content: true,
+      collect_response_time: false,
+      disable_ssl_validation: true,
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:4096}) }
+    it { should contain_file(conf_file).with_content(%r{username: foouser}) }
+    it { should contain_file(conf_file).with_content(%r{password: barpassword}) }
+    it { should contain_file(conf_file).with_content(%r{timeout: 123}) }
+    it { should contain_file(conf_file).with_content(%r{threshold: 456}) }
+    it { should contain_file(conf_file).with_content(%r{window: 789}) }
+    it { should contain_file(conf_file).with_content(%r{include_content: true}) }
+    it { should contain_file(conf_file).without_content(%r{collect_response_time: true}) }
+    it { should contain_file(conf_file).with_content(%r{disable_ssl_validation: true}) }
+  end
+
+  context 'with headers parameter array' do
+    let(:params) {{
+      headers: %w{ foo bar baz },
+    }}
+    it { should contain_file(conf_file).with_content(/headers:\s+foo\s+bar\s+baz\s*?[^-]/m) }
+  end
+
+  context 'with headers parameter empty values' do
+    context 'mixed in with other headers' do
+      let(:params) {{
+        headers: [ 'foo', '', 'baz' ]
+      }}
+
+      it { should contain_file(conf_file).with_content(/headers:\s+foo\s+baz\s*?[^-]/m) }
+    end
+
+    context 'single element array of an empty string' do
+      let(:params) {{
+        headers: [''],
+      }}
+
+      skip("undefined behavior")
+    end
+
+    context 'single value empty string' do
+      let(:params) {{
+        headers: '',
+      }}
+
+      skip("doubly undefined behavior")
+    end
+  end
+
+
+  context 'with tags parameter array' do
+    let(:params) {{
+      tags: %w{ foo bar baz },
+    }}
+    it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+  end
+
+  context 'with tags parameter empty values' do
+    context 'mixed in with other tags' do
+      let(:params) {{
+        tags: [ 'foo', '', 'baz' ]
+      }}
+
+      it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+    end
+
+    context 'single element array of an empty string' do
+      let(:params) {{
+        tags: [''],
+      }}
+
+      skip("undefined behavior")
+    end
+
+    context 'single value empty string' do
+      let(:params) {{
+        tags: '',
+      }}
+
+      skip("doubly undefined behavior")
+    end
+  end
+end

--- a/spec/classes/datadog_agent_integrations_jenkins_spec.rb
+++ b/spec/classes/datadog_agent_integrations_jenkins_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::jenkins' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/jenkins.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{jenkins_home: /var/lib/jenkins}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      path: '/foo/bar/baz',
+    }}
+    it { should contain_file(conf_file).with_content(%r{jenkins_home: /foo/bar/baz}) }
+  end
+  
+end

--- a/spec/classes/datadog_agent_integrations_marathon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_marathon_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::marathon' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/marathon.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0644',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{default_timeout: 5}) }
+    it { should contain_file(conf_file).with_content(%r{url: http://localhost:8080}) }
+  end
+
+  context 'with params set' do
+    let(:params) {{
+      marathon_timeout: 867,
+      url: 'http://foo.bar.baz:5309',
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{default_timeout: 867}) }
+    it { should contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:5309}) }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_mesos_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mesos_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::mesos' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/mesos.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0644',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{default_timeout: 5}) }
+    it { should contain_file(conf_file).with_content(%r{url: http://localhost:5050}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      mesos_timeout: 867,
+      url: 'http://foo.bar.baz:5309',
+    }}
+    it { should contain_file(conf_file).with_content(%r{default_timeout: 867}) }
+    it { should contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:5309}) }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_mongo_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mongo_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::mongo' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/mongo.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{- server: mongodb://localhost:27017}) }
+    it { should contain_file(conf_file).without_content(%r{tags:}) }
+  end
+
+  context 'with one mongo' do
+    let(:params) {{
+      servers: [
+        {
+          'host' => '127.0.0.1',
+          'port' => '12345',
+          'tags' => %w{ foo bar baz },
+        }
+      ]
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345\s+tags:\s+- foo\s+- bar\s+- baz}) }
+  end
+
+  context 'with multiple mongos' do
+    let(:params) {{
+      servers: [
+        {
+          'host' => '127.0.0.1',
+          'port' => '34567',
+          'tags' => %w{foo bar},
+        },
+        {
+          'host' => '127.0.0.2',
+          'port' => '45678',
+          'tags' => %w{baz bat},
+        }
+      ]
+    }}
+    it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:34567\s+tags:\s+- foo\s+- bar}) }
+    it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.2:45678\s+tags:\s+- baz\s+- bat}) }
+    it { should contain_file(conf_file).with_content(%r{server:.*127.0.0.1.*server:.*127.0.0.2}m) }
+  end
+
+  context 'without tags' do
+    let(:params) {{
+      servers: [
+        {
+          'host' => '127.0.0.1',
+          'port' => '12345',
+        }
+      ]
+    }}
+
+  end
+
+  context 'weird tags' do
+    let(:params) {{
+      servers: [
+        {
+          'host' => '127.0.0.1',
+          'port' => '56789',
+          'tags' => 'word'
+        }
+      ]
+    }}
+    it { should_not compile }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_mysql_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mysql_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::mysql' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/mysql.yaml" }
+
+  context 'with default parameters' do
+    it { should_not compile }
+  end
+
+  context 'with password set' do
+    let(:params) {{
+      password: 'foobar',
+    }}
+
+    it { should compile.with_all_deps }
+    it { should contain_file(conf_file).with(
+      owner: dd_user,
+      group: dd_group,
+      mode: '0600',
+    )}
+    it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+    it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+    it { should contain_file(conf_file).with_content(%r{pass: foobar}) }
+    it { should contain_file(conf_file).without_content(%r{tags: }) }
+
+    context 'with defaults' do
+      it { should contain_file(conf_file).with_content(%r{server: localhost}) }
+      it { should contain_file(conf_file).with_content(%r{user: datadog}) }
+      it { should contain_file(conf_file).without_content(%r{sock: }) }
+      it { should contain_file(conf_file).with_content(%r{replication: 0}) }
+      it { should contain_file(conf_file).with_content(%r{galera_cluster: 0}) }
+    end
+
+    context 'with parameters set' do
+      let(:params) {{
+        password: 'foobar',
+        host: 'mysql1',
+        user: 'baz',
+        sock: '/tmp/mysql.foo.sock',
+        replication: '1',
+        galera_cluster: '1',
+      }}
+
+      it { should contain_file(conf_file).with_content(%r{pass: foobar}) }
+      it { should contain_file(conf_file).with_content(%r{server: mysql1}) }
+      it { should contain_file(conf_file).with_content(%r{user: baz}) }
+      it { should contain_file(conf_file).with_content(%r{sock: /tmp/mysql.foo.sock}) }
+      it { should contain_file(conf_file).with_content(%r{replication: 1}) }
+      it { should contain_file(conf_file).with_content(%r{galera_cluster: 1}) }
+    end
+
+    context 'with tags parameter array' do
+      let(:params) {{
+        password: 'foobar',
+        tags: %w{ foo bar baz },
+      }}
+      it { should contain_file(conf_file).with_content(/tags:[^-]+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+    end
+
+    context 'tags not array' do
+      let(:params) {{
+        password: 'foobar',
+        tags: 'aoeu',
+      }}
+
+      it { should_not compile }
+    end
+  end
+end

--- a/spec/classes/datadog_agent_integrations_nginx_spec.rb
+++ b/spec/classes/datadog_agent_integrations_nginx_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::nginx' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/nginx.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'default parameters' do
+    it { should contain_file(conf_file).without_content(/^[^#]*nginx_status_url/) }
+  end
+
+  context 'parameters set' do
+    let(:params) {{
+      instances: [
+        {
+          'nginx_status_url' => 'http://foo.bar:1941/check',
+          'tags' => %w{foo bar baz}
+        }
+      ]
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{nginx_status_url:.*http://foo.bar:1941/check}m) }
+    it { should contain_file(conf_file).with_content(%r{tags:.*foo.*bar.*baz}m) }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_ntp_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ntp_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::ntp' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/ntp.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(/offset_threshold: 60/) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      offset_threshold: 42,
+    }}
+    it { should contain_file(conf_file).with_content(/offset_threshold: 42/) }
+  end
+
+
+end

--- a/spec/classes/datadog_agent_integrations_postgres_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postgres_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::postgres' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/postgres.yaml" }
+
+  context 'with default parameters' do
+    it { should_not compile }
+  end
+
+  context 'with password set' do
+    let(:params) {{
+      password: 'abc123',
+    }}
+
+    it { should compile.with_all_deps }
+    it { should contain_file(conf_file).with(
+      owner: dd_user,
+      group: dd_group,
+      mode: '0600',
+    )}
+    it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+    it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+    it { should contain_file(conf_file).with_content(/password: abc123/) }
+
+    context 'with default parameters' do
+      it { should contain_file(conf_file).with_content(%r{host: localhost}) }
+      it { should contain_file(conf_file).with_content(%r{dbname: postgres}) }
+      it { should contain_file(conf_file).with_content(%r{port: 5432}) }
+      it { should contain_file(conf_file).with_content(%r{username: datadog}) }
+      it { should contain_file(conf_file).without_content(%r{tags: })}
+      it { should contain_file(conf_file).without_content(%r{^[^#]*relations: }) }
+    end
+
+    context 'with parameters set' do
+      let(:params) {{
+        host: 'postgres1',
+        dbname: 'cats',
+        port: 4142,
+        username: 'monitoring',
+        password: 'abc123',
+        tags: %w{foo bar baz},
+        tables: %w{furry fuzzy funky}
+      }}
+      it { should contain_file(conf_file).with_content(%r{host: postgres1}) }
+      it { should contain_file(conf_file).with_content(%r{dbname: cats}) }
+      it { should contain_file(conf_file).with_content(%r{port: 4142}) }
+      it { should contain_file(conf_file).with_content(%r{username: monitoring}) }
+      it { should contain_file(conf_file).with_content(%r{^[^#]*tags:\s+- foo\s+- bar\s+- baz}) }
+      it { should contain_file(conf_file).with_content(%r{^[^#]*relations:\s+- furry\s+- fuzzy\s+- funky}) }
+    end
+  end
+
+end

--- a/spec/classes/datadog_agent_integrations_process_spec.rb
+++ b/spec/classes/datadog_agent_integrations_process_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::process' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/process.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).without_content(%r{^[^#]*name:}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      processes: [
+        {
+          'name' => 'foo',
+          'search_string' => 'bar',
+          'exact_match' => true
+        }
+      ]
+    }}
+    it { should contain_file(conf_file).with_content(%r{name: foo}) }
+    it { should contain_file(conf_file).with_content(%r{search_string: bar}) }
+    it { should contain_file(conf_file).with_content(%r{exact_match: true}) }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
+++ b/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::rabbitmq' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/rabbitmq.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url: }) }
+    it { should contain_file(conf_file).without_content(%r{rabbitmq_user: }) }
+    it { should contain_file(conf_file).without_content(%r{rabbitmq_pass: }) }
+    it { should contain_file(conf_file).without_content(%r{queues: }) }
+    it { should contain_file(conf_file).without_content(%r{vhosts: }) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      url: 'http://rabbit1:15672/',
+      username: 'foo',
+      password: 'bar',
+      queues: %w{ queue1 queue2 queue3 },
+      vhosts: %w{ vhost1 vhost2 vhost3 },
+    }}
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url: http://rabbit1:15672/}) }
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_user: foo}) }
+    it { should contain_file(conf_file).with_content(%r{rabbitmq_pass: bar}) }
+    it { should contain_file(conf_file).with_content(%r{queues:\s+- queue1\s+- queue2\s+- queue3}) }
+    it { should contain_file(conf_file).with_content(%r{vhosts:\s+- vhost1\s+- vhost2\s+- vhost3}) }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::redis' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/redisdb.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{host: localhost}) }
+    it { should contain_file(conf_file).without_content(%r{^[^#]*password: }) }
+    it { should contain_file(conf_file).with_content(%r{port: 6379}) }
+    it { should contain_file(conf_file).without_content(%r{^[^#]*slowlog-max-len: }) }
+    it { should contain_file(conf_file).without_content(%r{tags:}) }
+    it { should contain_file(conf_file).without_content(%r{\bkeys:}) }
+    it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: true}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      host: 'redis1',
+      password: 'hunter2',
+      port: 867,
+      slowlog_max_len: 5309,
+      tags: %w{foo bar},
+      keys: %w{baz bat},
+      warn_on_missing_keys: false,
+    }}
+    it { should contain_file(conf_file).with_content(%r{host: redis1}) }
+    it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+    it { should contain_file(conf_file).with_content(%r{port: 867}) }
+    it { should contain_file(conf_file).with_content(%r{^[^#]*slowlog-max-len: 5309}) }
+    it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
+    it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
+    it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
+  end
+
+end

--- a/spec/classes/datadog_agent_integrations_solr_spec.rb
+++ b/spec/classes/datadog_agent_integrations_solr_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::solr' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/solr.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{host: localhost}) }
+    it { should contain_file(conf_file).with_content(%r{port: 7199}) }
+    it { should contain_file(conf_file).without_content(%r{user:}) }
+    it { should contain_file(conf_file).without_content(%r{password:}) }
+    it { should contain_file(conf_file).without_content(%r{java_bin_path:}) }
+    it { should contain_file(conf_file).without_content(%r{trust_store_path:}) }
+    it { should contain_file(conf_file).without_content(%r{trust_store_password:}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      hostname: 'solr1',
+      port: 867,
+      username: 'userfoo',
+      password: 'passbar',
+      java_bin_path: '/opt/java/bin',
+      trust_store_path: '/var/lib/solr/trust_store',
+      trust_store_password: 'hunter2',
+      tags: {
+        'foo' => 'bar',
+        'baz' => 'bat',
+      }
+    }}
+    it { should contain_file(conf_file).with_content(%r{host: solr1}) }
+    it { should contain_file(conf_file).with_content(%r{port: 867}) }
+    it { should contain_file(conf_file).with_content(%r{user: userfoo}) }
+    it { should contain_file(conf_file).with_content(%r{password: passbar}) }
+    it { should contain_file(conf_file).with_content(%r{java_bin_path: /opt/java/bin}) }
+    it { should contain_file(conf_file).with_content(%r{trust_store_path: /var/lib/solr/trust_store}) }
+    it { should contain_file(conf_file).with_content(%r{trust_store_password: hunter2}) }
+    it { should contain_file(conf_file).with_content(%r{tags:\s+foo: bar\s+baz: bat}) }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_tomcat_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tomcat_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::tomcat' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/tomcat.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{host: localhost}) }
+    it { should contain_file(conf_file).with_content(%r{port: 7199}) }
+    it { should contain_file(conf_file).without_content(%r{user: }) }
+    it { should contain_file(conf_file).without_content(%r{password: }) }
+    it { should contain_file(conf_file).without_content(%r{java_bin_path:}) }
+    it { should contain_file(conf_file).without_content(%r{trust_store_path:}) }
+    it { should contain_file(conf_file).without_content(%r{trust_store_password}) }
+    it { should contain_file(conf_file).without_content(%r{tags:}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      hostname: 'tomcat1',
+      port: 867,
+      username: 'userfoo',
+      password: 'passbar',
+      java_bin_path: '/opt/bin/java',
+      trust_store_path: '/var/lib/tomcat/trust_store_path',
+      trust_store_password: 'hunter2',
+      tags: {
+        'foo' => 'bar',
+        'baz' => 'bat',
+      }
+    }}
+    it { should contain_file(conf_file).with_content(%r{host: tomcat1}) }
+    it { should contain_file(conf_file).with_content(%r{port: 867}) }
+    it { should contain_file(conf_file).with_content(%r{user: userfoo}) }
+    it { should contain_file(conf_file).with_content(%r{password: passbar}) }
+    it { should contain_file(conf_file).with_content(%r{java_bin_path: /opt/bin/java}) }
+    it { should contain_file(conf_file).with_content(%r{trust_store_path: /var/lib/tomcat/trust_store_path}) }
+    it { should contain_file(conf_file).with_content(%r{trust_store_password: hunter2}) }
+    it { should contain_file(conf_file).with_content(%r{tags:\s+foo: bar\s+baz: bat}) }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_varnish_spec.rb
+++ b/spec/classes/datadog_agent_integrations_varnish_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::varnish' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/varnish.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{varnishstat: /usr/bin/varnishstat}) }
+    it { should contain_file(conf_file).without_content(%r{tags: }) }
+  end
+
+  context 'with parameters set' do
+    let(:params){{
+      varnishstat: '/opt/bin/varnishstat',
+      tags: %w{ foo bar baz },
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{varnishstat: /opt/bin/varnishstat}) }
+    it { should contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz}) }
+  end
+end

--- a/spec/classes/datadog_agent_integrations_zk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_zk_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::zk' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/zk.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{host: localhost}) }
+    it { should contain_file(conf_file).with_content(%r{port: 2181}) }
+    it { should contain_file(conf_file).with_content(%r{timeout: 3}) }
+    it { should contain_file(conf_file).without_content(%r{tags:}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      servers: [
+        {
+          'host' => 'zookeeper1',
+          'port' => '1234',
+          'tags' => %w{foo bar},
+        },
+        {
+          'host' => 'zookeeper2',
+          'port' => '4567',
+          'tags' => %w{baz bat},
+        }
+      ]
+    }}
+    it { should contain_file(conf_file).with_content(%r{host: zookeeper1}) }
+    it { should contain_file(conf_file).with_content(%r{port: 1234}) }
+    it { should contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar}) }
+    it { should contain_file(conf_file).with_content(%r{host: zookeeper2}) }
+    it { should contain_file(conf_file).with_content(%r{port: 4567}) }
+    it { should contain_file(conf_file).with_content(%r{tags:\s+- baz\s+- bat}) }
+    it { should contain_file(conf_file).with_content(%r{host: zookeeper1.+host: zookeeper2}m) }
+  end
+end


### PR DESCRIPTION
these are tests for the integration classes.

I have left out 2 integrations:

1. `datadog_agent::integration::directory`

     This integration doesn't appear to be functional. Catalogs which include it cannot compile. I've opened an issue at #144 for this.

2. `datadog_agent::integration::generic`

    The work I plan to do next on this will obviate the need for the 'generic' integration, so it didn't make sense adding tests for something that's going to go away Real Soon Now™