### PR TITLE
Fixing 'already initialized constant' warnings

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -15,11 +15,11 @@ Puppet::Reports.register_report(:datadog_reports) do
   API_KEY = config[:datadog_api_key]
 
   # if need be initialize the regex
-  HOSTNAME_EXTRACTION_REGEX = config[:hostname_extraction_regex]
+  HOSTNAME_REGEX = config[:hostname_extraction_regex]
   begin
-    HOSTNAME_EXTRACTION_REGEX = Regexp.new HOSTNAME_EXTRACTION_REGEX unless HOSTNAME_EXTRACTION_REGEX.nil?
+    HOSTNAME_EXTRACTION_REGEX = Regexp.new HOSTNAME_REGEX unless HOSTNAME_REGEX.nil?
   rescue
-    raise(Puppet::ParseError, "Invalid hostname_extraction_regex #{HOSTNAME_EXTRACTION_REGEX}")
+    raise(Puppet::ParseError, "Invalid hostname_extraction_regex #{HOSTNAME_REGEX}")
   end
 
   desc <<-DESC


### PR DESCRIPTION
```
/etc/puppetlabs/code/modules/datadog_agent/lib/puppet/reports/datadog_reports.rb:20: warning: already initialized constant HOSTNAME_EXTRACTION_REGEX
/etc/puppetlabs/code/modules/datadog_agent/lib/puppet/reports/datadog_reports.rb:18: warning: previous definition of HOSTNAME_EXTRACTION_REGEX was here```