### PR TITLE
Additional Mongo configuration for SSL, additional metrics, and database connection

### DIFF
--- a/manifests/integrations/mongo.pp
+++ b/manifests/integrations/mongo.pp
@@ -3,21 +3,48 @@
 # This class will install the necessary configuration for the mongo integration
 #
 # Parameters:
+#   $additional_metrics
+#       Optional array of additional metrics
+#   $database
+#       Optionally specify database to query. Defaults to 'admin'
 #   $host:
 #       The host mongo is running on. Defaults to '127.0.0.1'
+#   $password
+#       Optionally specify password for connection
 #   $port
-#       The mongo password for the datadog user. Defaults to 27017
+#       The port mongo is running on. Defaults to 27017
+#   $ssl
+#       Optionally enable SSL for connection
+#   $ssl_ca_certs
+#       Optionally specify path to SSL Certificate Authority certificates
+#   $ssl_cert_reqs
+#       Optionally require SSL client certificate for connection
+#   $ssl_certfile
+#       Optionally specify path to SSL certificate for connection
+#   $ssl_keyfile
+#       Optionally specify path to SSL private key for connection
 #   $tags
 #       Optional array of tags
+#   $username
+#       Optionally specify username for connection
 #
 # Sample Usage:
 #
 #  class { 'datadog_agent::integrations::mongo' :
 #    servers => [
 #      {
-#        'host' => 'localhost',
-#        'port' => '27017',
-#        'tags' => [],
+#        'additional_metrics' => ['top'],
+#        'database'           => 'database_name',
+#        'host'               => 'localhost',
+#        'password'           => 'mongo_password',
+#        'port'               => '27017',
+#        'ssl'                => true,
+#        'ssl_ca_certs'       => '/path/to/ca.pem',
+#        'ssl_cert_reqs'      => 'CERT_REQUIRED',
+#        'ssl_certfile'       => '/path/to/client.pem',
+#        'ssl_keyfile'        => '/path/to/key.pem',
+#        'tags'               => ['optional_tag1', 'optional_tag2'],
+#        'username'           => 'mongo_username',
 #      },
 #      {
 #        'host' => 'localhost',

--- a/templates/agent-conf.d/mongo.yaml.erb
+++ b/templates/agent-conf.d/mongo.yaml.erb
@@ -6,11 +6,32 @@ init_config:
 
 instances:
 <% @servers.each do |server| -%>
-  - server: mongodb://<%= server['host'] %>:<%= server['port'] %>
+  - server: mongodb://<%= server['username'] %><%= ":" unless server['password'].nil? %><%= server['password'] %><%= "@" unless server['username'].nil? %><%= server['host'] %>:<%= server['port'] %>/<%= server['database'] %>
   <%- if !server['tags'].nil? && server['tags'].any? -%>
     tags:
     <%- server['tags'].each do |tag| -%>
       - <%= tag %>
+    <%- end -%>
+  <%- end -%>
+  <%- if !server['ssl'].nil? -%>
+    ssl: <%= server['ssl'] %>
+    <%- if !server['ssl_keyfile'].nil? -%>
+    ssl_keyfile: <%= server['ssl_keyfile'] %>
+    <%- end -%>
+    <%- if !server['ssl_certfile'].nil? -%>
+    ssl_certfile: <%= server['ssl_certfile'] %>
+    <%- end -%>
+    <%- if !server['ssl_cert_reqs'].nil? -%>
+    ssl_cert_reqs: <%= server['ssl_cert_reqs'] %>
+    <%- end -%>
+    <%- if !server['ssl_ca_certs'].nil? -%>
+    ssl_ca_certs: <%= server['ssl_ca_certs'] %>
+    <%- end -%>
+  <%- end -%>
+  <%- if !server['additional_metrics'].nil? && server['additional_metrics'].any? -%>
+    additional_metrics:
+    <%- server['additional_metrics'].each do |additional_metric| -%>
+      - <%= additional_metric %>
     <%- end -%>
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
This PR copies additional available configuration found upstream here:
https://github.com/DataDog/dd-agent/blob/master/conf.d/mongo.yaml.example

Given this hiera and `include datadog_agent::integrations::mongo`:
```
datadog_agent::integrations::mongo::servers:
  - additional_metrics:
      - top
    database: my_db
    host: 127.0.0.1
    port: 27017
    ssl: true
    tags:
      - "replica_set:foo"
```

It generated this mongo configuration:
```
#
# MANAGED BY PUPPET
#

init_config:

instances:
  - server: mongodb://127.0.0.1:27017/my_db
    tags:
      - replica_set:foo
    ssl: true
    additional_metrics:
      - top
```

And reported as stable in the 5.6.3 agent after restart:
```
service datadog-agent info
===================
Collector (v 5.6.3)
===================
...
  Checks
  ======
...
    mongo
    -----
      - instance #0 [OK]
      - Collected 112 metrics, 0 events & 2 service checks
      - Dependencies:
          - pymongo: 2.8
```

Along with seeing metrics in the DataDog dashboard. Please let me know if you need anything else to get this merged! :tada: 