### PR TITLE
Create DNS check integration manifest

### DIFF
--- a/manifests/integrations/dns_check.pp
+++ b/manifests/integrations/dns_check.pp
@@ -1,0 +1,49 @@
+# Class: datadog_agent::integrations::dns_check
+#
+# This class will install the necessary configuration for the DNS check
+# integration.
+#
+# Parameters:
+#   $hostname:
+#       Domain or IP you wish to check the availability of.
+#   $nameserver
+#       The nameserver you wish to use to check the hostname
+#       availability.
+#   $timeout
+#       Time in seconds to wait before terminating the request.
+#
+# Sample Usage:
+#
+#  class { 'datadog_agent::integrations::dns_check':
+#    checks => [
+#      {
+#        'hostname'   => 'example.com',
+#        'nameserver' => '8.8.8.8',
+#        'timeout'    => 5,
+#      }
+#    ]
+#  }
+#
+class datadog_agent::integrations::dns_check (
+  $checks = [
+    {
+      'hostname'   => 'google.com',
+      'nameserver' => '8.8.8.8',
+      'timeout'    => 5,
+    }
+  ]
+) inherits datadog_agent::params {
+  include datadog_agent
+
+  validate_array($checks)
+
+  file { "${datadog_agent::params::conf_dir}/dns_check.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0600',
+    content => template('datadog_agent/agent-conf.d/dns_check.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name],
+  }
+}

--- a/spec/classes/datadog_agent_integrations_dns_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_dns_check_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::dns_check' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir)   { '/etc/dd-agent/conf.d' }
+  let(:dd_user)    { 'dd-agent' }
+  let(:dd_group)   { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file)  { "#{conf_dir}/dns_check.yaml" }
+
+  it { should compile.with_all_deps }
+  it { should contain_file(conf_file).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'with default parameters' do
+    it { should contain_file(conf_file).with_content(%r{hostname: google.com}) }
+    it { should contain_file(conf_file).with_content(%r{nameserver: 8.8.8.8}) }
+    it { should contain_file(conf_file).with_content(%r{timeout: 5}) }
+  end
+
+  context 'with parameters set' do
+    let(:params) {{
+      checks: [
+        {
+          'hostname'   => 'example.com',
+          'nameserver' => '1.2.3.4',
+          'timeout'    => 5,
+        },
+        {
+          'hostname'   => 'localdomain.com',
+          'nameserver' => '4.3.2.1',
+          'timeout'    => 3,
+        }
+      ]
+    }}
+
+    it { should contain_file(conf_file).with_content(%r{hostname: example.com}) }
+    it { should contain_file(conf_file).with_content(%r{nameserver: 1.2.3.4}) }
+    it { should contain_file(conf_file).with_content(%r{timeout: 5}) }
+    it { should contain_file(conf_file).with_content(%r{hostname: localdomain.com}) }
+    it { should contain_file(conf_file).with_content(%r{nameserver: 4.3.2.1}) }
+    it { should contain_file(conf_file).with_content(%r{timeout: 3}) }
+  end
+end

--- a/templates/agent-conf.d/dns_check.yaml.erb
+++ b/templates/agent-conf.d/dns_check.yaml.erb
@@ -1,0 +1,13 @@
+#
+# MANAGED BY PUPPET
+#
+
+init_config:
+  default_timeout: 4
+
+instances:
+<% @checks.each do |check| -%>
+  - hostname: <%= check['hostname'] %>
+    nameserver: <%= check['nameserver'] %>
+    timeout: <%= check['timeout'] %>
+<% end -%>


### PR DESCRIPTION
This creates a manifest for the [DNS check integration](http://docs.datadoghq.com/integrations/dnscheck/) and allows
configuration via a class or hiera. Examples:

Using a puppet class

```puppet
class { 'datadog_agent::integrations::dns_check':
  checks => [
    {
      'hostname'   => 'example.com',
      'nameserver' => '8.8.8.8',
      'timeout'    => 5,
    }
  ]
}
```

Hiera

```yaml
datadog_agent::integrations::dns_check::checks:
  - hostname: 'example.com'
    nameserver: '8.8.8.8'
    timeout: 5
```