### PR TITLE
[apt] support custom repo/channel for the agent

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,9 @@ fixtures:
     concat:
       repo: "git://github.com/puppetlabs/puppetlabs-concat.git"
       ref: "2.2.0"
+    apt:
+      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
+      ref: "4.1.0"
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
     remote_file: "git://github.com/lwf/puppet-remote_file.git"
   symlinks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,48 +4,19 @@ sudo: false
 bundler_args: --full-index
 cache: bundler
 rvm:
-  - 2.0.0
-  - 2.1.0
   - 2.2.3
+  - 2.3.1
+  - 2.4.1
 script:
   - bundle exec rake spec
   - bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.5" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.8.1" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 4.1.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 4.2.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 4.2.1" STRICT_VARIABLES=yes
-matrix:
-  exclude:
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-
-  # Ruby 2.1.0
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
-
-  # Ruby 2.2.3
-  - rvm: 2.2.3
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.2.3
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.2.3
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.2.3
-    env: PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 4.3.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.4.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.5.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.6.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.7.0" STRICT_VARIABLES=yes

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ group :test do
   gem "syck"
   gem "safe_yaml", "~> 1.0.4"
   gem "listen", "~> 3.0.0"
-  gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.2.0'
+  gem "puppet", ENV['PUPPET_VERSION'] || "~> 4.2.0"
   gem "puppet-lint"
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ end
 
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")
-PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.log_format = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
 
 # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.

