### PR TITLE
Fix incorrect GPG public key and other GPG issues on redhat

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -23,7 +23,7 @@ class datadog_agent::redhat(
 
   validate_bool($manage_repo)
   if $manage_repo {
-    $public_key_local = '/tmp/DATADOG_RPM_KEY.public'
+    $public_key_local = '/etc/pki/rpm-gpg/DATADOG_RPM_KEY.public'
 
     validate_string($baseurl)
 
@@ -39,13 +39,7 @@ class datadog_agent::redhat(
         command => "/bin/rpm --import ${public_key_local}",
         onlyif  => "/usr/bin/gpg --quiet --with-fingerprint -n ${public_key_local} | grep \'60A3 89A4 4A0C 32BA E3C0  3F0B 069B 56F5 4172 A230\'",
         unless  => '/bin/rpm -q gpg-pubkey-4172a230',
-        require => Remote_file['DATADOG_RPM_KEY.public'],
-        notify  => Exec['cleanup-gpg-key'],
-    }
-
-    exec { 'cleanup-gpg-key':
-        command => "/bin/rm ${public_key_local}",
-        onlyif  => "/usr/bin/test -f ${public_key_local}",
+        require => Remote_file['DATADOG_RPM_KEY.public']
     }
 
     yumrepo {'datadog':

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -16,7 +16,7 @@
 #
 class datadog_agent::redhat(
   $baseurl = "https://yum.datadoghq.com/rpm/${::architecture}/",
-  $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+  $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
   $manage_repo = true,
   $agent_version = 'latest'
 ) {
@@ -37,8 +37,8 @@ class datadog_agent::redhat(
 
     exec { 'install-gpg-key':
         command => "/bin/rpm --import ${public_key_local}",
-        onlyif  => "/usr/bin/gpg --quiet --with-fingerprint -n ${public_key_local} | grep \'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3\'",
-        unless  => '/bin/rpm -q gpg-pubkey-e09422b3',
+        onlyif  => "/usr/bin/gpg --quiet --with-fingerprint -n ${public_key_local} | grep \'60A3 89A4 4A0C 32BA E3C0  3F0B 069B 56F5 4172 A230\'",
+        unless  => '/bin/rpm -q gpg-pubkey-4172a230',
         require => Remote_file['DATADOG_RPM_KEY.public'],
         notify  => Exec['cleanup-gpg-key'],
     }

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -51,7 +51,7 @@ class datadog_agent::redhat(
     yumrepo {'datadog':
       enabled  => 1,
       gpgcheck => 1,
-      gpgkey   => 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+      gpgkey   => $gpgkey,
       descr    => 'Datadog, Inc.',
       baseurl  => $baseurl,
       require  => Exec['install-gpg-key'],


### PR DESCRIPTION
This PR fixes a bunch of problems around how the GPG key is being handled on redhat/derivatives.

Problem 1 -  The installation of the RPM fails due to the Puppet module having installed the old GPG key, which does not match the GPG key that is currently being used by Datadog. This breaks the install since it recognises that the key installed does not match the one used by the RPM.

```
Error: Could not update: Execution of '/usr/bin/yum -d 0 -e 0 -y install datadog-agent' returned 1: warning: /var/cache/yum/x86_64/latest/datadog/packages/datadog-agent-5.12.3-1.x86_64.rpm: Header V3 DSA/SHA1 Signature, key ID 4172a230: NOKEY


The GPG keys listed for the "Datadog, Inc." repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.


 Failing package is: 1:datadog-agent-5.12.3-1.x86_64
 GPG Keys are configured as: https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
```


Problem 2:

The Yum repo config GPG key URL was not being inherited from the one set in the class params, rather it was a different hard coded URL.


Problem 3:

Because of the use of `remote_file` module for downloading the GPG key which does not seem to have the ability to support `unless` or `onlyif` arguments like the `exec` type can, we end up downloading and deleting the GPG key repeatedly.

"Fixed" by moving the downloaded key to a persistent location on disk and removing the cleanup command, but it's still not a particularly good implementation.

I'd suggest changing the implementation to simply bundle the current GPG key with the Puppet module in files, install directly into RPM when needed and not even worry about the complexity of downloading a file from a remote server and having to validate the authenticity of the file.


Tested on Amazon Linux 2017.03 (A RHEL 6 derivative) - should work on the other EL variants, but have not conducted testing there.