### PR TITLE
Puppet runs are now idempotent on rhel 7 distros

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -49,6 +49,7 @@ class datadog_agent::redhat(
     enable    => $::datadog_agent::service_enable,
     hasstatus => false,
     pattern   => 'dd-agent',
+    provider  => 'init',
     require   => Package['datadog-agent'],
   }
 


### PR DESCRIPTION
When I do puppet runs on centos7, I kept getting the following happening:



```
# puppet agent -t
Notice: Local environment: 'production' doesn't match server specified node environment 'development', switching agent to 'development'.
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for xxxxxxxxxxxxxxxx
Info: Applying configuration version '1461254235'
Notice: /Stage[main]/Datadog_agent::Redhat/Service[datadog-agent]/enable: enable changed 'false' to 'true'
Notice: Applied catalog in 3.47 seconds

```
I.e. it isn't idempotent. Although it doesn't give any red error messages. 

This change fixes this. 
