### PR TITLE
Validate the process hashes for the process integration

### DIFF
--- a/lib/puppet/parser/functions/validate_processes.rb
+++ b/lib/puppet/parser/functions/validate_processes.rb
@@ -1,0 +1,29 @@
+# Function: validate_processes
+#
+# A function to validate processes for the datadog process integration.
+# It validates that the input is an array of process hashes, and that each key
+# has the correct data type.
+#
+# This currently has to be done in a custom function because this module
+# supports versions of Puppet < 4.0. This could be done with Puppet iterators,
+# so if support for < 4.0 is ever dropped, this should be moved into the
+# manifests.
+#
+# Parameters:
+#   processes:
+#     An array of process hashes
+#
+#
+module Puppet::Parser::Functions
+  newfunction(:validate_processes) do |args|
+    processes = args[0]
+
+    function_validate_array([processes])
+
+    processes.each do |process|
+      function_validate_string([process['name']])
+      function_validate_array([process['search_string']])
+      function_validate_bool([process['exact_match']])
+    end
+  end
+end

--- a/manifests/integrations/process.pp
+++ b/manifests/integrations/process.pp
@@ -42,7 +42,7 @@ class datadog_agent::integrations::process(
   $processes = [],
 ) inherits datadog_agent::params {
 
-  validate_array( $processes )
+  validate_processes( $processes )
 
   file { "${datadog_agent::params::conf_dir}/process.yaml":
     ensure  => file,

--- a/spec/functions/validate_processes_spec.rb
+++ b/spec/functions/validate_processes_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe 'validate_processes' do
+  context 'with valid input' do
+    it 'is expected to validate all fields and do nothing' do
+      params = [
+        {
+          'name' => 'my_process',
+          'search_string' => [
+            'my_process',
+          ],
+          'exact_match' => false,
+        }
+      ]
+
+      is_expected.to_not run.with_params(params).and_raise_error(Puppet::ParseError)
+    end
+  end
+
+  context 'with invalid input' do
+    it 'is expected to validate all fields and raise Puppet::ParseError' do
+      params = [
+        {
+          'name' => 'my_process',
+          'search_string' => [
+            'my_process',
+          ],
+          'exact_match' => false,
+        },
+        {
+          'name' => 'my_other_process',
+          'search_string' => 'my_other_process',
+          'exact_match' => false,
+        }
+      ]
+
+      is_expected.to run.with_params(params).and_raise_error(Puppet::ParseError)
+    end
+  end
+end


### PR DESCRIPTION
This adds a custom function that validates all fields of the
`$processes` array of hashes from the process integration. It had to be
done in a custom function in order to support all specific versions of
Puppet, otherwise it could be done with iterators at the manifest level.

Feel free to reject this if it's not the sort of thing you want to
maintain in this repo, this just bit me earlier today, so I thought I
would open this and see :)
