### PR TITLE
set disable_ssl_validation parameter

### DIFF
--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -104,9 +104,9 @@
 #        },
 #        {
 #          'sitename' => 'local',
-#         'url'      => 'http://localhost/',
-#         'headers'  => ['Host: stan.borbat.com', 'DNT: true'],
-#         'tags'     => ['production', 'wordpress']
+#          'url'      => 'http://localhost/',
+#          'headers'  => ['Host: stan.borbat.com', 'DNT: true'],
+#          'tags'     => ['production', 'wordpress']
 #        }]
 #     }
 

--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -3,8 +3,14 @@
 # This class will install the necessary config to hook the http_check in the agent
 #
 # Parameters:
+#   sitename
+#       (Required) The name of the instance.
+#
 #   url
+#       (Required) The url to check.
+#
 #   timeout
+#       The (optional) timeout in seconds.
 #
 #   username
 #   password
@@ -57,8 +63,11 @@
 #       a list of users to notify within the service configuration.
 #
 #   tags
+#       The (optional) tags to add to the check instance.
 #
 # Sample Usage:
+#
+# Add a class for each check instance:
 #
 # class { 'datadog_agent::integrations::http_check':
 #   sitename  => 'google',
@@ -86,6 +95,22 @@
 # }
 #
 #
+# Add multiple instances in one class declaration:
+#
+#  class { 'datadog_agent::integrations::http_check':
+#        instances => [{
+#          'sitename'  => 'google',
+#          'url'       => 'http://www.google.com',
+#        },
+#        {
+#          'sitename' => 'local',
+#         'url'      => 'http://localhost/',
+#         'headers'  => ['Host: stan.borbat.com', 'DNT: true'],
+#         'tags'     => ['production', 'wordpress']
+#        }]
+#     }
+
+
 class datadog_agent::integrations::http_check (
   $sitename  = undef,
   $url       = undef,
@@ -117,7 +142,7 @@ class datadog_agent::integrations::http_check (
       'content_match'            => $content_match,
       'include_content'          => $include_content,
       'collect_response_time'    => $collect_response_time,
-      'disable_ssl_validation' => $disable_ssl_validation,
+      'disable_ssl_validation'   => $disable_ssl_validation,
       'headers'                  => $headers,
       'tags'                     => $tags,
       'contact'                  => $contact,

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -29,9 +29,7 @@ instances:
     collect_response_time: <%= instance['collect_response_time'] %>
 <% end -%>
 <% if instance['disable_ssl_validation'] -%>
-    disable_ssl_validation: <%= instance['disable_ssl_validation'] %>
-<% else %>
-    disable_ssl_validation: false
+   disable_ssl_validation: <%= instance['disable_ssl_validation'] %>
 <% end -%>
 <% if instance['headers'] and ! instance['headers'].empty? -%>
     headers:

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -28,7 +28,11 @@ instances:
 <% if instance['collect_response_time'] -%>
     collect_response_time: <%= instance['collect_response_time'] %>
 <% end -%>
+<% if instance['disable_ssl_validation'] -%>
     disable_ssl_validation: <%= instance['disable_ssl_validation'] %>
+<% else %>
+    disable_ssl_validation: false
+<% end -%>
 <% if instance['headers'] and ! instance['headers'].empty? -%>
     headers:
   <%- Array(instance['headers']).each do |header| -%>


### PR DESCRIPTION
If an array of instances is declared in the main manifest `disable_ssl_validation` is not set, this PR fixes that bug and adds an example.