### PR TITLE
Correcting module header and example to use docker_daemon like the ac…

### DIFF
--- a/manifests/integrations/docker_daemon.pp
+++ b/manifests/integrations/docker_daemon.pp
@@ -1,4 +1,4 @@
-# Class: datadog_agent::integrations::docker
+# Class: datadog_agent::integrations::docker_daemon
 #
 # This class will install the necessary configuration for the docker integration
 #
@@ -15,7 +15,7 @@
 #
 # Sample Usage:
 #
-#   class { 'datadog_agent::integrations::docker' :
+#   class { 'datadog_agent::integrations::docker_daemon' :
 #     url           => 'unix://var/run/docker.sock',
 #   }
 #


### PR DESCRIPTION
I noticed this issue after copying over the example. The name of the actual class is ::docker_daemon and the example and header of the integration had "::docker".