### PR TITLE
Removing rvm 2.0.0 tests due to Nokogiri 1.7.0 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ before_install: rm -f Gemfile.lock
 sudo: false
 cache: bundler
 rvm:
-  - 2.0.0
   - 2.1.0
   - 2.2.3
 script:
@@ -25,10 +24,6 @@ env:
   - PUPPET_VERSION="~> 4.2.1" STRICT_VARIABLES=yes
 matrix:
   exclude:
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-
   # Ruby 2.1.0
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 2.7.0"


### PR DESCRIPTION
Travis tests are failing with 
```
Gem::InstallError: nokogiri requires Ruby version >= 2.1.0.
Installing rb-inotify 0.9.7
An error occurred while installing nokogiri (1.7.0), and Bundler cannot
continue.
Make sure that `gem install nokogiri -v '1.7.0'` succeeds before bundling.
```
due to the 1.7.0 release of nokogiri on 12-26-2016, which removed support for ruby 1.9.2, 1.9.3, and 2.0.0 (see [CHANGELOG](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#backwards-incompatibilities))

A more detailed PR for the nokogiri 1.7.0 release is [here](https://github.com/sparklemotion/nokogiri/commit/84870381847cb83b6a530f5eef2460026ade49f6)