### PR TITLE
support for instances and http_host

### DIFF
--- a/manifests/integrations/php_fpm.pp
+++ b/manifests/integrations/php_fpm.pp
@@ -21,11 +21,24 @@
 #
 
 class datadog_agent::integrations::php_fpm(
+  $http_host        = undef,
   $status_url       = 'http://localhost/status',
   $ping_url         = 'http://localhost/ping',
-  $tags             = []
+  $tags             = [],
+  $instances        = undef,
 ) inherits datadog_agent::params {
   include datadog_agent
+
+  if !$instances {
+   $_instances = [{
+     'http_host' => $http_host,
+     'status_url' => $status_url,
+     'ping_url' => $ping_url,
+     'tags' => $tags,
+    }]
+  } else {
+    $_instances = $instances
+  }
 
   file { "${datadog_agent::params::conf_dir}/php_fpm.yaml":
     ensure  => file,

--- a/manifests/integrations/php_fpm.pp
+++ b/manifests/integrations/php_fpm.pp
@@ -25,7 +25,7 @@ class datadog_agent::integrations::php_fpm(
   $status_url       = 'http://localhost/status',
   $ping_url         = 'http://localhost/ping',
   $tags             = [],
-  $instances        = undef,
+  $instances        = undef
 ) inherits datadog_agent::params {
   include datadog_agent
 

--- a/manifests/integrations/php_fpm.pp
+++ b/manifests/integrations/php_fpm.pp
@@ -30,11 +30,11 @@ class datadog_agent::integrations::php_fpm(
   include datadog_agent
 
   if !$instances {
-   $_instances = [{
-     'http_host' => $http_host,
-     'status_url' => $status_url,
-     'ping_url' => $ping_url,
-     'tags' => $tags,
+    $_instances = [{
+      'http_host' => $http_host,
+      'status_url' => $status_url,
+      'ping_url' => $ping_url,
+      'tags' => $tags,
     }]
   } else {
     $_instances = $instances

--- a/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
+++ b/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
@@ -33,4 +33,34 @@ describe 'datadog_agent::integrations::php_fpm' do
     it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/fpm_status/) }
     it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/fpm_ping/) }
   end
+
+  context 'with http_host set' do
+    let(:params) {{
+      status_url: 'http://localhost/fpm_status',
+      ping_url: 'http://localhost/fpm_ping',
+      http_host: 'php_fpm_server',
+    }}
+    it { should contain_file(conf_file).with_content(/http_host: php_fpm_server/) }
+    it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/fpm_status/) }
+    it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/fpm_ping/) }
+  end
+
+  context 'with instances set' do
+    let(:params) {{
+      instances: [
+        {
+          'status_url'   => 'http://localhost/a/fpm_status',
+          'ping_url'   => 'http://localhost/a/fpm_ping',
+        },
+        {
+          'status_url'   => 'http://localhost/b/fpm_status',
+          'ping_url'   => 'http://localhost/b/fpm_ping',
+        },
+      ]
+    }}
+    it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/a\/fpm_status/) }
+    it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/a\/fpm_ping/) }
+    it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/b\/fpm_status/) }
+    it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/b\/fpm_ping/) }
+  end
 end

--- a/templates/agent-conf.d/php_fpm.yaml.erb
+++ b/templates/agent-conf.d/php_fpm.yaml.erb
@@ -4,12 +4,17 @@
 init_config:
 
 instances:
+<%- (Array(@_instances)).each do |instance| -%>
   - # Get metrics from your FPM pool with this URL
-    status_url: <%= @status_url %>
+    status_url: <%= instance['status_url'] %>
     # Get a reliable service check of your FPM pool with that one
-    ping_url: <%= @ping_url %>
+    ping_url: <%= instance['ping_url'] %>
     # Set the expected reply to the ping.
     ping_reply: pong
+    <%- if instance['http_host'] -%>
+    # Set http host header
+    http_host: <%= instance['http_host'] %>
+    <%- end -%>
     # These 2 URLs should follow the options from your FPM pool
     # See http://php.net/manual/en/install.fpm.configuration.php
     #   * pm.status_path
@@ -19,11 +24,12 @@ instances:
     # you want to monitor (FPM `listen` directive in the config, usually
     # a UNIX socket or TCP socket.
     #
-<% if @tags and !@tags.empty? -%>
+<%- if instance['tags'] and !instance['tags'].empty? -%>
     # Array of custom tags
     # By default metrics and service check will be tagged by pool and host
     tags:
-    <% @tags.each do |tag| -%>
+    <%- instance['tags'].each do |tag| -%>
       - <%= tag %>
-    <% end -%>
+    <%- end -%>
+<%- end -%>
 <% end -%>


### PR DESCRIPTION
This will allow datadog's agent to monitor more than one instance of phpfpm on a machine as well as adding support for the http_host parameter to the check.