### PR TITLE
[process][spec] thresholds spec test.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ group :development do
   gem "beaker-rspec"
   gem "beaker", '2.51.0'
   gem "guard-rake"
-  gem "hiera-eyaml"
   gem "nokogiri", "~> 1.6.0"
   gem "puppet-blacksmith"
   gem "xmlrpc" if RUBY_VERSION >= '2.3'

--- a/manifests/integrations/process.pp
+++ b/manifests/integrations/process.pp
@@ -2,6 +2,11 @@
 #
 # This class will install the necessary configuration for the process integration
 #
+# Please note that if you wish to specify thresholds and are on an older puppet (<4.x)
+# you will likely have to enable the future YAML parser due to a known bug:
+#   - https://tickets.puppetlabs.com/browse/PUP-6810
+#   - https://docs.puppet.com/puppet/3.8/experiments_future.html
+#
 # Parameters:
 #   $processes:
 #       Array of process hashes. See example

--- a/spec/classes/datadog_agent_integrations_process_spec.rb
+++ b/spec/classes/datadog_agent_integrations_process_spec.rb
@@ -38,4 +38,21 @@ describe 'datadog_agent::integrations::process' do
     it { should contain_file(conf_file).with_content(%r{search_string: bar}) }
     it { should contain_file(conf_file).with_content(%r{exact_match: true}) }
   end
+
+  context 'with parameters with threshold set' do
+    let(:params) {{
+      processes: [
+        {
+          'name' => 'foo',
+          'search_string' => 'bar',
+          'exact_match' => true,
+          'thresholds'  =>  {'warning' => [1,4]},
+        }
+      ]
+    }}
+    it { should contain_file(conf_file).with_content(%r{name: foo}) }
+    it { should contain_file(conf_file).with_content(%r{search_string: bar}) }
+    it { should contain_file(conf_file).with_content(%r{exact_match: true}) }
+    it { should contain_file(conf_file).with_content(%r{thresholds:\s*\n    warning:\s*\n    - 1\s*\n    - 4}) }
+  end
 end

--- a/spec/classes/datadog_agent_integrations_process_spec.rb
+++ b/spec/classes/datadog_agent_integrations_process_spec.rb
@@ -10,6 +10,7 @@ describe 'datadog_agent::integrations::process' do
   let(:dd_package) { 'datadog-agent' }
   let(:dd_service) { 'datadog-agent' }
   let(:conf_file) { "#{conf_dir}/process.yaml" }
+  let(:parser) { 'future' }
 
   it { should compile.with_all_deps }
   it { should contain_file(conf_file).with(
@@ -53,6 +54,7 @@ describe 'datadog_agent::integrations::process' do
     it { should contain_file(conf_file).with_content(%r{name: foo}) }
     it { should contain_file(conf_file).with_content(%r{search_string: bar}) }
     it { should contain_file(conf_file).with_content(%r{exact_match: true}) }
-    it { should contain_file(conf_file).with_content(%r{thresholds:\s*\n    warning:\s*\n    - 1\s*\n    - 4}) }
+    # regex should account for both 3.x future yaml parser and 4.x yaml alignment - different.
+    it { should contain_file(conf_file).with_content(%r{thresholds:\s*\n\s{4}(\s{4})?warning:\s*\n\s{4}(\s{6})?- 1\s*\n\s{4}(\s{6})?- 4}) }
   end
 end


### PR DESCRIPTION
YAML breaks for `thresholds` section in the process checks in older puppets. The problem is not in our code, but rather in the puppet YAML parsers. See comments below for more context.