### PR TITLE
Use full key ID when adding GPG keys on Ubuntu

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -13,9 +13,9 @@
 #
 
 class datadog_agent::ubuntu(
-  $apt_key = '382E94DE',
+  $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
   $agent_version = 'latest',
-  $other_keys = ['C7A7DA52']
+  $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52']
 ) {
 
   ensure_packages(['apt-transport-https'])

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -14,8 +14,8 @@ describe 'datadog_agent::ubuntu' do
   end
 
   # it should install the mirror
-  it { should contain_datadog_agent__ubuntu__install_key('C7A7DA52') }
-  it { should contain_datadog_agent__ubuntu__install_key('382E94DE') }
+  it { should contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
+  it { should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
   it do
     should contain_file('/etc/apt/sources.list.d/datadog.list')\
       .that_notifies('Exec[datadog_apt-get_update]')


### PR DESCRIPTION
To decrease the chances of a collision attack, use the full key fingerprint.