### PR TITLE
Allow Service Discovery configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -228,6 +228,12 @@ class datadog_agent(
   $pup_log_file = '',
   $syslog_host  = '',
   $syslog_port  = '',
+  $service_discovery_backend = '',
+  $sd_config_backend = '',
+  $sd_backend_host = '',
+  $sd_backend_port = 0,
+  $sd_template_dir = '',
+  $consul_token = ''
 ) inherits datadog_agent::params {
 
   validate_string($dd_url)
@@ -280,6 +286,12 @@ class datadog_agent(
   validate_string($pup_log_file)
   validate_string($syslog_host)
   validate_string($syslog_port)
+  validate_string($service_discovery_backend)
+  validate_string($sd_config_backend)
+  validate_string($sd_backend_host)
+  validate_integer($sd_backend_port)
+  validate_string($sd_template_dir)
+  validate_string($consul_token)
 
   if $hiera_tags {
     $local_tags = hiera_array('datadog_agent::tags')

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -346,7 +346,57 @@ syslog_host: <%= @syslog_host  %>
 syslog_port: <%= @syslog_port  %>
 <% end -%>
 
+
+# ========================================================================== #
+# Service Discovery
+# ========================================================================== #
+
+# For now only docker is supported so you just need to un-comment this line.
+<% if @service_discovery_backend.empty? -%>
+# service_discovery_backend: docker
+<% else -%>
+service_discovery_backend: <%= @service_discovery_backend %>
+<% end -%>
+
+# Define which key/value store must be used to look for configuration templates.
+# Default is etcd. Consul is also supported.
+<% if @sd_config_backend.empty? -%>
+# sd_config_backend: etcd
+<% else -%>
+sd_config_backend: <%= @sd_config_backend %>
+<% end -%>
+
+# Settings for connecting to the backend. These are the default, edit them if you run a different config.
+<% if @sd_backend_host.empty? -%>
+# sd_backend_host: 127.0.0.1
+<% else -%>
+sd_backend_host: <%= @sd_backend_host %>
+<% end -%>
+<% if @sd_backend_port.to_i < 1 -%>
+# sd_backend_port: 4001
+<% else -%>
+sd_backend_port: <%= @sd_backend_port %>
+<% end -%>
+
+# By default, the agent will look for the configuration templates under the
+# `/datadog/check_configs` key in the back-end.
+# If you wish otherwise, uncomment this option and modify its value.
+<% if @sd_template_dir.empty? -%>
+# sd_template_dir: /datadog/check_configs
+<% else -%>
+sd_template_dir: <%= @sd_template_dir %>
+<% end -%>
+
+# If you Consul store requires token authentication for service discovery, you can define that token here.
+<% if @consul_token.empty? -%>
+# consul_token: f45cbd0b-5022-samp-le00-4eaa7c1f40f1
+<% else -%>
+consul_token: <%= @consul_token %>
+<% end -%>
+
+
 <% if not @extra_template.empty? -%>
+
 # ========================================================================== #
 # Custom Templates from Puppet                                               #
 # ========================================================================== #


### PR DESCRIPTION
Ability to configure the service discovery config options of Datadog via Puppet.

As explained here: http://docs.datadoghq.com/guides/servicediscovery/
