### PR TITLE
[concat] add dependency.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,9 @@ fixtures:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref: "4.12.0"
-    concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
+    concat:
+      repo: "git://github.com/puppetlabs/puppetlabs-concat.git"
+      ref: "2.2.0"
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
     remote_file: "git://github.com/lwf/puppet-remote_file.git"
   symlinks:

--- a/metadata.json
+++ b/metadata.json
@@ -73,6 +73,10 @@
       "version_requirement": ">=0.2.0 <1.0.0"
     },
     {
+      "name": "puppetlabs/concat",
+      "version_requirement": "2.2.0"
+    },
+    {
       "name": "lwf/remote_file",
       "version_requirement": ">=1.1.3"
     }


### PR DESCRIPTION
We need this dependency after https://github.com/DataDog/puppet-datadog-agent/pull/261, missing in the module metadata currently. 