### PR TITLE
Raise the priority for 'changed' event types so they're visible

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -54,10 +54,11 @@ Puppet::Reports.register_report(:datadog_reports) do
       elsif @status == 'changed'
         event_title = "Puppet changed resources on #{@msg_host}"
         alert_type = "success"
+        event_priority = "normal"
       elsif @status == "unchanged"
         event_title = "Puppet ran on, and left #{@msg_host} unchanged"
         alert_type = "success"
-      else 
+      else
         event_title = "Puppet ran on #{@msg_host}"
         alert_type = "success"
       end
@@ -76,7 +77,7 @@ Puppet::Reports.register_report(:datadog_reports) do
     config_version_blurb = if defined?(self.configuration_version) then "applied version #{self.configuration_version} and" else "" end
 
     event_data << "Puppet #{config_version_blurb} changed #{pluralize(changed_resources.length, 'resource')} out of #{total_resource_count}."
-    
+
     # List changed resources
     if changed_resources.length > 0
       event_data << "\nThe resources that changed are:\n@@@\n"


### PR DESCRIPTION
If your Puppet infrastructure never fails, let's say because you have a good
testing pipeline, it might not be obvious to you that any Puppet events are
being reported because everything but failures is 'low' priority. Datadog's web
UI defaults to showing only things of 'normal' priority.

This changes the priority of a 'changed' resource to 'normal' since a change of
configuration is useful information to use when correlating data or showing
events in a dashboard.