### PR TITLE
Added puppetserver_gem as a dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -69,6 +69,10 @@
       "version_requirement": ">=4.6.0"
     },
     {
+      "name": "puppetlabs/puppetserver_gem",
+      "version_requirement": ">=0.2.0"
+    },
+    {
       "name": "puppetlabs/ruby",
       "version_requirement": ">=0.2.0 <1.0.0"
     }


### PR DESCRIPTION
The package _dogapi_  is installed using the `puppetserver_gem` provider, but this is not available by default (at least on Puppet FOSS, perhaps it is on PE).