--- a/files/datadog.list
+++ b/files/datadog.list
@@ -1,1 +1,0 @@
-deb https://apt.datadoghq.com/ stable main

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -13,7 +13,7 @@
 #
 
 class datadog_agent::ubuntu(
-  $location = '',
+  $location = 'https://apt.datadoghq.com',
   $release = 'stable',
   $repos = 'main',
   $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
@@ -46,8 +46,8 @@ class datadog_agent::ubuntu(
     include  => {
       'deb' => true,
     },
-    notify  => Exec['datadog_apt-get_update'],
-    require => Package['apt-transport-https'],
+    notify   => Exec['datadog_apt-get_update'],
+    require  => Package['apt-transport-https'],
   }
 
   exec { 'datadog_apt-get_update':

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -13,9 +13,13 @@
 #
 
 class datadog_agent::ubuntu(
+  $location = '',
+  $release = 'stable',
+  $repos = 'main',
   $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
   $agent_version = 'latest',
-  $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52']
+  $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52'],
+  $key_server = 'keyserver.ubuntu.com:80'
 ) {
 
   ensure_packages(['apt-transport-https'])
@@ -30,10 +34,18 @@ class datadog_agent::ubuntu(
 
   }
 
-  file { '/etc/apt/sources.list.d/datadog.list':
-    source  => 'puppet:///modules/datadog_agent/datadog.list',
-    owner   => 'root',
-    group   => 'root',
+  apt::source { 'datadog':
+    comment  => 'This is the datadog dd-agent repository',
+    location => $location,
+    release  => $release,
+    repos    => $repos,
+    key      => {
+      'id'     => $apt_key,
+      'server' => 'keyserver.ubuntu.com',
+    },
+    include  => {
+      'deb' => true,
+    },
     notify  => Exec['datadog_apt-get_update'],
     require => Package['apt-transport-https'],
   }
@@ -63,5 +75,4 @@ class datadog_agent::ubuntu(
     pattern   => 'dd-agent',
     require   => Package['datadog-agent'],
   }
-
 }

--- a/manifests/ubuntu/install_key.pp
+++ b/manifests/ubuntu/install_key.pp
@@ -12,9 +12,11 @@
 #
 #
 #
-define datadog_agent::ubuntu::install_key() {
+define datadog_agent::ubuntu::install_key(
+  $keyserver = 'keyserver.ubuntu.com:80'
+) {
   exec { "key ${name}":
-    command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${name}",
+    command => "/usr/bin/apt-key adv --keyserver hkp://${keyserver} --recv-keys ${name}",
     unless  => "/usr/bin/apt-key list | grep ${name} | grep expires",
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -77,6 +77,10 @@
       "version_requirement": "2.2.0"
     },
     {
+      "name": "puppetlabs/apt",
+      "version_requirement": "4.1.0"
+    },
+    {
       "name": "lwf/remote_file",
       "version_requirement": ">=1.1.3"
     }

--- a/spec/classes/datadog_agent_integrations_apache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_apache_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::apache' do
   let(:facts) {{
+      os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_cacti_spec.rb
+++ b/spec/classes/datadog_agent_integrations_cacti_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::cacti' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_cassandra_spec.rb
+++ b/spec/classes/datadog_agent_integrations_cassandra_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::cassandra' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_ceph_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ceph_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::ceph' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_consul_spec.rb
+++ b/spec/classes/datadog_agent_integrations_consul_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::consul' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_disk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_disk_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::disk' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_dns_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_dns_check_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::dns_check' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir)   { '/etc/dd-agent/conf.d' }
   let(:dd_user)    { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::docker_daemon' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::elasticsearch' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_fluentd_spec.rb
+++ b/spec/classes/datadog_agent_integrations_fluentd_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::fluentd' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_haproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_haproxy_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::haproxy' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
     ipaddress: '1.2.3.4',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::http_check' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_jenkins_spec.rb
+++ b/spec/classes/datadog_agent_integrations_jenkins_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::jenkins' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_jmx_spec.rb
+++ b/spec/classes/datadog_agent_integrations_jmx_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::jmx' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_kong_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kong_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::kong' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_marathon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_marathon_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::marathon' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_memcache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_memcache_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::memcache' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_mesos_master_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mesos_master_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::mesos_master' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_mongo_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mongo_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::mongo' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_mysql_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mysql_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::mysql' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_nginx_spec.rb
+++ b/spec/classes/datadog_agent_integrations_nginx_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::nginx' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_ntp_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ntp_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::ntp' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
+++ b/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::php_fpm' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_postgres_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postgres_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::postgres' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_process_spec.rb
+++ b/spec/classes/datadog_agent_integrations_process_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::process' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
+++ b/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::rabbitmq' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::redis' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_riak_spec.rb
+++ b/spec/classes/datadog_agent_integrations_riak_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::riak' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_solr_spec.rb
+++ b/spec/classes/datadog_agent_integrations_solr_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::solr' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_ssh_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ssh_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::ssh' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_supervisrd_spec.rb
+++ b/spec/classes/datadog_agent_integrations_supervisrd_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::supervisord' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::tcp_check' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_tomcat_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tomcat_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::tomcat' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_varnish_spec.rb
+++ b/spec/classes/datadog_agent_integrations_varnish_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::varnish' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_integrations_zk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_zk_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe 'datadog_agent::integrations::zk' do
   let(:facts) {{
+    os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
     operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
   }}
   let(:conf_dir) { '/etc/dd-agent/conf.d' }
   let(:dd_user) { 'dd-agent' }

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -26,7 +26,10 @@ describe 'datadog_agent' do
         let(:facts) do
           {
             operatingsystem: operatingsystem,
-            osfamily: DEBIAN_OS.include?(operatingsystem) ? 'debian' : 'redhat'
+            osfamily: DEBIAN_OS.include?(operatingsystem) ? 'debian' : 'redhat',
+            os: { :family => DEBIAN_OS.include?(operatingsystem) ? 'debian' : 'redhat',
+                  :name => DEBIAN_OS.include?(operatingsystem) ? 'debian' : 'redhat',
+                  :release => {} },
           }
         end
 

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe 'datadog_agent::ubuntu' do
   let(:facts) do
     {
-      osfamily: 'debian',
-      operatingsystem: 'Ubuntu'
+      os: { :family => 'Ubuntu', :name => 'Ubuntu', :release => { :major => '16', :minor => '04', :full => '16.04' } },
+      operatingsystem: 'Ubuntu',
+      osfamily: 'Debian',
     }
   end
 


### PR DESCRIPTION
Adds support for adding a totally custom repository for the `datadog-agent`.

This PR adds a dependency for `puppetlabs/apt` module and will potentially break in older puppet versions - it might require a new module major release. Note that puppets `<4.x` are EOL'd by now, so that might be in order anyways to aid with some of the necessary cleanup.

Tests are fine locally for `puppet_version=4.7` on ruby `2.2.3` - we'll see how badly this breaks with other puppet version rspecs... 😄 