### PR TITLE
Add -n argument in varnish integration

### DIFF
--- a/manifests/integrations/varnish.pp
+++ b/manifests/integrations/varnish.pp
@@ -6,6 +6,9 @@
 #   varnishstat
 #       Path to the varnishstat binary
 #
+#   instance_name
+#       Used in the varnishstat command for the -n argument
+#
 #   tags
 #       DataDog tags
 #
@@ -19,8 +22,9 @@
 # }
 #
 class datadog_agent::integrations::varnish (
-  $varnishstat = '/usr/bin/varnishstat',
-  $tags      = [],
+  $varnishstat   = '/usr/bin/varnishstat',
+  $instance_name = undef,
+  $tags          = [],
 ) inherits datadog_agent::params {
   include datadog_agent
 

--- a/templates/agent-conf.d/varnish.yaml.erb
+++ b/templates/agent-conf.d/varnish.yaml.erb
@@ -2,6 +2,9 @@ init_config:
 
 instances:
     -   varnishstat: <%= @varnishstat %>
+<% if @instance_name -%>
+        name: <%= @instance_name %>
+<% end -%>
 <% if @tags and ! @tags.empty? -%>
         tags:
   <%- Array(@tags).each do |tag| -%>


### PR DESCRIPTION
We need use -n argument in varnishstat command to specify the name of the varnishd instance.