### PR TITLE
datadog6 default yum repo: s/rpm/stable in url

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class datadog_agent::params {
     'RedHat','CentOS','Fedora','Amazon','Scientific' : {
       $rubydev_package   = 'ruby-devel'
       $agent5_default_repo = "https://yum.datadoghq.com/rpm/${::architecture}/"
-      $agent6_default_repo = "https://yum.datadoghq.com/rpm/6/${::architecture}/"
+      $agent6_default_repo = "https://yum.datadoghq.com/stable/6/${::architecture}/"
     }
     default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
   }

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -65,7 +65,7 @@ describe 'datadog_agent::redhat::agent6' do
         .with_enabled(1)\
         .with_gpgcheck(1)\
           .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
-        .with_baseurl('https://yum.datadoghq.com/rpm/6/x86_64/')
+        .with_baseurl('https://yum.datadoghq.com/stable/6/x86_64/')
     end
   end
   context 'with manage_repo => false' do


### PR DESCRIPTION
See: https://github.com/DataDog/puppet-datadog-agent/issues/398