### PR TITLE
etc/dd-agent should be ensured to be a directory not merely present

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -362,7 +362,7 @@ class datadog_agent(
   }
 
   file { '/etc/dd-agent':
-    ensure  => present,
+    ensure  => directory,
     owner   => $dd_user,
     group   => $dd_group,
     mode    => '0755',


### PR DESCRIPTION
If the agent_version is set to absent, the datadog-agent package doesn't get installed, thus /etc/dd-agent doesn't get created.  This causes the file resource for /etc/dd-agent in init.pp to create it as an empty file instead of a directory.  Because it's an empty file, further dependent resources like /etc/dd-agent/conf.d are unable to be created.  By ensuring it's a directory, even if the package version is set to absent, you'll still get clean puppet runs.