### PR TITLE
Add test for apm footer to not apply template if = empty string

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -451,7 +451,7 @@ class datadog_agent(
       $apm_footer_order = '06'
     }
 
-    if $apm_env != '' {
+    if ($apm_enabled == true) and ($apm_env != '') {
       concat::fragment{ 'datadog apm footer':
         target  => '/etc/dd-agent/datadog.conf',
         content => template('datadog_agent/datadog_apm_footer.conf.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -451,10 +451,12 @@ class datadog_agent(
       $apm_footer_order = '06'
     }
 
-    concat::fragment{ 'datadog apm footer':
-      target  => '/etc/dd-agent/datadog.conf',
-      content => template('datadog_agent/datadog_apm_footer.conf.erb'),
-      order   => $apm_footer_order,
+    if $apm_env != '' {
+      concat::fragment{ 'datadog apm footer':
+        target  => '/etc/dd-agent/datadog.conf',
+        content => template('datadog_agent/datadog_apm_footer.conf.erb'),
+        order   => $apm_footer_order,
+      }
     }
   } else {
 


### PR DESCRIPTION
This causes an error on nodes that don't have an apm footer set. The default value is an empty string and tests between puppet 3 and puppet 4 are different.
Explicitly testing for an empty string to know if we should create the template.