### PR TITLE
Fix for Issue #146.  Require at least v4.6 of stdlib 

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -66,7 +66,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": "4.x"
+      "version_requirement": ">=4.6"
     },
     {
       "name": "puppetlabs/ruby",


### PR DESCRIPTION
validate_integer function isn't available prior to v4.6 of stdlib.

This should fix #146 