### PR TITLE
Add manage_ruby, making the management of ruby in reports optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,8 @@
 #       the scheme: "fact_name:fact_value".
 #   $puppet_run_reports
 #       Will send results from your puppet agent runs back to the datadog service.
+#   $manage_ruby
+#       Invoke the ruby class to manage ruby install
 #   $puppetmaster_user
 #       Will chown the api key used by the report processor to this user.
 #       Defaults to the user the puppetmaster is configured to run as.
@@ -188,6 +190,7 @@ class datadog_agent(
   $hiera_tags = false,
   $facts_to_tags = [],
   $puppet_run_reports = false,
+  $manage_ruby = true,
   $puppet_gem_provider = 'puppetserver_gem',
   $puppetmaster_user = $settings::user,
   $non_local_traffic = false,
@@ -269,6 +272,7 @@ class datadog_agent(
   validate_array($dogstreams)
   validate_array($facts_to_tags)
   validate_bool($puppet_run_reports)
+  validate_bool($manage_ruby)
   validate_string($puppet_gem_provider)
   validate_string($puppetmaster_user)
   validate_bool($non_local_traffic)
@@ -415,6 +419,7 @@ class datadog_agent(
   if $puppet_run_reports {
     class { 'datadog_agent::reports':
       api_key                   => $api_key,
+      manage_ruby               => $manage_ruby,
       puppet_gem_provider       => $puppet_gem_provider,
       puppetmaster_user         => $puppetmaster_user,
       dogapi_version            => $datadog_agent::params::dogapi_version,

--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -55,6 +55,10 @@
 #       problematic SSL server certificates. To maintain backwards
 #       compatibility this defaults to false.
 #
+#   ignore_ssl_warning
+#       The (optional) ignore_ssl_warning will instruct the check to ignore
+#       SSL warnings.  Defaults to false.
+#
 #   skip_event
 #       The (optional) skip_event parameter will instruct the check to not
 #       create any event to avoid duplicates with a server side service check.
@@ -154,6 +158,7 @@ class datadog_agent::integrations::http_check (
   $http_response_status_code = undef,
   $collect_response_time = true,
   $disable_ssl_validation = false,
+  $ignore_ssl_warning = false,
   $skip_event = true,
   $no_proxy  = false,
   $check_certificate_expiration = undef,
@@ -180,6 +185,7 @@ class datadog_agent::integrations::http_check (
       'http_response_status_code'    => $http_response_status_code,
       'collect_response_time'        => $collect_response_time,
       'disable_ssl_validation'       => $disable_ssl_validation,
+      'ignore_ssl_warning'           => $ignore_ssl_warning,
       'skip_event'                   => $skip_event,
       'no_proxy'                     => $no_proxy,
       'check_certificate_expiration' => $check_certificate_expiration,

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -23,7 +23,7 @@ class datadog_agent::redhat(
 
   validate_bool($manage_repo)
   if $manage_repo {
-    $public_key_local = '/tmp/DATADOG_RPM_KEY.public'
+    $public_key_local = '/opt/puppetlabs/puppet/cache/DATADOG_RPM_KEY.public'
 
     validate_string($baseurl)
 
@@ -40,12 +40,6 @@ class datadog_agent::redhat(
         onlyif  => "/usr/bin/gpg --quiet --with-fingerprint -n ${public_key_local} | grep \'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3\'",
         unless  => '/bin/rpm -q gpg-pubkey-e09422b3',
         require => Remote_file['DATADOG_RPM_KEY.public'],
-        notify  => Exec['cleanup-gpg-key'],
-    }
-
-    exec { 'cleanup-gpg-key':
-        command => "/bin/rm ${public_key_local}",
-        onlyif  => "/usr/bin/test -f ${public_key_local}",
     }
 
     yumrepo {'datadog':

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -43,7 +43,7 @@ class datadog_agent::redhat(
     }
 
     yumrepo {'datadog':
-      enabled  => 1,
+      enabled  => 0, # because Datadog brilliantly shadowed system packages with custom versions
       gpgcheck => 1,
       gpgkey   => 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
       descr    => 'Datadog, Inc.',
@@ -51,7 +51,10 @@ class datadog_agent::redhat(
       require  => Exec['install-gpg-key'],
     }
 
-    Package { require => Yumrepo['datadog']}
+    Package {
+      require => Yumrepo['datadog'],
+      install_options => ['--enablerepo', 'datadog'],
+    }
   }
 
   package { 'datadog-agent-base':

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -15,27 +15,30 @@
 #
 class datadog_agent::reports(
   $api_key,
+  $manage_ruby,
   $puppet_gem_provider,
   $puppetmaster_user,
   $dogapi_version,
   $hostname_extraction_regex = nil
 ) {
 
-  include datadog_agent::params
-  $rubydev_package = $datadog_agent::params::rubydev_package
+  if $manage_ruby {
+    include datadog_agent::params
+    $rubydev_package = $datadog_agent::params::rubydev_package
 
-  # check to make sure that you're not installing rubydev somewhere else
-  if ! defined(Package[$rubydev_package]) {
-    package {$rubydev_package:
-      ensure => installed,
-      before => Package['dogapi']
+    # check to make sure that you're not installing rubydev somewhere else
+    if ! defined(Package[$rubydev_package]) {
+      package {$rubydev_package:
+        ensure => installed,
+        before => Package['dogapi']
+      }
     }
-  }
 
-  if (! defined(Package['rubygems'])) {
-    # Ensure rubygems is installed
-    class { 'ruby':
-      rubygems_update => false
+    if (! defined(Package['rubygems'])) {
+      # Ensure rubygems is installed
+      class { 'ruby':
+        rubygems_update => false
+      }
     }
   }
 

--- a/manifests/ubuntu/install_key.pp
+++ b/manifests/ubuntu/install_key.pp
@@ -13,8 +13,8 @@
 #
 #
 define datadog_agent::ubuntu::install_key() {
-  exec { "key ${name}":
-    command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${name}",
-    unless  => "/usr/bin/apt-key list | grep ${name} | grep expires",
+  apt::key { $name:
+    id     => $name,
+    server => 'hkp://keyserver.ubuntu.com:80',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -77,6 +77,10 @@
       "version_requirement": "2.2.0"
     },
     {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">=2.4.0 <5.0.0"
+    },
+    {
       "name": "lwf/remote_file",
       "version_requirement": ">=1.1.3"
     }

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -34,6 +34,9 @@ instances:
 <% if instance['disable_ssl_validation'] -%>
     disable_ssl_validation: <%= instance['disable_ssl_validation'] %>
 <% end -%>
+<% if instance['ignore_ssl_warning'] -%>
+    ignore_ssl_warning: <%= instance['ignore_ssl_warning'] %>
+<% end -%>
 <% if instance['skip_event'] -%>
     skip_event: <%= instance['skip_event'] %>
 <% end -%>


### PR DESCRIPTION
Many people do not use the ruby module to manage ruby installs.  Invoking it, or attempting to manage other ruby packages directly, can and does break many things-- and the very last thing one wants to break on their puppet master is _ruby_.

This adds a manage_ruby option to the module, defaulting to true, which can then be set to false in order to prevent such carnage.
