### PR TITLE
Add Elasticsearch shield support

### DIFF
--- a/manifests/integrations/elasticsearch.pp
+++ b/manifests/integrations/elasticsearch.pp
@@ -13,9 +13,30 @@
 #   }
 #
 class datadog_agent::integrations::elasticsearch(
-  $url = 'http://localhost:9200'
+  $cluster_stats      = false,
+  $password           = undef,
+  $pending_task_stats = true,
+  $pshard_stats       = false,
+  $ssl_cert           = undef,
+  $ssl_key            = undef,
+  $ssl_verify         = true,
+  $tags               = [],
+  $url                = 'http://localhost:9200',
+  $username           = undef,
 ) inherits datadog_agent::params {
   include datadog_agent
+
+  validate_array($tags)
+  # $ssl_verify can be a bool or a string
+  # https://github.com/DataDog/dd-agent/blob/master/checks.d/elastic.py#L454-L455
+  if is_bool($ssl_verify) {
+    validate_bool($ssl_verify)
+  } elsif $ssl_verify != undef {
+    validate_string($ssl_verify)
+    validate_absolute_path($ssl_verify)
+  }
+  validate_bool($cluster_stats, $pending_task_stats, $pshard_stats)
+  validate_string($password, $ssl_cert, $ssl_key, $url, $username)
 
   file { "${datadog_agent::params::conf_dir}/elastic.yaml":
     ensure  => file,

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -22,14 +22,36 @@ describe 'datadog_agent::integrations::elasticsearch' do
   it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
 
   context 'with default parameters' do
-    it { should contain_file(conf_file).with_content(%r{url: http://localhost:9200}) }
+    it { should contain_file(conf_file).with_content(%r{    - url: http://localhost:9200}) }
+    it { should contain_file(conf_file).with_content(%r{      cluster_stats: false}) }
+    it { should contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
+    it { should contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
+    it { should_not contain_file(conf_file).with_content(%r{      username}) }
+    it { should_not contain_file(conf_file).with_content(%r{      password}) }
+    it { should_not contain_file(conf_file).with_content(%r{      ssl_verify}) }
+    it { should_not contain_file(conf_file).with_content(%r{      ssl_cert}) }
+    it { should_not contain_file(conf_file).with_content(%r{      ssl_key}) }
+    it { should_not contain_file(conf_file).with_content(%r{      tags:}) }
   end
-
-  context 'with parameters set' do
+context 'with parameters set' do
     let(:params) {{
-      url: 'http://foo:4242',
+      password:           'password',
+      pending_task_stats: false,
+      url:                'https://foo:4242',
+      username:           'username',
+      ssl_cert:           '/etc/ssl/certs/client.pem',
+      ssl_key:            '/etc/ssl/private/client.key',
+      tags:               ['tag1:key1'],
     }}
-    it { should contain_file(conf_file).with_content(%r{http://foo:4242}) }
+    it { should contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
+    it { should contain_file(conf_file).with_content(%r{      pending_task_stats: false}) }
+    it { should contain_file(conf_file).with_content(%r{      username: username}) }
+    it { should contain_file(conf_file).with_content(%r{      password: password}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_verify: true}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
+    it { should contain_file(conf_file).with_content(%r{      tags:}) }
+    it { should contain_file(conf_file).with_content(%r{        - tag1:key1}) }
   end
 
 end

--- a/templates/agent-conf.d/elastic.yaml.erb
+++ b/templates/agent-conf.d/elastic.yaml.erb
@@ -6,3 +6,27 @@ init_config:
 
 instances:
     - url: <%= @url %>
+<%- if @username -%>
+      username: <%= @username %>
+<%- end -%>
+<%- if @password -%>
+      password: <%= @password %>
+<%- end -%>
+      cluster_stats: <%= @cluster_stats %>
+      pshard_stats: <%= @pshard_stats %>
+      pending_task_stats: <%= @pending_task_stats %>
+<%- if @url.match(/^https/) -%>
+      ssl_verify: <%= @ssl_verify %>
+<%- end -%>
+<%- if @ssl_cert -%>
+      ssl_cert: <%= @ssl_cert %>
+<%- end -%>
+<%- if @ssl_key -%>
+      ssl_key: <%= @ssl_key %>
+<%- end -%>
+<%- unless @tags.empty? -%>
+      tags:
+  <%- @tags.each do |tag| -%>
+        - <%= tag %>
+  <%- end -%>
+<%- end -%>


### PR DESCRIPTION
This pull request will add support for Elasticsearch shield (added in dd-agent 5.8.0)
```
14:21:15 - INFO - running test
---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml
Cloning into 'spec/fixtures/modules/stdlib'...
Cloning into 'spec/fixtures/modules/ruby'...
remote: Counting objects: 48, done.
remote: Compressing objects: 100% (39/39), done.
remote: Total 48 (delta 5), reused 25 (delta 1), pack-reused 0
Receiving objects: 100% (48/48), 25.82 KiB | 0 bytes/s, done.
Resolving deltas: 100% (5/5), done.
Checking connectivity... done.
remote: Counting objects: 458, done.
remote: Compressing objects: 100% (318/318), done.
remote: Total 458 (delta 142), reused 365 (delta 125), pack-reused 0
Receiving objects: 100% (458/458), 209.63 KiB | 0 bytes/s, done.
Resolving deltas: 100% (142/142), done.
Checking connectivity... done.
/Users/pabrahamsson/.rvm/rubies/ruby-2.1.6/bin/ruby -I/Users/pabrahamsson/.rvm/gems/ruby-2.1.6/gems/rspec-core-3.4.4/lib:/Users/pabrahamsson/.rvm/gems/ruby-2.1.6/gems/rspec-support-3.4.1/lib /Users/pabrahamsson/.rvm/gems/ruby-2.1.6/gems/rspec-core-3.4.4/exe/rspec --pattern spec/\{classes,defines,unit,functions,hosts,integration,types\}/\*\*/\*_spec.rb --color
............*..**........**.................................*............................**..***..........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) datadog_agent::integrations::apache with tags parameter single value this is currently unimplemented behavior
     # No reason given
     # ./spec/classes/datadog_agent_integrations_apache_spec.rb:48

  2) datadog_agent::integrations::apache with tags parameter empty values single element array of an empty string undefined behavior
     # No reason given
     # ./spec/classes/datadog_agent_integrations_apache_spec.rb:74

  3) datadog_agent::integrations::apache with tags parameter empty values single value empty string doubly undefined behavior
     # No reason given
     # ./spec/classes/datadog_agent_integrations_apache_spec.rb:82

  4) datadog_agent::integrations::docker_daemon with tags parameter empty values single element array of an empty string undefined behavior
     # No reason given
     # ./spec/classes/datadog_agent_integrations_docker_daemon_spec.rb:58

  5) datadog_agent::integrations::docker_daemon with tags parameter empty values single value empty string doubly undefined behavior
     # No reason given
     # ./spec/classes/datadog_agent_integrations_docker_daemon_spec.rb:66

  6) datadog_agent::integrations::haproxy with creds set incorrectly functionality not yet implemented
     # No reason given
     # ./spec/classes/datadog_agent_integrations_haproxy_spec.rb:53

  7) datadog_agent::integrations::http_check with headers parameter empty values single element array of an empty string undefined behavior
     # No reason given
     # ./spec/classes/datadog_agent_integrations_http_check_spec.rb:89

  8) datadog_agent::integrations::http_check with headers parameter empty values single value empty string doubly undefined behavior
     # No reason given
     # ./spec/classes/datadog_agent_integrations_http_check_spec.rb:97

  9) datadog_agent::integrations::http_check with tags parameter empty values single element array of an empty string undefined behavior
     # No reason given
     # ./spec/classes/datadog_agent_integrations_http_check_spec.rb:127

  10) datadog_agent::integrations::http_check with tags parameter empty values single value empty string doubly undefined behavior
     # No reason given
     # ./spec/classes/datadog_agent_integrations_http_check_spec.rb:135

  11) datadog_agent::integrations::http_check with contact set this functionality appears to not be functional
     # No reason given
     # ./spec/classes/datadog_agent_integrations_http_check_spec.rb:145


Finished in 36.51 seconds (files took 1.1 seconds to load)
1002 examples, 0 failures, 11 pending


Total resources:   26
Touched resources: 6
Resource coverage: 23.08%
Untouched resources:

  Class[Datadog_agent::Integrations::Apache]
  Class[Datadog_agent::Integrations::Docker_daemon]
  Class[Datadog_agent::Integrations::Elasticsearch]
  Class[Datadog_agent::Integrations::Haproxy]
  Class[Datadog_agent::Integrations::Http_check]
  Class[Datadog_agent::Integrations::Jenkins]
  Class[Datadog_agent::Integrations::Marathon]
  Class[Datadog_agent::Integrations::Mesos_master]
  Class[Datadog_agent::Integrations::Mongo]
  Class[Datadog_agent::Integrations::Mysql]
  Class[Datadog_agent::Integrations::Nginx]
  Class[Datadog_agent::Integrations::Ntp]
  Class[Datadog_agent::Integrations::Postgres]
  Class[Datadog_agent::Integrations::Process]
  Class[Datadog_agent::Integrations::Rabbitmq]
  Class[Datadog_agent::Integrations::Redis]
  Class[Datadog_agent::Integrations::Solr]
  Class[Datadog_agent::Integrations::Tomcat]
  Class[Datadog_agent::Integrations::Varnish]
  Class[Datadog_agent::Integrations::Zk]
```