### PR TITLE
Redis updates - Allow command_stats

### DIFF
--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -17,6 +17,8 @@
 #       Optional array of tags
 #   $keys
 #       Optional array of keys to check length
+#   $command_stats
+#       Collect INFO COMMANDSTATS output as metrics
 #
 # Sample Usage:
 #
@@ -34,12 +36,15 @@ class datadog_agent::integrations::redis(
   $tags = [],
   $keys = [],
   $warn_on_missing_keys = true,
+  $command_stats = false,
+
 ) inherits datadog_agent::params {
   include datadog_agent
 
   validate_array($tags)
   validate_array($keys)
   validate_bool($warn_on_missing_keys)
+  validate_bool($command_stats)
 
   if $ports == undef {
     $_ports = [ $port ]

--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -28,6 +28,7 @@ describe 'datadog_agent::integrations::redis' do
     it { should contain_file(conf_file).without_content(%r{tags:}) }
     it { should contain_file(conf_file).without_content(%r{\bkeys:}) }
     it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: true}) }
+    it { should contain_file(conf_file).with_content(%r{command_stats: false}) }
   end
 
   context 'with parameters set' do
@@ -39,6 +40,7 @@ describe 'datadog_agent::integrations::redis' do
       tags: %w{foo bar},
       keys: %w{baz bat},
       warn_on_missing_keys: false,
+      command_stats: true,
     }}
     it { should contain_file(conf_file).with_content(%r{host: redis1}) }
     it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
@@ -47,6 +49,7 @@ describe 'datadog_agent::integrations::redis' do
     it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
     it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
     it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
+    it { should contain_file(conf_file).with_content(%r{command_stats: true}) }
   end
 
 end

--- a/templates/agent-conf.d/redisdb.yaml.erb
+++ b/templates/agent-conf.d/redisdb.yaml.erb
@@ -9,6 +9,7 @@ instances:
   - host: <%= @host %>
     port: <%= port %>
     warn_on_missing_keys: <%= @warn_on_missing_keys %>
+    command_stats: <%= @command_stats %>
     <% if @password.empty? %># <%end %>password: <%= @password %>
     # unix_socket_path: /var/run/redis/redis.sock # optional, can be used in lieu of host/port
     <% if @slowlog_max_len.empty? %># <%end %>slowlog-max-len: <%= @slowlog_max_len %>


### PR DESCRIPTION
Datadog added a new option for redis `command_stats`
http://docs.datadoghq.com/integrations/redis/

https://github.com/Datadog/integrations-core/blob/master/redisdb/conf.yaml.example#L57