### PR TITLE
Fix tomcat integration

### DIFF
--- a/templates/agent-conf.d/tomcat.yaml.erb
+++ b/templates/agent-conf.d/tomcat.yaml.erb
@@ -74,17 +74,19 @@ init_config:
             metric_type: counter
     - include:
         type: Cache
-        accessCount:
-          alias: tomcat.cache.access_count
-          metric_type: counter
-        hitsCounts:
-          alias: tomcat.cache.hits_count
-          metric_type: counter
+        attribute:
+          accessCount:
+            alias: tomcat.cache.access_count
+            metric_type: counter
+          hitsCounts:
+            alias: tomcat.cache.hits_count
+            metric_type: counter
     - include:
         type: JspMonitor
-        jspCount:
-          alias: tomcat.jsp.count
-          metric_type: counter
-        jspReloadCount:
-          alias: tomcat.jsp.reload_count
-          metric_type: counter
+        attribute:
+          jspCount:
+            alias: tomcat.jsp.count
+            metric_type: counter
+          jspReloadCount:
+            alias: tomcat.jsp.reload_count
+            metric_type: counter


### PR DESCRIPTION
This fixes tomcat integration when some its metrics start reporting wrong values (jumps and drops) after tomcat restart. This PR adds only two lines with `attribute:` after `type: Cache` and `type: JspMonitor`.

![image](https://user-images.githubusercontent.com/10218528/35908023-346efab0-0bf8-11e8-9c35-e8031f8bf389.png)

Also, config for tomcat integration, which are shipped with Datadog agent package, already contains these changes, but [Datadog documentation](https://docs.datadoghq.com/integrations/tomcat/) does not have the lines with `attribute:`.




