### PR TITLE
Use HTTPS protocol, not Git, in .fixtures.yml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    ruby: "https://github.com/puppetlabs/puppetlabs-ruby.git"
   symlinks:
     datadog_agent: "#{source_dir}"


### PR DESCRIPTION
Without this patch applied, many external users will be unable to run
the unit tests.
