### PR TITLE
Fix beta6 fact

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -32,8 +32,6 @@ class datadog_agent::ubuntu(
     }
   }
 
-  debug(sprintf("Fact ::apt_agent6_beta_repo=%s type=%s is_true=%s str2bool=%s", $::apt_agent6_beta_repo, type3x($::apt_agent6_beta_repo), ($::apt_agent6_beta_repo and true), str2bool("$::apt_agent6_beta_repo")))
-
   # This is a hack - I'm not happy about it, but we should rarely
   # hit this code path
   #

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -32,12 +32,14 @@ class datadog_agent::ubuntu(
     }
   }
 
+  debug(sprintf("Fact ::apt_agent6_beta_repo=%s type=%s is_true=%s str2bool=%s", $::apt_agent6_beta_repo, type3x($::apt_agent6_beta_repo), ($::apt_agent6_beta_repo and true), str2bool("$::apt_agent6_beta_repo")))
+
   # This is a hack - I'm not happy about it, but we should rarely
   # hit this code path
   #
   # Also, using $::apt_agent6_beta_repo to access fact instead of
   # $facts hash - for compatibility with puppet3.x default behavior
-  if $::apt_agent6_beta_repo and $agent_version == 'latest' {
+  if str2bool("$::apt_agent6_beta_repo") and $agent_version == 'latest' {
     exec { 'datadog_apt-get_remove_agent6':
       command     => '/usr/bin/apt-get remove -y -q datadog-agent',
     }
@@ -50,7 +52,7 @@ class datadog_agent::ubuntu(
     }
   }
 
-  if $::apt_agent6_beta_repo {
+  if str2bool("$::apt_agent6_beta_repo") {
     file { '/etc/apt/sources.list.d/datadog-beta.list':
       ensure => absent,
     }


### PR DESCRIPTION
In some situations facts are likely returned as a string. Any non-empty string can be interpreted as `true` when building a conditional. See https://puppet.com/docs/puppet/5.3/lang_facts_and_builtin_vars.html#handling-boolean-facts-in-older-puppet-versions

Ensure we're interpreting `::apt_agent6_beta_repo` as a valid boolean, so we don't get half-baked package removals.

Example debug message confirming the various ways to interpret the fact:
```
Debug: Scope(Class[Datadog_agent::Ubuntu]): Fact ::apt_agent6_beta_repo=false type=string is_true=true str2bool=false
```
```
puppet --version
3.8.7
```