### PR TITLE
Add manifest for the pgbouncer integration

### DIFF
--- a/manifests/integrations/pgbouncer.pp
+++ b/manifests/integrations/pgbouncer.pp
@@ -1,0 +1,46 @@
+# Class: datadog_agent::integrations::pgbouncer
+#
+# This class will install the necessary configuration for the pgbouncer integration
+#
+# Parameters:
+#   $host:
+#       The host pgbouncer is listening on
+#   $port
+#       The pgbouncer port number
+#   $username
+#       The username for the datadog user
+#   $password
+#       The password for the datadog user
+#   $tags
+#       Optional array of tags
+#
+# Sample Usage:
+#
+#  class { 'datadog_agent::integrations::pgbouncer' :
+#    host     => 'localhost',
+#    username => 'datadog',
+#    port     => '6432',
+#    password => 'some_pass',
+#  }
+#
+#
+class datadog_agent::integrations::pgbouncer(
+  $host   = 'localhost',
+  $port   = '6432',
+  $username = 'datadog',
+  $password,
+  $tags = [],
+) inherits datadog_agent::params {
+
+  validate_array($tags)
+
+  file { "${datadog_agent::params::conf_dir}/pgbouncer.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0600',
+    content => template('datadog_agent/agent-conf.d/pgbouncer.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name],
+  }
+}

--- a/templates/agent-conf.d/pgbouncer.yaml.erb
+++ b/templates/agent-conf.d/pgbouncer.yaml.erb
@@ -1,0 +1,23 @@
+init_config:
+
+instances:
+#   -   host: localhost
+#       port: 6432
+#       username: my_username
+#       password: my_password
+#       tags:
+#            - optional_tag1
+#            - optional_tag2
+#
+  - host: <%= @host %>
+    port: <%= @port %>
+    username: <%= @username %>
+    password: <%= @password %>
+<% if @tags and ! @tags.empty? -%>
+    tags:
+  <%- Array(@tags).each do |tag| -%>
+    <%- if tag != '' -%>
+      - <%= tag %>
+    <%- end -%>
+  <%- end -%>
+<% end -%>


### PR DESCRIPTION
This adds a manifest and template for the DataDog-pgbouncer integration, which is almost an exact copy of the postgres integration, minus the `dbname` and `tables`.

I'm currently running this on my servers and it's successfully pulling in data.