### PR TITLE
Add network_latency_checks parameter to consul checks (#393)

### DIFF
--- a/manifests/integrations/consul.pp
+++ b/manifests/integrations/consul.pp
@@ -27,10 +27,11 @@
 #   }
 #
 class datadog_agent::integrations::consul(
-  $url               = 'http://localhost:8500',
-  $catalog_checks    = true,
-  $new_leader_checks = true,
-  $service_whitelist = []
+  $url                    = 'http://localhost:8500',
+  $catalog_checks         = true,
+  $network_latency_checks = true,
+  $new_leader_checks      = true,
+  $service_whitelist      = []
 ) inherits datadog_agent::params {
   include datadog_agent
 

--- a/templates/agent-conf.d/consul.yaml.erb
+++ b/templates/agent-conf.d/consul.yaml.erb
@@ -29,6 +29,12 @@ instances:
       # you will receive one event per leader change per agent
       new_leader_checks: <%= @new_leader_checks ? 'yes' : 'no' %>
 
+      # Whether to enable network latency metrics collection. When enabled
+      # consul network coordinates will be retrieved and latency calculated for
+      # each node and between data centers.
+      # See https://www.consul.io/docs/internals/coordinates.html
+      network_latency_checks: <%= @network_latency_checks ? 'yes' : 'no' %>
+
       # Services to restrict catalog querying to
       # The default settings query up to 50 services. So if you have more than
       # this many in your Consul service catalog, you will want to fill in the


### PR DESCRIPTION
Add a network_latency_checks parameter to consul checks, which is supported by the core integration:
https://github.com/DataDog/integrations-core/blob/master/consul/conf.yaml.example#L42

https://github.com/DataDog/puppet-datadog-agent/issues/393