### PR TITLE
fixing logic in if statement

### DIFF
--- a/templates/datadog.yaml.erb
+++ b/templates/datadog.yaml.erb
@@ -3,6 +3,6 @@
 #
 ---
 :datadog_api_key: '<%= @api_key %>'
-<% if @hostname_extraction_regex.nil? -%>
+<% if !@hostname_extraction_regex.nil? -%>
 :hostname_extraction_regex: '<%= @hostname_extraction_regex %>'
 <% end -%>


### PR DESCRIPTION
Currently, the test on hostname_extraction_regex only works if the hostname is nil. The test should add the regex if the variable is not null as the code below does.