### PR TITLE
remove spaces that break resulting yaml

### DIFF
--- a/templates/agent-conf.d/docker_daemon.yaml.erb
+++ b/templates/agent-conf.d/docker_daemon.yaml.erb
@@ -80,10 +80,10 @@ instances:
     ## Tagging
     ##
 <% if @tags and ! @tags.empty? -%>
-      tags:
+    tags:
   <%- Array(@tags).each do |tag| -%>
     <%- if tag != '' -%>
-          - <%= tag %>
+       - <%= tag %>
     <%- end -%>
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
As written in master, the yaml produced by the docker_daemon.yaml.erb results in an agent stack trace on `configtest`. After investigation, it seems that there are too many spaces being added in the tag: element and that results in invalid yaml.

```
[root@xxxx agent-conf.d]# /etc/init.d/datadog-agent configtest                                                  
2017-07-18 16:13:00,995 | ERROR | dd.collector | utils.dockerutil(dockerutil.py:138) | Docker check configuration file is invalid. The docker check and other Docker related components will not work.
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/utils/dockerutil.py", line 134, in get_check_config
    check_config = check_yaml(conf_path)
  File "/opt/datadog-agent/agent/util.py", line 106, in check_yaml
    check_config = yaml.load(f.read(), Loader=yLoader)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/yaml/__init__.py", line 71, in load
    return loader.get_single_data()
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/yaml/constructor.py", line 37, in get_single_data
    node = self.get_single_node()
  File "_yaml.pyx", line 707, in _yaml.CParser.get_single_node (ext/_yaml.c:8308)
  File "_yaml.pyx", line 725, in _yaml.CParser._compose_document (ext/_yaml.c:8581)
  File "_yaml.pyx", line 776, in _yaml.CParser._compose_node (ext/_yaml.c:9306)
  File "_yaml.pyx", line 890, in _yaml.CParser._compose_mapping_node (ext/_yaml.c:10838)
  File "_yaml.pyx", line 774, in _yaml.CParser._compose_node (ext/_yaml.c:9284)
  File "_yaml.pyx", line 851, in _yaml.CParser._compose_sequence_node (ext/_yaml.c:10311)
  File "_yaml.pyx", line 776, in _yaml.CParser._compose_node (ext/_yaml.c:9306)
  File "_yaml.pyx", line 892, in _yaml.CParser._compose_mapping_node (ext/_yaml.c:10868)
  File "_yaml.pyx", line 905, in _yaml.CParser._parse_next_event (ext/_yaml.c:11045)
ParserError: while parsing a block mapping
  in "<byte string>", line 30, column 5
did not find expected key
  in "<byte string>", line 82, column 7
2017-07-18 16:13:00,996 | ERROR | dd.collector | utils.dockerutil(dockerutil.py:146) | No instance was found in the docker check configuration. Docker related collection will not work.
disk.yaml is valid
network.yaml is valid
docker_daemon.yaml contains errors:
    while parsing a block mapping
  in "<byte string>", line 30, column 5
did not find expected key
  in "<byte string>", line 82, column 7
ntp.yaml is valid
Fix the invalid yaml files above in order to start the Datadog agent. A useful external tool for yaml parsing can be found at http://yaml-online-parser.appspot.com/
```
```
[root@xxxx agent-conf.d]# egrep -v "^$|#" /etc/dd-agent/conf.d/docker_daemon.yaml                               
init_config:                                                                                                              
instances:
    url: unix://var/run/docker.sock
      tags:
          - app:foo
          - type:bar
```

After application of patch and re-apply:
```
[root@xxxx agent-conf.d]# /etc/init.d/datadog-agent configtest                                                                                          
disk.yaml is valid
network.yaml is valid
docker_daemon.yaml is valid
ntp.yaml is valid
All yaml files passed. You can now run the Datadog agent.
```
```
[root@xxxx agent-conf.d]# egrep -v "^$|#" /etc/dd-agent/conf.d/docker_daemon.yaml
init_config:
instances:
    url: unix://var/run/docker.sock
    tags:
      - app:foo
      - type:bar
```
