### PR TITLE
Brought httpd_check up to date with current variables.

### DIFF
--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -31,6 +31,9 @@ instances:
 <% if instance['disable_ssl_validation'] -%>
    disable_ssl_validation: <%= instance['disable_ssl_validation'] %>
 <% end -%>
+<% if instance['skip_event'] -%>
+   skip_event: <%= instance['skip_event'] %>
+<% end -%>
 <% if instance['headers'] and ! instance['headers'].empty? -%>
     headers:
   <%- Array(instance['headers']).each do |header| -%>

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -34,6 +34,15 @@ instances:
 <% if instance['skip_event'] -%>
    skip_event: <%= instance['skip_event'] %>
 <% end -%>
+<% if instance['check_certificate_expiration'] -%>
+   check_certificate_expiration: <%= instance['check_certificate_expiration'] %>
+<% end -%>
+<% if instance['days_warning'] -%>
+   days_warning: <%= instance['days_warning'] %>
+<% end -%>
+<% if instance['days_critical'] -%>
+   days_critical: <%= instance['days_critical'] %>
+<% end -%>
 <% if instance['headers'] and ! instance['headers'].empty? -%>
     headers:
   <%- Array(instance['headers']).each do |header| -%>


### PR DESCRIPTION
skip_event is needed to squelch:

> Warning: Using events for service checks is deprecated in favor of monitors and will be removed in future versions of the Datadog Agent.

The others are handy as well. 