### PR TITLE
Make a generic define for creating modules

### DIFF
--- a/lib/puppet/parser/functions/to_instances_yaml.rb
+++ b/lib/puppet/parser/functions/to_instances_yaml.rb
@@ -1,0 +1,13 @@
+require 'yaml'
+
+module Puppet::Parser::Functions
+    newfunction(:to_instances_yaml, :type => :rvalue) do |args|
+        init_config = args[0]
+        instances = args[1]
+        default_values = {
+            'init_config'  => init_config.is_a?(String) ? nil: init_config,
+            'instances' => instances
+        }
+        YAML::dump(default_values)
+    end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -229,6 +229,11 @@ class datadog_agent(
   $pup_log_file = '',
   $syslog_host  = '',
   $syslog_port  = '',
+  $conf_dir = $datadog_agent::params::conf_dir,
+  $service_name = $datadog_agent::params::service_name,
+  $package_name = $datadog_agent::params::package_name,
+  $dd_user = $datadog_agent::params::dd_user,
+  $dd_group = $datadog_agent::params::dd_group,
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)

--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -1,0 +1,24 @@
+define datadog_agent::integration (
+  $instances,
+  $init_config = undef,
+  $integration = $title,
+){
+
+  include datadog_agent
+
+  validate_array($instances)
+  if $init_config != undef {
+    validate_hash($init_config)
+  }
+  validate_string($integration)
+
+  file { "${datadog_agent::conf_dir}/${integration}.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::dd_user,
+    group   => $datadog_agent::dd_group,
+    mode    => '0600',
+    content => to_instances_yaml($init_config, $instances),
+    notify  => Service[$datadog_agent::service_name]
+  }
+
+}

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe "datadog_agent::integration" do
+    let (:title) { "test" }
+    let(:facts) do
+      {
+        operatingsystem: 'CentOS',
+        osfamily: 'redhat'
+      }
+    end
+    let (:params) {{
+        :instances => [
+            { 'one' => "two" }
+        ]
+    }}
+    it { should compile }
+    it { should contain_file('/etc/dd-agent/conf.d/test.yaml').with_content(/init_config: /) }
+    it { should contain_file('/etc/dd-agent/conf.d/test.yaml').with_content(/---\ninit_config: \ninstances:\n- one: two\n/) }
+    it { should contain_file('/etc/dd-agent/conf.d/test.yaml').that_notifies("Service[datadog-agent]") }
+end

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -15,6 +15,11 @@ describe "datadog_agent::integration" do
     }}
     it { should compile }
     it { should contain_file('/etc/dd-agent/conf.d/test.yaml').with_content(/init_config: /) }
-    it { should contain_file('/etc/dd-agent/conf.d/test.yaml').with_content(/---\ninit_config: \ninstances:\n- one: two\n/) }
+    gem_spec = Gem.loaded_specs['puppet']
+    if gem_spec.version >= Gem::Version.new('4.0.0')
+      it { should contain_file('/etc/dd-agent/conf.d/test.yaml').with_content(/---\ninit_config: \ninstances:\n- one: two\n/) }
+    else
+      it { should contain_file('/etc/dd-agent/conf.d/test.yaml').with_content(/--- \n  init_config: \n  instances: \n    - one: two/) }
+    end
     it { should contain_file('/etc/dd-agent/conf.d/test.yaml').that_notifies("Service[datadog-agent]") }
 end


### PR DESCRIPTION
There is one already but only allows one since its a class we can not do
a bunch of integrations and replace the class with this. Also this will
allow you to write ruby, or hiera and put it in the config you need.

Supersedes #141 - it's still all @cwood work. His PR had been sitting there for so long I felt bad asking him to do this for us. This just rebases to the latest master and makes sure the CI passes. 

Thank you @cwood!