### PR TITLE
Puppet v4 upgrades - subset of @bittner work in #362

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -194,7 +194,7 @@ class datadog_agent(
   $hiera_tags = false,
   $facts_to_tags = [],
   $puppet_run_reports = false,
-  $puppet_gem_provider = 'system_gem',
+  $puppet_gem_provider = 'puppetserver_gem',
   $puppetmaster_user = $settings::user,
   $non_local_traffic = false,
   $dogstreams = [],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -194,7 +194,7 @@ class datadog_agent(
   $hiera_tags = false,
   $facts_to_tags = [],
   $puppet_run_reports = false,
-  $puppet_gem_provider = 'puppetserver_gem',
+  $puppet_gem_provider = 'system_gem',
   $puppetmaster_user = $settings::user,
   $non_local_traffic = false,
   $dogstreams = [],

--- a/metadata.json
+++ b/metadata.json
@@ -58,10 +58,6 @@
       "version_requirement": ">=2.2.0 <5.0.0"
     },
     {
-      "name": "puppetlabs/puppetserver_gem",
-      "version_requirement": ">=0.2.0 <2.0.0"
-    },
-    {
       "name": "lwf/remote_file",
       "version_requirement": ">=1.1.3 <2.0.0"
     }

--- a/metadata.json
+++ b/metadata.json
@@ -58,8 +58,8 @@
       "version_requirement": ">=2.2.0 <5.0.0"
     },
     {
-      "name": "puppetlabs/puppetserver_gem",
-      "version_requirement": ">=0.2.0 <2.0.0"
+      "name": "tkishel/system_gem",
+      "version_requirement": ">=1.0.0 <2.0.0"
     },
     {
       "name": "lwf/remote_file",

--- a/metadata.json
+++ b/metadata.json
@@ -58,8 +58,8 @@
       "version_requirement": ">=2.2.0 <5.0.0"
     },
     {
-      "name": "tkishel/system_gem",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "name": "puppetlabs/puppetserver_gem",
+      "version_requirement": ">=0.2.0 <2.0.0"
     },
     {
       "name": "lwf/remote_file",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-datadog_agent",
-  "version": "1.11.0",
+  "version": "1.12.0-alpha",
   "author": "James Turnbull (<james@lovedthanlost.net>) and Rob Terhaar (<rob@atlanticdynamic>) for Datadog Inc.",
   "summary": "Install the Datadog monitoring agent and report Puppet runs to Datadog",
   "license": "Apache-2.0",
@@ -11,46 +11,27 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
+      "operatingsystemrelease": ["6", "7"]
     },
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
+      "operatingsystemrelease": ["6", "7"]
     },
     {
       "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
+      "operatingsystemrelease": ["6", "7"]
     },
     {
       "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "19",
-        "20"
-      ]
+      "operatingsystemrelease": ["19", "20", "21", "22", "23", "24", "25", "26"]
     },
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
+      "operatingsystemrelease": ["6", "7", "8", "9"]
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "10.04",
-        "12.04",
-        "14.04"
-      ]
+      "operatingsystemrelease": ["10.04", "12.04", "14.04", "16.04", "17.04", "17.10"]
     }
   ],
   "requirements": [
@@ -70,11 +51,15 @@
     },
     {
       "name": "puppetlabs/ruby",
-      "version_requirement": ">=0.2.0 <1.0.0"
+      "version_requirement": ">=0.2.0 <2.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": "2.2.0"
+      "version_requirement": ">=2.2.0 <5.0.0"
+    },
+    {
+      "name": "puppetlabs/puppetserver_gem",
+      "version_requirement": ">=0.2.0 <2.0.0"
     },
     {
       "name": "lwf/remote_file",


### PR DESCRIPTION
This PR addresses some of the issues brought up by @bittner in PR #362. Unfortunately we've had to remove the changes pertaining to `puppetserver_gem` as the alternative proposed `tkishel/system_gem` would definitely break legacy puppet systems supported by the `1.x` version of the module.  

Also, please note that the `puppetserver_gem` is a soft dependency for reporting and must be installed manually (please take a look at the existing [README](https://github.com/DataDog/puppet-datadog-agent/blob/master/README.md) for more information). Should you need to address [PUP-6134](https://tickets.puppetlabs.com/browse/PUP-6134) - you are likely able to do so by installing https://forge.puppet.com/tkishel/system_gem manually, in the same way you'd install `puppetserver_gem` and overriding the value here: https://github.com/DataDog/puppet-datadog-agent/blob/master/manifests/init.pp#L197 to `system_gem`.