### PR TITLE
Revert to Datadog Packages key 4172a230

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -16,7 +16,7 @@
 #
 class datadog_agent::redhat(
   $baseurl = "https://yum.datadoghq.com/rpm/${::architecture}/",
-  $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+  $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
   $manage_repo = true,
   $agent_version = 'latest'
 ) {
@@ -37,7 +37,7 @@ class datadog_agent::redhat(
 
     exec { 'install-gpg-key':
         command => "/bin/rpm --import ${public_key_local}",
-        onlyif  => "/usr/bin/gpg --quiet --with-fingerprint -n ${public_key_local} | grep \'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3\'",
+        onlyif  => "/usr/bin/gpg --quiet --with-fingerprint -n ${public_key_local} | grep \'60A3 89A4 4A0C 32BA E3C0  3F0B 069B 56F5 4172 A230\'",
         unless  => '/bin/rpm -q gpg-pubkey-e09422b3',
         require => Remote_file['DATADOG_RPM_KEY.public'],
         notify  => Exec['cleanup-gpg-key'],

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -23,7 +23,7 @@ class datadog_agent::redhat(
 
   validate_bool($manage_repo)
   if $manage_repo {
-    $public_key_local = 'file:///etc/pki/rpm-gpg/DATADOG_RPM_KEY.public'
+    $public_key_local = '/etc/pki/rpm-gpg/DATADOG_RPM_KEY.public'
 
     validate_string($baseurl)
 
@@ -45,7 +45,7 @@ class datadog_agent::redhat(
     yumrepo {'datadog':
       enabled  => 1,
       gpgcheck => 1,
-      gpgkey   => $public_key_local,
+      gpgkey   => "file://${public_key_local}",
       descr    => 'Datadog, Inc.',
       baseurl  => $baseurl,
       require  => Exec['install-gpg-key'],

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -16,7 +16,7 @@ describe 'datadog_agent::redhat' do
       should contain_yumrepo('datadog')
         .with_enabled(1)\
         .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_gpgkey('file:///etc/pki/rpm-gpg/DATADOG_RPM_KEY.public')\
         .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
     end
   end

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -16,7 +16,7 @@ describe 'datadog_agent::redhat' do
       should contain_yumrepo('datadog')
         .with_enabled(1)\
         .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
         .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
     end
   end


### PR DESCRIPTION
For Issue https://github.com/DataDog/puppet-datadog-agent/issues/270

Revert the RPM key changes to specify the current package signing key available in the yum repository.