### PR TITLE
Change owner/group of /etc/dd-agent

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -363,8 +363,8 @@ class datadog_agent(
 
   file { '/etc/dd-agent':
     ensure  => present,
-    owner   => 'root',
-    group   => 'root',
+    owner   => $dd_user,
+    group   => $dd_group,
     mode    => '0755',
     require => Package['datadog-agent'],
   }


### PR DESCRIPTION
Set the owner groups to the default one after installation, `dd-agent:dd-agent`.