### PR TITLE
Fix nokogiri version dependency for puppet-blacksmith.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 before_install: rm -f Gemfile.lock
 sudo: false
+bundler_args: --full-index
 cache: bundler
 rvm:
   - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,6 @@ group :development do
   gem "beaker", '2.51.0'
   gem "beaker-rspec"
   gem "puppet-blacksmith"
+  gem "nokogiri", "~> 1.6.0"
   gem "guard-rake"
 end


### PR DESCRIPTION
Due to the tests failing for Ruby 2.0.0 the `nokogiri` gem version needs to less than 1.7.0

Also add `bundler_args: --full-index` for TravisCI to fix the 'too many gems' messages.