### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ before_install: rm -f Gemfile.lock
 sudo: false
 cache: bundler
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.3
 script:
   - bundle exec rake spec
   - bundle exec rake test
@@ -25,10 +25,6 @@ env:
   - PUPPET_VERSION="~> 4.2.1" STRICT_VARIABLES=yes
 matrix:
   exclude:
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-
   # Ruby 2.0.0
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 2.7.0"
@@ -41,4 +37,14 @@ matrix:
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.3.0"
   - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.4.0"
+
+  # Ruby 2.2.3
+  - rvm: 2.2.3
+    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 2.2.3
+    env: PUPPET_VERSION="~> 3.2.0"
+  - rvm: 2.2.3
+    env: PUPPET_VERSION="~> 3.3.0"
+  - rvm: 2.2.3
     env: PUPPET_VERSION="~> 3.4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source "https://rubygems.org"
 
 group :test do
+  gem "syck"
+  gem "safe_yaml", "~> 1.0.4"
+  gem "listen", "~> 3.0.0"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.2.0'
   gem "puppet-lint"
   gem "puppet-syntax"


### PR DESCRIPTION
By setting `gem "listen", "~> 3.0.0"` we should be able to get around the `listen` requirement in newer gem versions for ruby `>=2.2.4`. Not really convinced this is the way to go, but until we (and puppet) decide to drop support for older rubies, it might be our only option.

Also removing 1.9.3 (which has been EOLd for a while) tests for now, until we get elegant way of bringing them back.