### PR TITLE
Decouple the yum repo definition from the package.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,9 @@
 #   $statsd_forward_port
 #       Set the value of the statsd_forward_port varable. Used to forward all
 #       statsd metrics to another host.
+#   $manage_repo
+#       Boolean to indicate whether this module should attempt to manage
+#       the package repo. Default true.
 #   $proxy_host
 #       Set value of 'proxy_host' variable. Default is blank.
 #   $proxy_port
@@ -103,6 +106,7 @@ class datadog_agent(
   $log_to_syslog = true,
   $service_ensure = 'running',
   $service_enable = true,
+  $manage_repo = true,
   $use_mount = false,
   $dogstatsd_port = 8125,
   $statsd_forward_host = '',
@@ -132,6 +136,7 @@ class datadog_agent(
   validate_string($puppetmaster_user)
   validate_bool($non_local_traffic)
   validate_bool($log_to_syslog)
+  validate_bool($manage_repo)
   validate_string($log_level)
   validate_integer($dogstatsd_port)
   validate_string($statsd_histogram_percentiles)
@@ -167,7 +172,11 @@ class datadog_agent(
 
   case $::operatingsystem {
     'Ubuntu','Debian' : { include datadog_agent::ubuntu }
-    'RedHat','CentOS','Fedora','Amazon','Scientific' : { include datadog_agent::redhat }
+    'RedHat','CentOS','Fedora','Amazon','Scientific' : {
+      class { 'datadog_agent::redhat':
+        manage_repo => $manage_repo,
+      }
+    }
     default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
   }
 

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -14,17 +14,23 @@
 # Sample Usage:
 #
 class datadog_agent::redhat(
-  $baseurl = "https://yum.datadoghq.com/rpm/${::architecture}/"
+  $baseurl     = "https://yum.datadoghq.com/rpm/${::architecture}/",
+  $manage_repo = true,
 ) {
 
-  validate_string($baseurl)
+  validate_bool($manage_repo)
+  if $manage_repo {
+    validate_string($baseurl)
 
-  yumrepo {'datadog':
-    enabled  => 1,
-    gpgcheck => 1,
-    gpgkey   => 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
-    descr    => 'Datadog, Inc.',
-    baseurl  => $baseurl,
+    yumrepo {'datadog':
+      enabled  => 1,
+      gpgcheck => 1,
+      gpgkey   => 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+      descr    => 'Datadog, Inc.',
+      baseurl  => $baseurl,
+    }
+
+    Package['datadog-agent'] -> Yumrepo['datadog']
   }
 
   package { 'datadog-agent-base':
@@ -34,7 +40,6 @@ class datadog_agent::redhat(
 
   package { 'datadog-agent':
     ensure  => latest,
-    require => Yumrepo['datadog'],
   }
 
   service { 'datadog-agent':

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -10,13 +10,23 @@ describe 'datadog_agent::redhat' do
   end
 
   # it should install the mirror
-  it do
-    should contain_yumrepo('datadog')
-      .with_enabled(1)\
-      .with_gpgcheck(1)\
-      .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
-      .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
+  context 'with manage_repo => true' do
+    let(:params){ {:manage_repo => true} }
+    it do
+      should contain_yumrepo('datadog')
+        .with_enabled(1)\
+        .with_gpgcheck(1)\
+        .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+        .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
+    end
   end
+  context 'with manage_repo => false' do
+    let(:params){ {:manage_repo => false} }
+    it do
+      should_not contain_yumrepo('datadog')
+    end
+  end
+
 
   # it should install the packages
   it do


### PR DESCRIPTION
Control management via the manage_repo parameter.

This allows for private repos in the case where there might
be a network issue between the host and datadog's yum repo, or you just want to 
manage the package in your own repo.

Added some tests for both cases