### PR TITLE
[datadog-report] `m` could be nil, breaking reporting. Fix gem provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,40 +70,55 @@ Reporting
 ---------
 To enable reporting of changes to the Datadog timeline, enable the report
 processor on your Puppet master, and enable reporting for your clients.
-The clients will send a run report after each check-in back to the master,
-and the master will process the reports and send them to the Datadog API.
+The clients will send a run report after each check-in back to the master.
 
+Please specify what clients/hosts you'd like to submit puppet run reports
+for by setting the puppet_run_reports option to true in the node configuration
+manifest.
+
+```ruby
+class { "datadog-agent":
+    api_key => "<your_api_key>",
+    puppet_run_reports => true
+    # ...
+}
+```
 
 In your Puppet master `/etc/puppet/puppet.conf`, add these configuration options:
 
-    [main]
-    # No need to modify this section
-    # ...
+```ini
+[main]
+# No need to modify this section
+# ...
 
-    [master]
-    # Enable reporting to datadog
-    reports=datadog_reports
-    # If you use other reports already, just add datadog_reports at the end
-    # reports=store,log,datadog_reports
-    # ...
+[master]
+# Enable reporting to datadog
+reports=datadog_reports
+# If you use other reports already, just add datadog_reports at the end
+# reports=store,log,datadog_reports
+# ...
 
-    [agent]
-    # ...
-    pluginsync=true
-    report=true
+[agent]
+# ...
+pluginsync=true
+report=true
+```
 
 And on all of your Puppet client nodes add:
 
-    [agent]
-    # ...
-    report=true
-
+```ini
+[agent]
+# ...
+report=true
+```
 
 If you get
 
-    err: Could not send report:
-    Error 400 on SERVER: Could not autoload datadog_reports:
-    Class Datadog_reports is already defined in Puppet::Reports
+```
+err: Could not send report:
+Error 400 on SERVER: Could not autoload datadog_reports:
+Class Datadog_reports is already defined in Puppet::Reports
+```
 
 Make sure `reports=datadog_reports` is defined in **[master]**, not **[main]**.
 

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -48,7 +48,7 @@ Puppet::Reports.register_report(:datadog_reports) do
     @msg_host = self.host
     unless HOSTNAME_EXTRACTION_REGEX.nil?
       m = @msg_host.match(HOSTNAME_EXTRACTION_REGEX)
-      unless m[:hostname].nil?
+      if !m.nil? && !m[:hostname].nil?
         @msg_host = m[:hostname]
       end
     end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -341,6 +341,7 @@ class datadog_agent(
     class { 'datadog_agent::reports':
       api_key                   => $api_key,
       puppetmaster_user         => $puppetmaster_user,
+      dogapi_version            => $datadog_agent::params::dogapi_version,
       hostname_extraction_regex => $hostname_extraction_regex,
     }
   }

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -16,6 +16,7 @@
 class datadog_agent::reports(
   $api_key,
   $puppetmaster_user,
+  $dogapi_version,
   $hostname_extraction_regex = nil
 ) {
 
@@ -48,7 +49,7 @@ class datadog_agent::reports(
   }
 
   package{'dogapi':
-    ensure   => $datadog_agent::params::dogapi_version,
+    ensure   => $dogapi_version,
     provider => $gemprovider,
   }
 

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -21,14 +21,7 @@ class datadog_agent::reports(
 
   include datadog_agent::params
   $rubydev_package = $datadog_agent::params::rubydev_package
-  $gemprovider = 'puppetserver_gem'
-
-  # set the right provider
-  if (!defined('$::serverversion') or versioncmp($::serverversion, '3.7.0') < 0) {
-      $_gemprovider = 'gem'
-  } else {
-      $_gemprovider = $gemprovider
-  }
+  $gemprovider = 'gem'
 
   # check to make sure that you're not installing rubydev somewhere else
   if ! defined(Package[$rubydev_package]) {
@@ -56,7 +49,7 @@ class datadog_agent::reports(
 
   package{'dogapi':
     ensure   => $datadog_agent::params::dogapi_version,
-    provider => $_gemprovider,
+    provider => $gemprovider,
   }
 
 }

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
 
 describe 'datadog_agent::reports' do
-  let(:params) do
-    {
-      api_key: 'notanapikey',
-      hostname_extraction_regex: nil,
-      puppetmaster_user: 'puppet'
-    }
-  end
-
   context 'all supported operating systems' do
+    let(:params) do
+      {
+        api_key: 'notanapikey',
+        hostname_extraction_regex: nil,
+        puppetmaster_user: 'puppet',
+        dogapi_version: 'installed'
+      }
+    end
     ALL_OS.each do |operatingsystem|
       describe "datadog_agent class common actions on #{operatingsystem}" do
         let(:facts) do
@@ -50,6 +50,47 @@ describe 'datadog_agent::reports' do
             .with_group('root')
         end
 
+      end
+    end
+  end
+  context 'specific dogapi version' do
+    let(:params) do
+      {
+        api_key: 'notanapikey',
+        hostname_extraction_regex: nil,
+        puppetmaster_user: 'puppet',
+        dogapi_version: '1.2.2'
+      }
+    end
+    describe "datadog_agent class dogapi version override" do
+      let(:facts) do
+        {
+          operatingsystem: 'Debian',
+          osfamily: 'debian'
+        }
+      end
+
+      it { should contain_class('ruby').with_rubygems_update(false) }
+      it { should contain_class('ruby::params') }
+      it { should contain_package('ruby').with_ensure('installed') }
+      it { should contain_package('rubygems').with_ensure('installed') }
+
+      it do
+        should contain_package('ruby-dev')\
+          .with_ensure('installed')\
+          .that_comes_before('Package[dogapi]')
+      end
+
+      it do
+        should contain_package('dogapi')\
+          .with_ensure('1.2.2')
+          .with_provider('gem')
+      end
+
+      it do
+        should contain_file('/etc/dd-agent/datadog.yaml')\
+          .with_owner('puppet')\
+          .with_group('root')
       end
     end
   end


### PR DESCRIPTION
Reporting could potentially break if m happened to be nil.

Also, because the reporting code will indeed run on the agent (as tested on `4.5.1`) we don't need to rely on the `puppetserver_gem` (required to install gems on the JRuby environment on the `puppetserver` when code runs on the server-side).

Also improves a bit on #210 so we can better spec-test for it (making dogapi_version a parameter for the `reports` submodule), and perhaps change the source of the `dogapi_version` in the future.