### PR TITLE
Only grep for last 8 characters as this is what apt-key list returns

### DIFF
--- a/manifests/ubuntu/install_key.pp
+++ b/manifests/ubuntu/install_key.pp
@@ -15,6 +15,6 @@
 define datadog_agent::ubuntu::install_key() {
   exec { "key ${name}":
     command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${name}",
-    unless  => "/usr/bin/apt-key list | grep ${name} | grep expires",
+    unless  => "/usr/bin/apt-key list | grep ${name[-8,8]} | grep expires",
   }
 }


### PR DESCRIPTION
This fixes #367 by grepping only the last 8 characters of the key ID, which is what apt-key list returns on Debian and Ubuntu