### PR TITLE
Use ensure_packages() to be more polite about apt-transport-https

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -14,10 +14,7 @@ class datadog_agent::ubuntu(
   $apt_key = 'C7A7DA52'
 ) {
 
-  package { 'apt-transport-https':
-    ensure => latest,
-    before => File['/etc/apt/sources.list.d/datadog.list'],
-  }
+  ensure_packages(['apt-transport-https'])
 
   if !$::datadog_agent::skip_apt_key_trusting {
     exec { 'datadog_key':
@@ -28,10 +25,11 @@ class datadog_agent::ubuntu(
   }
 
   file { '/etc/apt/sources.list.d/datadog.list':
-    source => 'puppet:///modules/datadog_agent/datadog.list',
-    owner  => 'root',
-    group  => 'root',
-    notify => Exec['datadog_apt-get_update'],
+    source  => 'puppet:///modules/datadog_agent/datadog.list',
+    owner   => 'root',
+    group   => 'root',
+    notify  => Exec['datadog_apt-get_update'],
+    require => Package['apt-transport-https'],
   }
 
   exec { 'datadog_apt-get_update':


### PR DESCRIPTION
This will prevent this module from getting up in arms with any other package
resource trying to ensure that apt-transport-https is installed