### PR TITLE
Adding new mysql options

### DIFF
--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -47,7 +47,7 @@ class datadog_agent::integrations::mysql(
   $extra_status_metrics = false,
   $extra_innodb_metrics = false,
   $extra_performance_metrics = false,
-  $schema_size_metrics = false, 
+  $schema_size_metrics = false 
   $disable_innodb_metrics = false,
 ) inherits datadog_agent::params {
   include datadog_agent

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -47,8 +47,9 @@ class datadog_agent::integrations::mysql(
   $extra_status_metrics = false,
   $extra_innodb_metrics = false,
   $extra_performance_metrics = false,
-  $schema_size_metrics = false 
-  $disable_innodb_metrics = false,)
+  $schema_size_metrics = false, 
+  $disable_innodb_metrics = false,
+  )
   
   inherits datadog_agent::params {
   include datadog_agent

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -17,7 +17,16 @@
 #       replication option
 #   $galera_cluster
 #       galera cluster option
-#
+#   $extra_status_metrics
+#       extra status metrics
+#   $extra_innodb_metrics
+#       extra innodb metrics
+#   $extra_performance_metrics
+#       extra performance metrics, query run time, 95th precentile avg
+#   $schema_size_metrics
+#       schema size metrics
+#   $disable_innodb_metrics
+#       disable innodb metrics, used with older versions of MySQL without innodb engine support.
 # Sample Usage:
 #
 #  class { 'datadog_agent::integrations::mysql' :
@@ -34,7 +43,12 @@ class datadog_agent::integrations::mysql(
   $sock = undef,
   $tags = [],
   $replication = '0',
-  $galera_cluster = '0'
+  $galera_cluster = '0',
+  $extra_status_metrics = false,
+  $extra_innodb_metrics = false,
+  $extra_performance_metrics = false,
+  $schema_size_metrics = false, 
+  $disable_innodb_metrics = false,
 ) inherits datadog_agent::params {
   include datadog_agent
 
@@ -50,3 +64,4 @@ class datadog_agent::integrations::mysql(
     notify  => Service[$datadog_agent::params::service_name],
   }
 }
+

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -48,8 +48,9 @@ class datadog_agent::integrations::mysql(
   $extra_innodb_metrics = false,
   $extra_performance_metrics = false,
   $schema_size_metrics = false 
-  $disable_innodb_metrics = false,
-) inherits datadog_agent::params {
+  $disable_innodb_metrics = false,)
+  
+  inherits datadog_agent::params {
   include datadog_agent
 
   validate_array($tags)

--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -22,3 +22,9 @@ instances:
     options:               # Optional
         replication: <%= @replication %>
         galera_cluster: <%= @galera_cluster %>
+        extra_status_metrics: <%= @extra_status_metrics %>
+        extra_innodb_metrics: <%= @extra_innodb_metrics %>
+        extra_performance_metrics: <%= @extra_performance_metrics %>
+        schema_size_metrics: <%= @schema_size_metrics %>
+        disable_innodb_metrics: <%= @disable_innodb_metrics %>
+


### PR DESCRIPTION
Had to remake the branch locally, This should work hopefully @truthbk.

Updating mysql to have the 5 mission options [Datadog's MySQL](http://docs.datadoghq.com/integrations/mysql/).

This replaces #192