### PR TITLE
add option in datadog_agent to extract hostnames

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -207,8 +207,8 @@ class datadog_agent(
 
   if $puppet_run_reports {
     class { 'datadog_agent::reports':
-      api_key           => $api_key,
-      puppetmaster_user => $puppetmaster_user,
+      api_key                   => $api_key,
+      puppetmaster_user         => $puppetmaster_user,
       hostname_extraction_regex => $hostname_extraction_regex,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,11 @@
 #   $log_level
 #       Set value of 'log_level' variable. Default is 'info' as in dd-agent.
 #       Valid values here are: critical, debug, error, fatal, info, warn and warning.
+#   $hostname_extraction_regex
+#       Completely optional.
+#       Instead of reporting the puppet nodename, use this regex to extract the named
+#       'hostname' captured group to report the run in Datadog.
+#       ex.: '^(?<hostname>.*\.datadoghq\.com)(\.i-\w{8}\..*)?$'
 #   $log_to_syslog
 #       Set value of 'log_to_syslog' variable. Default is true -> yes as in dd-agent.
 #       Valid values here are: true or false.
@@ -103,6 +108,7 @@ class datadog_agent(
   $log_to_syslog = true,
   $service_ensure = 'running',
   $service_enable = true,
+  $hostname_extraction_regex = nil,
   $use_mount = false,
   $dogstatsd_port = 8125,
   $statsd_forward_host = '',
@@ -203,6 +209,7 @@ class datadog_agent(
     class { 'datadog_agent::reports':
       api_key           => $api_key,
       puppetmaster_user => $puppetmaster_user,
+      hostname_extraction_regex => $hostname_extraction_regex,
     }
   }
 

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -15,7 +15,8 @@
 #
 class datadog_agent::reports(
   $api_key,
-  $puppetmaster_user
+  $puppetmaster_user,
+  $hostname_extraction_regex = nil
 ) {
 
   include datadog_agent::params

--- a/templates/datadog.yaml.erb
+++ b/templates/datadog.yaml.erb
@@ -3,3 +3,6 @@
 #
 ---
 :datadog_api_key: '<%= @api_key %>'
+<% if @hostname_extraction_regex.nil? -%>
+:hostname_extraction_regex: '<%= @hostname_extraction_regex %>'
+<% end -%>


### PR DESCRIPTION
Fixes #160.

This option is a string regex which can be enabled and used to extract
the hostname from puppet hostname strings with a capture group.
It is useful for people that have specific puppet hostnames and that
would like to sanitize them before reporting those in Datadog.

cc @olivielpeau @diranged

There are unrelated `rake lint` and `rake spec` errors that I can fix as part of another PR.