### PR TITLE
Apt repo class

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -4,16 +4,53 @@
 #
 # Parameters:
 #
+# $apt_key = 'currentkey'
+#
+# $agent_version = 'latest'
+#
+# $repo = 'datadog'
+#
 # Actions:
 #
 # Requires:
 #
 # Sample Usage:
 #
+# Class: datadog_agent::ubuntu::update_repo
+#
+# handles updating the apt-sources.list to add a datadog repo
+#
 class datadog_agent::ubuntu(
   $apt_key = 'C7A7DA52',
-  $agent_version = 'latest'
+  $agent_version = 'latest',
+  $repo = 'local'
 ) {
+  if $repo == 'datadog' {
+    include ::datadog_agent::ubuntu::update_repo
+  }
+
+  package { 'datadog-agent-base':
+    ensure => absent,
+    before => Package['datadog-agent'],
+  }
+
+  package { 'datadog-agent':
+    ensure  => $agent_version,
+  }
+
+  service { 'datadog-agent':
+    ensure    => $::datadog_agent::service_ensure,
+    enable    => $::datadog_agent::service_enable,
+    hasstatus => false,
+    pattern   => 'dd-agent',
+    require   => Package['datadog-agent'],
+  }
+
+}
+
+# This should probably make use of puppetlabs::apt, though that opens a big can-o-worms
+#
+class datadog_agent::ubuntu::update_repo {
 
   ensure_packages(['apt-transport-https'])
 
@@ -38,25 +75,6 @@ class datadog_agent::ubuntu(
     refreshonly => true,
     tries       => 2, # https://bugs.launchpad.net/launchpad/+bug/1430011 won't get fixed until 16.04 xenial
     try_sleep   => 30,
-  }
-
-  package { 'datadog-agent-base':
-    ensure => absent,
-    before => Package['datadog-agent'],
-  }
-
-  package { 'datadog-agent':
-    ensure  => $agent_version,
-    require => [File['/etc/apt/sources.list.d/datadog.list'],
-                Exec['datadog_apt-get_update']],
-  }
-
-  service { 'datadog-agent':
-    ensure    => $::datadog_agent::service_ensure,
-    enable    => $::datadog_agent::service_enable,
-    hasstatus => false,
-    pattern   => 'dd-agent',
-    require   => Package['datadog-agent'],
   }
 
 }

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -23,7 +23,7 @@
 class datadog_agent::ubuntu(
   $apt_key = 'C7A7DA52',
   $agent_version = 'latest',
-  $repo = 'local'
+  $repo = 'datadog'
 ) {
   if $repo == 'datadog' {
     include ::datadog_agent::ubuntu::update_repo

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -9,24 +9,6 @@ describe 'datadog_agent::ubuntu' do
   end
 
   it do
-    contain_file('/etc/apt/sources.list.d/datadog.list')\
-      .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+main})
-  end
-
-  # it should install the mirror
-  it { should contain_exec('datadog_key') }
-  it do
-    should contain_file('/etc/apt/sources.list.d/datadog.list')\
-      .that_notifies('Exec[datadog_apt-get_update]')
-  end
-  it { should contain_exec('datadog_apt-get_update') }
-
-  # it should install the packages
-  it do
-    should contain_package('apt-transport-https')\
-      .that_comes_before('File[/etc/apt/sources.list.d/datadog.list]')
-  end
-  it do
     should contain_package('datadog-agent-base')\
       .with_ensure('absent')\
       .that_comes_before('Package[datadog-agent]')

--- a/spec/classes/datadog_agent_ubuntu_update_repo_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_update_repo_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'datadog_agent::ubuntu::update_repo' do
+  let(:facts) do
+    {
+      osfamily: 'debian',
+      operatingsystem: 'Ubuntu'
+    }
+  end
+
+  it do
+    contain_file('/etc/apt/sources.list.d/datadog.list')\
+      .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+main})
+  end
+
+  # it should install the mirror
+  it { should contain_exec('datadog_key') }
+  it do
+    should contain_file('/etc/apt/sources.list.d/datadog.list')\
+      .that_notifies('Exec[datadog_apt-get_update]')
+  end
+  it { should contain_exec('datadog_apt-get_update') }
+
+  # it should install the packages
+  it do
+    should contain_package('apt-transport-https')\
+      .that_comes_before('File[/etc/apt/sources.list.d/datadog.list]')
+  end
+end


### PR DESCRIPTION
We use a central apt repo and only install from it to avoid problems like ACLs blocking access to remote repos from our nodes, having all servers manage their own sources.list, etc. The necessary packages are managed there via apt-mirror. This pr splits out the sources.list management code to another class, and includes it conditionally in the ubuntu class if the repo param is set to 'datadog'. Set repo to anything else to skip the sources.list work and try to install the package with existing repos. 
The new update_repo class could be written better, and should probably use the puppetlabs::apt module to do its dirty work, but for us that is sideways work.