### PR TITLE
redhat: stop specifying service resource provider 'redhat'

### DIFF
--- a/manifests/redhat/agent5.pp
+++ b/manifests/redhat/agent5.pp
@@ -93,7 +93,6 @@ class datadog_agent::redhat::agent5(
     enable    => $service_enable,
     hasstatus => false,
     pattern   => 'dd-agent',
-    provider  => 'redhat',
     require   => Package[$datadog_agent::params::package_name],
   }
 

--- a/manifests/redhat/agent6.pp
+++ b/manifests/redhat/agent6.pp
@@ -67,7 +67,6 @@ class datadog_agent::redhat::agent6(
     enable    => $service_enable,
     hasstatus => false,
     pattern   => 'dd-agent',
-    provider  => 'redhat',
     require   => Package[$datadog_agent::params::package_name],
   }
 


### PR DESCRIPTION
The default provider for "`operatingsystemmajrelease` == `7` and `osfamily` == `redhat`" is systemd. See [here](https://puppet.com/docs/puppet/4.10/types/service.html#service-provider-systemd).

This PR removes the override to use the `redhat` provider, which can cause issues on newer RHEL/CentOS, and instead falls back to the default, which should be safe.