### PR TITLE
Fix the default redis port value

### DIFF
--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -28,7 +28,7 @@
 class datadog_agent::integrations::redis(
   $host = 'localhost',
   $password = '',
-  $port = 6379,
+  $port = '6379',
   $ports = undef,
   $slowlog_max_len = '',
   $tags = [],


### PR DESCRIPTION
validate_re expects a string to match against, but the default value for
the redis port is a fixnum, causing a compilation error when using the
default value.