### PR TITLE
ubuntu: Retry `apt-get update`

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -36,6 +36,8 @@ class datadog_agent::ubuntu(
   exec { 'datadog_apt-get_update':
     command     => '/usr/bin/apt-get update',
     refreshonly => true,
+    tries       => 2, # https://bugs.launchpad.net/launchpad/+bug/1430011 won't get fixed until 16.04 xenial
+    try_sleep   => 30,
   }
 
   package { 'datadog-agent-base':


### PR DESCRIPTION
`apt-get update` occasionally runs into https://bugs.launchpad.net/launchpad/+bug/1430011 which is fixed in 15.10 and 16.04, but many of us are still on older versions of ubuntu. It seems unlikely that this fix will ever be backported and the datadog repo would need to support by-hash, so waiting 30s for the repo to finish syncing and trying again is the next best thing we can do.