### PR TITLE
Adding ability to manage disk.yaml

### DIFF
--- a/manifests/integrations/disk.pp
+++ b/manifests/integrations/disk.pp
@@ -1,0 +1,29 @@
+# Class: datadog_agent::integrations::ntp
+#
+# This class will enable ntp check
+#
+# Parameters:
+#   $offset_threshold:
+#        Offset threshold for a critical alert. Defaults to 600.
+#
+# Sample Usage:
+#
+#  class { 'datadog_agent::integrations::ntp' :
+#    offset_threshold     => 60,
+#  }
+#
+
+class datadog_agent::integrations::disk(
+  $offset_threshold = 60,
+) inherits datadog_agent::params {
+
+  file { "${datadog_agent::params::conf_dir}/disk.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0600',
+    content => template('datadog_agent/agent-conf.d/disk.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/templates/agent-conf.d/disk.yaml.erb
+++ b/templates/agent-conf.d/disk.yaml.erb
@@ -1,0 +1,30 @@
+init_config:
+
+instances:
+  # The use_mount parameter will instruct the check to collect disk
+  # and fs metrics using mount points instead of volumes
+  - use_mount: yes
+    # The (optional) excluded_filesystems parameter will instruct the check to
+    # ignore disks using these filesystems
+    # excluded_filesystems:
+    #   - tmpfs
+
+    # The (optional) excluded_disks parameter will instruct the check to
+    # ignore this list of disks
+    # excluded_disks:
+    #   - /dev/sda1
+    #   - /dev/sda2
+    #
+    # The (optional) excluded_disk_re parameter will instruct the check to
+    # ignore all disks matching this regex
+    # excluded_disk_re: /dev/sde*
+    #
+    # The (optional) tag_by_filesystem parameter will instruct the check to
+    # tag all disks with their filesystem (for ex: filesystem:nfs)
+    # tag_by_filesystem: no
+    #
+    # The (optional) all_partitions parameter will instruct the check to
+    # get metrics for all partitions. use_mount should be set to yes (to avoid
+    # collecting empty device names) when using this option.
+    # all_partitions: no
+


### PR DESCRIPTION
Added disk.pp and disk.yaml.erb.

This allows the use of puppet to manage the disk.yaml config file through Puppet.
