### PR TITLE
Allow multiple instances in mysql

### DIFF
--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -66,8 +66,7 @@ class datadog_agent::integrations::mysql(
   $schema_size_metrics = false, 
   $disable_innodb_metrics = false,
   $instances = undef,
-  ) 
-  inherits datadog_agent::params {
+  ) inherits datadog_agent::params {
   include datadog_agent
   validate_array($tags)
   

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -63,12 +63,12 @@ class datadog_agent::integrations::mysql(
   $extra_status_metrics = false,
   $extra_innodb_metrics = false,
   $extra_performance_metrics = false,
-  $schema_size_metrics = false, 
+  $schema_size_metrics = false,
   $disable_innodb_metrics = false,
   $instances = undef,
   ) inherits datadog_agent::params {
   include datadog_agent
-  validate_array($tags)
+  validate_hash($tags)
   
   if !$instances and $host {
     $_instances = [{
@@ -103,3 +103,4 @@ class datadog_agent::integrations::mysql(
     notify  => Service[$datadog_agent::params::service_name],
   }
 }
+

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -53,8 +53,9 @@
 #  }
 class datadog_agent::integrations::mysql(
   $host = 'localhost',
-  $password,
+  $password = undef,
   $user = 'datadog',
+  $port = 3306,
   $sock = undef,
   $tags = [],
   $replication = '0',
@@ -62,7 +63,7 @@ class datadog_agent::integrations::mysql(
   $extra_status_metrics = false,
   $extra_innodb_metrics = false,
   $extra_performance_metrics = false,
-  $schema_size_metrics = false,
+  $schema_size_metrics = false, 
   $disable_innodb_metrics = false,
   $instances = undef,
   ) 
@@ -70,7 +71,7 @@ class datadog_agent::integrations::mysql(
   include datadog_agent
   validate_array($tags)
   
-  if !$instances {
+    if !$instances {
     $_instances = [{
       'host'                      => $host,
       'password'                  => $password,
@@ -91,6 +92,7 @@ class datadog_agent::integrations::mysql(
   } else {
     $_instances = $instances
   }
+ 
 
   file { "${datadog_agent::params::conf_dir}/mysql.yaml":
     ensure  => file,
@@ -102,4 +104,3 @@ class datadog_agent::integrations::mysql(
     notify  => Service[$datadog_agent::params::service_name],
   }
 }
-

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -35,7 +35,22 @@
 #    user     => 'datadog'
 #  }
 #
-#
+# Sample Usage (Instance):
+#  class { 'datadog_agent::integrations::mysql' :
+#    instances => [{
+#      host                      => 'localhost',
+#      password                  => 'mypassword',
+#      user                      => 'datadog',
+#      port                      => '3306',
+#      tags                      => ['instance:mysql1'],
+#      replication               => '0',
+#      galera_cluster            => '0',
+#      extra_status_metrics      => 'true',
+#      extra_innodb_metrics      => 'true',
+#      extra_performance_metrics => 'true',
+#      schema_size_metrics       => 'true', 
+#      disable_innodb_metrics    => 'false',
+#  }
 class datadog_agent::integrations::mysql(
   $host = 'localhost',
   $password,
@@ -49,10 +64,33 @@ class datadog_agent::integrations::mysql(
   $extra_performance_metrics = false,
   $schema_size_metrics = false,
   $disable_innodb_metrics = false,
-  ) inherits datadog_agent::params {
+  $instances = undef,
+  ) 
+  inherits datadog_agent::params {
   include datadog_agent
-
   validate_array($tags)
+  
+  if !$instances {
+    $_instances = [{
+      'host'                      => $host,
+      'password'                  => $password,
+      'user'                      => $user,
+      'port'                      => $port,
+      'sock'                      => $sock,
+      'tags'                      => $tags,
+      'replication'               => $replication,
+      'galera_cluster'            => $galera_cluster,
+      'extra_status_metrics'      => $extra_status_metrics,
+      'extra_innodb_metrics'      => $extra_innodb_metrics,
+      'extra_performance_metrics' => $extra_performance_metrics,
+      'schema_size_metrics'       => $schema_size_metrics,
+      'disable_innodb_metrics'    => $disable_innodb_metrics,
+    }]
+  } elsif !$instances{
+    $_instances = []
+  } else {
+    $_instances = $instances
+  }
 
   file { "${datadog_agent::params::conf_dir}/mysql.yaml":
     ensure  => file,

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -71,7 +71,7 @@ class datadog_agent::integrations::mysql(
   include datadog_agent
   validate_array($tags)
   
-    if !$instances {
+  if !$instances and $host {
     $_instances = [{
       'host'                      => $host,
       'password'                  => $password,

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -68,7 +68,7 @@ class datadog_agent::integrations::mysql(
   $instances = undef,
   ) inherits datadog_agent::params {
   include datadog_agent
-  validate_hash($tags)
+  validate_array($tags)
   
   if !$instances and $host {
     $_instances = [{

--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -5,7 +5,7 @@
 init_config:
 
 instances:
-<%- (Array(@instances)).each do |instance| -%>
+<%- (Array(@_instances)).each do |instance| -%>
   - server: <%= instance['host'] %>
     user: <%= instance['user'] %>
     pass: <%= instance['password'] %>

--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -5,26 +5,31 @@
 init_config:
 
 instances:
-  - server: <%= @host %>
-    user: <%= @user %>
-    pass: <%= @password %>
-<% if @sock -%>
-    sock: <%= @sock %>
+<%- (Array(@instances)).each do |instance| -%>
+  - server: <%= instance['host'] %>
+    user: <%= instance['user'] %>
+    pass: <%= instance['password'] %>
+<% if instance['port'] -%>
+    port: <%= instance['port'] %>
 <% end -%>
-#    port: 3306             # Optional
-#    defaults_file: my.cnf  # Alternate configuration mechanism
-<% if !@tags.empty? -%>
+<% if instance['sock'] -%>
+    sock: <%= instance['sock'] %>
+<% end -%>
+
+<% if !instance['tags'].empty? -%>
     tags:                  # Optional
-<% @tags.each do |tag| -%>
+<% instance['tags'].each do |tag| -%>
         - <%= tag %>
 <% end -%>
 <% end -%>
-    options:               # Optional
-        replication: <%= @replication %>
-        galera_cluster: <%= @galera_cluster %>
-        extra_status_metrics: <%= @extra_status_metrics %>
-        extra_innodb_metrics: <%= @extra_innodb_metrics %>
-        extra_performance_metrics: <%= @extra_performance_metrics %>
-        schema_size_metrics: <%= @schema_size_metrics %>
-        disable_innodb_metrics: <%= @disable_innodb_metrics %>
 
+    options:               # Optional
+        replication: <%= instance['replication'] %>
+        galera_cluster: <%= instance['galera_cluster'] %>
+        extra_status_metrics: <%= instance['extra_status_metrics'] %>
+        extra_innodb_metrics: <%= instance['extra_innodb_metrics'] %>
+        extra_performance_metrics: <%= instance['extra_performance_metrics'] %>
+        schema_size_metrics: <%= instance['schema_size_metrics'] %>
+        disable_innodb_metrics: <%= instance['disable_innodb_metrics'] %>
+
+<% end -%>

--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -33,3 +33,4 @@ instances:
         disable_innodb_metrics: <%= instance['disable_innodb_metrics'] %>
 
 <% end -%>
+


### PR DESCRIPTION
The idea for this is along the lines of #155. I needed to be able to check multiple MySQL instances on the same host so I modified the integration a bit to support this. 
I saw #147 has been under discussion for a while and needed something quick. This should have backward comparability as I've tested it in our environment. Would like some additional feedback on how this works for others.