### PR TITLE
Update the report config file check to account for permissions

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -10,7 +10,7 @@ end
 Puppet::Reports.register_report(:datadog_reports) do
 
   configfile = "/etc/dd-agent/datadog.yaml"
-  raise(Puppet::ParseError, "Datadog report config file #{configfile} not readable") unless File.exist?(configfile)
+  raise(Puppet::ParseError, "Datadog report config file #{configfile} not readable") unless File.readable?(configfile)
   config = YAML.load_file(configfile)
   API_KEY = config[:datadog_api_key]
 


### PR DESCRIPTION
Right now the report only raises an error if the agent's config file
doesn't exist. It should also raise an error if the file isn't readable,
otherwise you get a surprising permissions error.