### PR TITLE
[puppet] PE and POSS require puppetserver_gem to get the dogapi gem in the JRuby env.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ that needs to be done.
           puppet_run_reports => true,
         }
 
-  __To support reporting, your Puppet master needs to have the [dogapi](https://github.com/DataDog/dogapi-rb) gem installed, to do that either run the puppet agent on your master with this configuration or install it manually with `gem`__
+  __To support reporting, your Puppet master needs to have the [dogapi](https://github.com/DataDog/dogapi-rb) gem installed, to do that either run the puppet agent on your master with this configuration or install it manually with `gem`.__
+  _Please note if on Puppet Enterprise or POSS (ie. >=3.7.0) there is a soft dependency for reporting on the `puppetserver_gem` module. Install with `puppet module install puppetlabs-puppetserver_gem` - installing manually with `gem` will *not* work._
 
 3. Include any other integrations you want the agent to use, e.g.
 
@@ -96,6 +97,7 @@ And on all of your Puppet client nodes add:
     [agent]
     # ...
     report=true
+
 
 If you get
 

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -21,6 +21,14 @@ class datadog_agent::reports(
 
   include datadog_agent::params
   $rubydev_package = $datadog_agent::params::rubydev_package
+  $gemprovider = 'puppetserver_gem'
+
+  # set the right provider
+  if (!defined('$::serverversion') or versioncmp($::serverversion, '3.7.0') < 0) {
+      $_gemprovider = 'gem'
+  } else {
+      $_gemprovider = $gemprovider
+  }
 
   # check to make sure that you're not installing rubydev somewhere else
   if ! defined(Package[$rubydev_package]) {
@@ -48,7 +56,7 @@ class datadog_agent::reports(
 
   package{'dogapi':
     ensure   => 'installed',
-    provider => 'gem',
+    provider => $_gemprovider,
   }
 
 }


### PR DESCRIPTION
## Why
As it turns out PE and POSS have the puppetserver sit on top of their own JRuby environment, with its own set of gems, etc. Fortunately the `puppetserver_gem` provider comes to the rescue to allow us to provide the required `dogapi` gem (if you want reporting enabled) into the environment.