### PR TITLE
Fixes problems with the ntp.yaml template

### DIFF
--- a/templates/agent-conf.d/ntp.yaml.erb
+++ b/templates/agent-conf.d/ntp.yaml.erb
@@ -7,16 +7,16 @@ init_config:
 instances:
   - offset_threshold: <%= @offset_threshold %>
 <% if @host -%>
-  - host: <%= @host %>
+    host: <%= @host %>
 <% end -%>
 <% if @port -%>
-  - port: <%= @port %>
+    port: <%= @port %>
 <% end -%>
 <% if @version -%>
-  - version: <%= @version %>
+    version: <%= @version %>
 <% end -%>
 <% if @timeout -%>
-  - timeout: <%= @timeout %>
+    timeout: <%= @timeout %>
 <% end -%>
     # Optional params:
     #


### PR DESCRIPTION
removes the prepending "-" from the optional params since they should not be there. If the dash isn't removed the agent will fallback to the default value but will not print any warnings.

So for instance if you set the host to "ntp.yourserver.net" with the previous template it will not use that host but instead fallback to "datadog.pool.ntp.org"
