### PR TITLE
[service discovery] Allow Service Discovery configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -230,6 +230,12 @@ class datadog_agent(
   $pup_log_file = '',
   $syslog_host  = '',
   $syslog_port  = '',
+  $service_discovery_backend = '',
+  $sd_config_backend = '',
+  $sd_backend_host = '',
+  $sd_backend_port = 0,
+  $sd_template_dir = '',
+  $consul_token = ''
   $conf_dir = $datadog_agent::params::conf_dir,
   $service_name = $datadog_agent::params::service_name,
   $package_name = $datadog_agent::params::package_name,
@@ -288,6 +294,12 @@ class datadog_agent(
   validate_string($pup_log_file)
   validate_string($syslog_host)
   validate_string($syslog_port)
+  validate_string($service_discovery_backend)
+  validate_string($sd_config_backend)
+  validate_string($sd_backend_host)
+  validate_integer($sd_backend_port)
+  validate_string($sd_template_dir)
+  validate_string($consul_token)
 
   if $hiera_tags {
     $local_tags = hiera_array('datadog_agent::tags')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,7 +235,7 @@ class datadog_agent(
   $sd_backend_host = '',
   $sd_backend_port = 0,
   $sd_template_dir = '',
-  $consul_token = ''
+  $consul_token = '',
   $conf_dir = $datadog_agent::params::conf_dir,
   $service_name = $datadog_agent::params::service_name,
   $package_name = $datadog_agent::params::package_name,

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -177,7 +177,28 @@ describe 'datadog_agent' do
                     )}
                     it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^# syslog_port:\n/,
-                )}
+                    )}
+                end
+
+                context 'for service_discovery' do
+                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    'content' => /^service_discovery_backend:\n/,
+                    )}
+                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    'content' => /^sd_config_backend:\n/,
+                    )}
+                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    'content' => /^sd_backend_host:\n/,
+                    )}
+                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    'content' => /^sd_backend_port:\n/,
+                    )}
+                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    'content' => /^sd_template_dir:\n/,
+                    )}
+                    it { should contain_file('/etc/dd-agent/datadog.conf').without(
+                    'content' => /^consul_token:\n/,
+                    )}
                 end
             end
 
@@ -474,6 +495,26 @@ describe 'datadog_agent' do
                 let(:params) {{:syslog_port  => '8080' }}
                 it { should contain_file('/etc/dd-agent/datadog.conf').with(
                     'content' => /^syslog_port: 8080\n/,
+                )}
+            end
+            context 'with service_discovery enabled' do
+                let(:params) {
+                    {:service_discovery_backend  => 'docker',
+                     :sd_config_backend          => 'etcd',
+                     :sd_backend_host            => 'localhost',
+                     :sd_backend_port            => '8080',
+                }}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                'content' => /^service_discovery_backend: docker\n/,
+                )}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                'content' => /^sd_config_backend: etcd\n/,
+                )}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                'content' => /^sd_backend_host: localhost\n/,
+                )}
+                it { should contain_file('/etc/dd-agent/datadog.conf').with(
+                'content' => /^sd_backend_port: 8080\n/,
                 )}
             end
             end

--- a/templates/datadog.conf.erb
+++ b/templates/datadog.conf.erb
@@ -346,7 +346,57 @@ syslog_host: <%= @syslog_host  %>
 syslog_port: <%= @syslog_port  %>
 <% end -%>
 
+
+# ========================================================================== #
+# Service Discovery
+# ========================================================================== #
+
+# For now only docker is supported so you just need to un-comment this line.
+<% if @service_discovery_backend.empty? -%>
+# service_discovery_backend: docker
+<% else -%>
+service_discovery_backend: <%= @service_discovery_backend %>
+<% end -%>
+
+# Define which key/value store must be used to look for configuration templates.
+# Default is etcd. Consul is also supported.
+<% if @sd_config_backend.empty? -%>
+# sd_config_backend: etcd
+<% else -%>
+sd_config_backend: <%= @sd_config_backend %>
+<% end -%>
+
+# Settings for connecting to the backend. These are the default, edit them if you run a different config.
+<% if @sd_backend_host.empty? -%>
+# sd_backend_host: 127.0.0.1
+<% else -%>
+sd_backend_host: <%= @sd_backend_host %>
+<% end -%>
+<% if @sd_backend_port.to_i < 1 -%>
+# sd_backend_port: 4001
+<% else -%>
+sd_backend_port: <%= @sd_backend_port %>
+<% end -%>
+
+# By default, the agent will look for the configuration templates under the
+# `/datadog/check_configs` key in the back-end.
+# If you wish otherwise, uncomment this option and modify its value.
+<% if @sd_template_dir.empty? -%>
+# sd_template_dir: /datadog/check_configs
+<% else -%>
+sd_template_dir: <%= @sd_template_dir %>
+<% end -%>
+
+# If you Consul store requires token authentication for service discovery, you can define that token here.
+<% if @consul_token.empty? -%>
+# consul_token: f45cbd0b-5022-samp-le00-4eaa7c1f40f1
+<% else -%>
+consul_token: <%= @consul_token %>
+<% end -%>
+
+
 <% if not @extra_template.empty? -%>
+
 # ========================================================================== #
 # Custom Templates from Puppet                                               #
 # ========================================================================== #


### PR DESCRIPTION
This work just rebases @scottgeary work in #246 regarding service_discovery configuration via the puppet module. Also adds a couple spec tests. 