### PR TITLE
[report] allow setting `dogapi` version

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class datadog_agent::params {
   $dd_group       = 'root'
   $package_name   = 'datadog-agent'
   $service_name   = 'datadog-agent'
+  $dogapi_version = 'installed'
 
   case $::operatingsystem {
     'Ubuntu','Debian' : {

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -55,7 +55,7 @@ class datadog_agent::reports(
   }
 
   package{'dogapi':
-    ensure   => 'installed',
+    ensure   => $datadog_agent::params::dogapi_version,
     provider => $_gemprovider,
   }
 


### PR DESCRIPTION
The latest release of `dogapi` breaks compatibility with Ruby 1.8 (long
deprecated), which is still used in old versions of Puppet (with CentOS
6 notably).