### PR TITLE
[apt] Only grep for last 8 characters as this is what apt-key list returns

### DIFF
--- a/manifests/ubuntu/install_key.pp
+++ b/manifests/ubuntu/install_key.pp
@@ -13,8 +13,10 @@
 #
 #
 define datadog_agent::ubuntu::install_key() {
+  $shortkey =  regsubst($name, '.*(.{8})$', '\1')
+
   exec { "key ${name}":
     command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${name}",
-    unless  => "/usr/bin/apt-key list | grep ${name[-8,8]} | grep expires",
+    unless  => "/usr/bin/apt-key list | grep ${shortkey} | grep expires",
   }
 }

--- a/manifests/ubuntu/install_key.pp
+++ b/manifests/ubuntu/install_key.pp
@@ -15,6 +15,6 @@
 define datadog_agent::ubuntu::install_key() {
   exec { "key ${name}":
     command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${name}",
-    unless  => "/usr/bin/apt-key list | grep ${name} | grep expires",
+    unless  => "/usr/bin/apt-key list | grep ${name[-8,8]} | grep expires",
   }
 }


### PR DESCRIPTION
Supersedes #373 - we have to resort to something that will work on older puppets.

Big thanks to @szponek for bringing this up and his more elegant original fix, unfortunately we have to stay backward compatible, so had to resort to this.