### PR TITLE
Add mesos_role parameter

### DIFF
--- a/manifests/integrations/mesos.pp
+++ b/manifests/integrations/mesos.pp
@@ -14,10 +14,11 @@
 #
 class datadog_agent::integrations::mesos(
   $mesos_timeout = 5,
-  $url = 'http://localhost:5050'
+  $url = 'http://localhost:5050',
+  $mesos_role = 'master'
 ) inherits datadog_agent::params {
 
-  file { "${datadog_agent::params::conf_dir}/mesos.yaml":
+  file { "${datadog_agent::params::conf_dir}/mesos-${mesos_role}.yaml":
     ensure  => file,
     owner   => $datadog_agent::params::dd_user,
     group   => $datadog_agent::params::dd_group,


### PR DESCRIPTION
This influences the yaml file that puppet creates, so that the datadog
agent can correctly differentiate between mesos worker and master nodes.

This is to resolve #163 .