### PR TITLE
Fix zookeeper template

### DIFF
--- a/templates/agent-conf.d/zk.yaml.erb
+++ b/templates/agent-conf.d/zk.yaml.erb
@@ -7,12 +7,12 @@ init_config:
 instances:
 <% @servers.each do |server| -%>
   - host: <%= server['host'] %>
-  - port: <%= server['port'] %>
-  - timeout: 3
-  <% if !server['tags'].nil? && server['tags'].any? -%>
+    port: <%= server['port'] %>
+    timeout: 3
+<% if !server['tags'].nil? && server['tags'].any? -%>
     tags:
-    <% server['tags'].each do |tag| -%>
-      - <%= tag %>
-    <% end -%>
+  <% server['tags'].each do |tag| -%>
+    - <%= tag %>
   <% end -%>
+<% end -%>
 <% end -%>

--- a/templates/agent-conf.d/zk.yaml.erb
+++ b/templates/agent-conf.d/zk.yaml.erb
@@ -9,6 +9,12 @@ instances:
   - host: <%= server['host'] %>
     port: <%= server['port'] %>
     timeout: 3
+    # If `expected_mode` is defined we'll send a service check where the
+    # status is determined by whether the current mode matches the expected.
+    # Options: leader, follower, standalone
+<% if !server['expected_mode'].nil? -%>
+    expected_mode: <%= server['expected_mode'] %>
+<% end -%>
 <% if !server['tags'].nil? && server['tags'].any? -%>
     tags:
   <% server['tags'].each do |tag| -%>


### PR DESCRIPTION
I removed the dashes before ```port``` and ```timeout``` otherwise these will interpreted as a new ```Zookeeper``` host definition.

In addition I added the ```expected_mode``` property.