### PR TITLE
add extra_template back

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,4 +9,5 @@ fixtures:
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
     remote_file: "git://github.com/lwf/puppet-remote_file.git"
   symlinks:
+    custom_datadog: "#{source_dir}/spec/custom_fixtures/custom_datadog"
     datadog_agent: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,11 @@ group :test do
 end
 
 group :development do
-  gem "beaker", '2.51.0'
   gem "beaker-rspec"
-  gem "puppet-blacksmith"
-  gem "nokogiri", "~> 1.6.0"
+  gem "beaker", '2.51.0'
   gem "guard-rake"
+  gem "hiera-eyaml"
+  gem "nokogiri", "~> 1.6.0"
+  gem "puppet-blacksmith"
+  gem "xmlrpc" if RUBY_VERSION >= '2.3'
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -405,10 +405,21 @@ class datadog_agent(
     order   => '05',
   }
 
+  if ($extra_template != '') {
+    concat::fragment{ 'datadog extra_template footer':
+      target  => '/etc/dd-agent/datadog.conf',
+      content => template($extra_template),
+      order   => '06',
+    }
+    $apm_footer_order = '07'
+  } else {
+    $apm_footer_order = '06'
+  }
+
   concat::fragment{ 'datadog apm footer':
     target  => '/etc/dd-agent/datadog.conf',
     content => template('datadog_agent/datadog_apm_footer.conf.erb'),
-    order   => '06',
+    order   => $apm_footer_order,
   }
 
 

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -568,6 +568,9 @@ describe 'datadog_agent' do
                 it { should contain_concat__fragment('datadog apm footer').with(
                     'content' => /^env: foo\n/,
                 )}
+                it { should contain_concat__fragment('datadog apm footer').with(
+                    'order' => '06',
+                )}
             end
             context 'with service_discovery enabled' do
                 let(:params) {
@@ -591,6 +594,20 @@ describe 'datadog_agent' do
                 )}
                 it { should contain_concat__fragment('datadog footer').with(
                 'content' => /^sd_jmx_enable: true\n/,
+                )}
+            end
+            context 'with extra_template enabled' do
+                let(:params) {
+                    {:extra_template => 'custom_datadog/extra_template_test.erb',
+                }}
+                it { should contain_concat__fragment('datadog extra_template footer').with(
+                'order' => '06',
+                )}
+                it { should contain_concat__fragment('datadog extra_template footer').with(
+                'content' => /^# extra template is here\n/,
+                )}
+                it { should contain_concat__fragment('datadog apm footer').with(
+                'order' => '07',
                 )}
             end
             end

--- a/spec/custom_fixtures/custom_datadog/templates/extra_template_test.erb
+++ b/spec/custom_fixtures/custom_datadog/templates/extra_template_test.erb
@@ -1,0 +1,1 @@
+# extra template is here


### PR DESCRIPTION
Fix regression in https://github.com/DataDog/puppet-datadog-agent/pull/261
where an `extra_template` was no longer getting concat'd to the template file.