### PR TITLE
Move the GPGkey to a parameter.

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -14,7 +14,8 @@
 # Sample Usage:
 #
 class datadog_agent::redhat(
-  $baseurl = "https://yum.datadoghq.com/rpm/${::architecture}/"
+  $baseurl = "https://yum.datadoghq.com/rpm/${::architecture}/",
+  $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
 ) {
 
   validate_string($baseurl)
@@ -22,7 +23,7 @@ class datadog_agent::redhat(
   yumrepo {'datadog':
     enabled  => 1,
     gpgcheck => 1,
-    gpgkey   => 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+    gpgkey   => $gpgkey,
     descr    => 'Datadog, Inc.',
     baseurl  => $baseurl,
   }


### PR DESCRIPTION
In some environments with blocked egress connectivity, the location
of the GPGkey might need to be overwritten to an internal resource.