### PR TITLE
Send metrics for hosts as a batch to help with resources

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -108,13 +108,15 @@ Puppet::Reports.register_report(:datadog_reports) do
 
     Puppet.debug "Sending metrics for #{@msg_host} to Datadog"
     @dog = Dogapi::Client.new(API_KEY)
-    self.metrics.each { |metric,data|
-      data.values.each { |val|
-        name = "puppet.#{val[1].gsub(/ /, '_')}.#{metric}".downcase
-        value = val[2]
-        @dog.emit_point("#{name}", value, :host => "#{@msg_host}")
+    @dog.batch_metrics do
+      self.metrics.each { |metric,data|
+        data.values.each { |val|
+          name = "puppet.#{val[1].gsub(/ /, '_')}.#{metric}".downcase
+          value = val[2]
+          @dog.emit_point("#{name}", value, :host => "#{@msg_host}")
+        }
       }
-    }
+    end
 
     Puppet.debug "Sending events for #{@msg_host} to Datadog"
     @dog.emit_event(Dogapi::Event.new(event_data,


### PR DESCRIPTION
When datadog_reports sends metrics to the datadog server, it sends them one by one (opening a connection, negotiating SSL, sending data, closing connection). If you run a lot of puppet nodes that's a lot of connection overhead.