### PR TITLE
Add support for multiple instances of Elasticsearch.

### DIFF
--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -33,7 +33,8 @@ describe 'datadog_agent::integrations::elasticsearch' do
     it { should_not contain_file(conf_file).with_content(%r{      ssl_key}) }
     it { should_not contain_file(conf_file).with_content(%r{      tags:}) }
   end
-context 'with parameters set' do
+
+  context 'with parameters set' do
     let(:params) {{
       password:           'password',
       pending_task_stats: false,
@@ -54,4 +55,59 @@ context 'with parameters set' do
     it { should contain_file(conf_file).with_content(%r{        - tag1:key1}) }
   end
 
+  context 'with multiple instances set' do
+    let(:params) {
+      {
+        instances: [
+          {
+            'cluster_stats'      => true,
+            'password'           => 'password',
+            'pending_task_stats' => false,
+            'pshard_stats'       => false,
+            'url'                => 'https://foo:4242',
+            'username'           => 'username',
+            'ssl_verify'         => true,
+            'ssl_cert'           => '/etc/ssl/certs/client.pem',
+            'ssl_key'            => '/etc/ssl/private/client.key',
+            'tags'               => ['tag1:key1'],
+          },
+          {
+            'cluster_stats'      => true,
+            'password'           => 'password_2',
+            'pending_task_stats' => true,
+            'pshard_stats'       => false,
+            'url'                => 'https://bar:2424',
+            'username'           => 'username_2',
+            'ssl_verify'         => false,
+            'ssl_cert'           => '/etc/ssl/certs/client.pem',
+            'ssl_key'            => '/etc/ssl/private/client.key',
+            'tags'               => ['tag2:key2'],
+          }
+        ]
+      }
+    }
+    it { should contain_file(conf_file).with_content(%r{instances:}) }
+    it { should contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
+    it { should contain_file(conf_file).with_content(%r{      cluster_stats: true}) }
+    it { should contain_file(conf_file).with_content(%r{      pending_task_stats: false}) }
+    it { should contain_file(conf_file).with_content(%r{      username: username}) }
+    it { should contain_file(conf_file).with_content(%r{      password: password}) }
+    it { should contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_verify: true}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
+    it { should contain_file(conf_file).with_content(%r{      tags:}) }
+    it { should contain_file(conf_file).with_content(%r{        - tag1:key1}) }
+    it { should contain_file(conf_file).with_content(%r{    - url: https://bar:2424}) }
+    it { should contain_file(conf_file).with_content(%r{      cluster_stats: true}) }
+    it { should contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
+    it { should contain_file(conf_file).with_content(%r{      username: username_2}) }
+    it { should contain_file(conf_file).with_content(%r{      password: password_2}) }
+    it { should contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_verify: false}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
+    it { should contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
+    it { should contain_file(conf_file).with_content(%r{      tags:}) }
+    it { should contain_file(conf_file).with_content(%r{        - tag2:key2}) }
+  end
 end

--- a/templates/agent-conf.d/elastic.yaml.erb
+++ b/templates/agent-conf.d/elastic.yaml.erb
@@ -5,28 +5,30 @@
 init_config:
 
 instances:
-    - url: <%= @url %>
-<%- if @username -%>
-      username: <%= @username %>
+<%- (Array(@_instances)).each do |instance| -%>
+    - url: <%= instance['url'] %>
+<%- if instance['username'] && instance['username'] != :undef -%>
+      username: <%= instance['username'] %>
 <%- end -%>
-<%- if @password -%>
-      password: <%= @password %>
+<%- if instance['password'] && instance['password'] != :undef -%>
+      password: <%= instance['password'] %>
 <%- end -%>
-      cluster_stats: <%= @cluster_stats %>
-      pshard_stats: <%= @pshard_stats %>
-      pending_task_stats: <%= @pending_task_stats %>
-<%- if @url.match(/^https/) -%>
-      ssl_verify: <%= @ssl_verify %>
+      cluster_stats: <%= instance['cluster_stats'] %>
+      pshard_stats: <%= instance['pshard_stats'] %>
+      pending_task_stats: <%= instance['pending_task_stats'] %>
+<%- if instance['url'].match(/^https/) -%>
+      ssl_verify: <%= instance['ssl_verify'] %>
 <%- end -%>
-<%- if @ssl_cert -%>
-      ssl_cert: <%= @ssl_cert %>
+<%- if instance['ssl_cert'] && instance['ssl_cert'] != :undef -%>
+      ssl_cert: <%= instance['ssl_cert'] %>
 <%- end -%>
-<%- if @ssl_key -%>
-      ssl_key: <%= @ssl_key %>
+<%- if instance['ssl_key'] && instance['ssl_key'] != :undef -%>
+      ssl_key: <%= instance['ssl_key'] %>
 <%- end -%>
-<%- unless @tags.empty? -%>
+<%- unless instance['tags'].empty? -%>
       tags:
-  <%- @tags.each do |tag| -%>
+  <%- instance['tags'].each do |tag| -%>
         - <%= tag %>
   <%- end -%>
+<%- end -%>
 <%- end -%>


### PR DESCRIPTION
This allows monitoring of multiple instances of Elasticsearch. This follows the same pattern used by 'mysql.pp'. 