### PR TITLE
Don't fail if there is no value in hiera

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -323,13 +323,13 @@ class datadog_agent(
   validate_string($apm_env)
 
   if $hiera_tags {
-    $local_tags = hiera_array('datadog_agent::tags')
+    $local_tags = hiera_array('datadog_agent::tags', [])
   } else {
     $local_tags = $tags
   }
 
   if $hiera_integrations {
-    $local_integrations = hiera_hash('datadog_agent::integrations')
+    $local_integrations = hiera_hash('datadog_agent::integrations', {})
   } else {
     $local_integrations = $integrations
   }


### PR DESCRIPTION
If the `$hiera_tags` or `$hiera_integrations` is `true` but the `datadog_agent::tags` or `datadog_agent::integrations` are not defined (respectively) the puppet run shouldn't fail. So default an empty value.