### PR TITLE
New hostname_whitelist_regex configuration variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,9 @@
 #       Instead of reporting the puppet nodename, use this regex to extract the named
 #       'hostname' captured group to report the run in Datadog.
 #       ex.: '^(?<hostname>.*\.datadoghq\.com)(\.i-\w{8}\..*)?$'
+#   $hostname_whitelist_regex
+#       Completely optional.
+#       Only report the host to Datadog if its name matches this regular expression.
 #   $log_to_syslog
 #       Set value of 'log_to_syslog' variable. Default is true -> yes as in dd-agent.
 #       Valid values here are: true or false.
@@ -198,6 +201,7 @@ class datadog_agent(
   $service_enable = true,
   $manage_repo = true,
   $hostname_extraction_regex = nil,
+  $hostname_whitelist_regex = nil,
   $dogstatsd_port = 8125,
   $statsd_forward_host = '',
   $statsd_forward_port = '',
@@ -430,6 +434,7 @@ class datadog_agent(
       puppetmaster_user         => $puppetmaster_user,
       dogapi_version            => $datadog_agent::params::dogapi_version,
       hostname_extraction_regex => $hostname_extraction_regex,
+      hostname_whitelist_regex  => $hostname_whitelist_regex,
     }
   }
 

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -18,7 +18,8 @@ class datadog_agent::reports(
   $puppet_gem_provider,
   $puppetmaster_user,
   $dogapi_version,
-  $hostname_extraction_regex = nil
+  $hostname_extraction_regex = nil,
+  $hostname_whitelist_regex = nil
 ) {
 
   include datadog_agent::params

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -6,6 +6,7 @@ describe 'datadog_agent::reports' do
       {
         api_key: 'notanapikey',
         hostname_extraction_regex: nil,
+        hostname_whitelist_regex: nil,
         puppetmaster_user: 'puppet',
         dogapi_version: 'installed',
         puppet_gem_provider: 'gem'
@@ -59,6 +60,7 @@ describe 'datadog_agent::reports' do
       {
         api_key: 'notanapikey',
         hostname_extraction_regex: nil,
+        hostname_whitelist_regex: nil,
         puppetmaster_user: 'puppet',
         dogapi_version: '1.2.2',
         puppet_gem_provider: 'gem'

--- a/templates/datadog.yaml.erb
+++ b/templates/datadog.yaml.erb
@@ -6,3 +6,6 @@
 <% if !@hostname_extraction_regex.nil? -%>
 :hostname_extraction_regex: '<%= @hostname_extraction_regex %>'
 <% end -%>
+<% if !@hostname_whitelist_regex.nil? -%>
+:hostname_whitelist_regex: '<%= @hostname_whitelist_regex %>'
+<% end -%>


### PR DESCRIPTION
This variable, if set, determines whether a puppet run on a host is reported to
Datadog or not.  This can be used if only a subset of the hosts managed by puppet
are also using Datadog.