### PR TITLE
Multiple fixes to Kafka, Consul, stdlib deprecations

### DIFF
--- a/functions/tag6.pp
+++ b/functions/tag6.pp
@@ -8,7 +8,7 @@ function datadog_agent::tag6(
 ) {
   if $tag_names =~ Array {
     $tags = $tag_names.reduce([]) |$_tags , $tag| {
-        concat($_tags, datadog_agent::tag6($tag, lookup_fact))
+        concat($_tags, datadog_agent::tag6($tag, $lookup_fact))
     }
   } else {
     if $lookup_fact =~ String {

--- a/functions/tag6.pp
+++ b/functions/tag6.pp
@@ -6,20 +6,27 @@ function datadog_agent::tag6(
   Variant[Array, String] $tag_names,
   Variant[String, Boolean] $lookup_fact = false,
 ) {
-  if validate_legacy('Optional[Array]', 'is_array', $tag_names) {
+  if $tag_names =~ Array {
     $tags = $tag_names.reduce([]) |$_tags , $tag| {
         concat($_tags, datadog_agent::tag6($tag, lookup_fact))
     }
-  } elsif str2bool($lookup_fact) {
-    $value = getvar($tag_names)
+  } else {
+    if $lookup_fact =~ String {
+      $lookup = str2bool($lookup_fact)
+    } else {
+      $lookup = $lookup_fact
+    }
 
-    if validate_legacy('Optional[Array]', 'is_array', $value){
-      $tags = prefix($value, "${tag_names}:")
+    if $lookup {
+      $value = getvar($tag_names)
+      if $value =~ Array {
+        $tags = prefix($value, "${tag_names}:")
+      } else {
+        $tags = [$tag_names]
+      }
     } else {
       $tags = [$tag_names]
     }
-  } else {
-    $tags = [$tag_names]
   }
 
   $tags

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -525,7 +525,7 @@ class datadog_agent(
       'dogstatsd_non_local_traffic' => $non_local_traffic,
       'log_file' => $agent6_log_file,
       'log_level' => $log_level,
-      'tags' => union($_local_tags, $_facts_tags),
+      'tags' => unique(flatten(union($_local_tags, $_facts_tags))),
     }
 
     $agent_config = deep_merge($_agent_config, $extra_config)

--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -6,11 +6,9 @@ define datadog_agent::integration (
 
   include datadog_agent
 
-  validate_array($instances)
-  if $init_config != undef {
-    validate_hash($init_config)
-  }
-  validate_string($integration)
+  validate_legacy(Array, 'validate_array', $instances)
+  validate_legacy(Optional[Hash], 'validate_hash', $init_config)
+  validate_legacy(String, 'validate_string', $integration)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/${integration}.yaml"

--- a/manifests/integrations/apache.pp
+++ b/manifests/integrations/apache.pp
@@ -35,9 +35,9 @@ class datadog_agent::integrations::apache (
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_string($url)
-  validate_array($tags)
-  validate_bool($disable_ssl_validation)
+  validate_legacy('String', 'validate_string', $url)
+  validate_legacy('Array', 'validate_array', $tags)
+  validate_legacy('Boolean', 'validate_bool', $disable_ssl_validation)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/apache.yaml"

--- a/manifests/integrations/cassandra.pp
+++ b/manifests/integrations/cassandra.pp
@@ -33,7 +33,8 @@ class datadog_agent::integrations::cassandra(
   $tags = {},
 ) inherits datadog_agent::params {
   require ::datadog_agent
-  validate_hash($tags)
+
+  validate_legacy(Optional[Hash], 'validate_hash', $tags)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/cassandra.yaml"

--- a/manifests/integrations/ceph.pp
+++ b/manifests/integrations/ceph.pp
@@ -14,12 +14,13 @@
 #  }
 #
 class datadog_agent::integrations::ceph(
-  $tags = [ 'name:ceph_cluster' ],
-  $ceph_cmd = '/usr/bin/ceph',
+  Array $tags = [ 'name:ceph_cluster' ],
+  String $ceph_cmd = '/usr/bin/ceph',
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($tags)
+  validate_legacy('Array', 'validate_array', $tags)
+  validate_legacy('String', 'validate_string', $ceph_cmd)
 
   file { '/etc/sudoers.d/datadog_ceph':
     content => "# This file is required for dd ceph \ndd-agent ALL=(ALL) NOPASSWD:/usr/bin/ceph\n"

--- a/manifests/integrations/consul.pp
+++ b/manifests/integrations/consul.pp
@@ -27,18 +27,18 @@
 #   }
 #
 class datadog_agent::integrations::consul(
-  $url                    = 'http://localhost:8500',
-  $catalog_checks         = true,
-  $network_latency_checks = true,
-  $new_leader_checks      = true,
-  $service_whitelist      = []
+  String $url                        = 'http://localhost:8500',
+  Boolean $catalog_checks            = true,
+  Boolean $network_latency_checks    = true,
+  Boolean $new_leader_checks         = true,
+  Optional[Array] $service_whitelist = []
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_string($url)
-  validate_bool($catalog_checks)
-  validate_bool($new_leader_checks)
-  validate_array($service_whitelist)
+  validate_legacy('String', 'validate_string', $url)
+  validate_legacy('Boolean', 'validate_bool', $catalog_checks)
+  validate_legacy('Boolean', 'validate_bool', $new_leader_checks)
+  validate_legacy('Optional[Array]', 'validate_array', $service_whitelist)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/consul.yaml"

--- a/manifests/integrations/directory.pp
+++ b/manifests/integrations/directory.pp
@@ -55,22 +55,22 @@
 # }
 
 class datadog_agent::integrations::directory (
-  $directory   = '',
-  $filegauges  = false,
-  $recursive   = true,
-  $countonly   = false,
-  $nametag     = '',
-  $dirtagname  = '',
-  $filetagname = '',
-  $pattern     = '',
-  $instances   = undef,
+  String $directory          = '',
+  Boolean $filegauges        = false,
+  Boolean $recursive         = true,
+  Boolean $countonly         = false,
+  String $nametag            = '',
+  String $dirtagname         = '',
+  String $filetagname        = '',
+  String $pattern            = '',
+  Optional[Array] $instances = undef,
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_string($directory)
-  validate_bool($filegauges)
-  validate_bool($recursive)
-  validate_bool($countonly)
+  validate_legacy(String, 'validate_string', $directory)
+  validate_legacy(Boolean, 'validate_bool', $filegauges)
+  validate_legacy(Boolean, 'validate_bool', $recursive)
+  validate_legacy(Boolean, 'validate_bool', $countonly)
 
   if !$instances and $directory == '' {
     fail('bad directory argument and no instances hash provided')

--- a/manifests/integrations/disk.pp
+++ b/manifests/integrations/disk.pp
@@ -32,7 +32,7 @@
 #      excluded_disk_re     => '/dev/sd[e-z]*'
 #  }
 class datadog_agent::integrations::disk (
-  $use_mount              = 'no',
+  String $use_mount       = 'no',
   $excluded_filesystems   = undef,
   $excluded_disks         = undef,
   $excluded_disk_re       = undef,
@@ -42,9 +42,10 @@ class datadog_agent::integrations::disk (
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_re($use_mount, '^(no|yes)$', "use_mount should be either 'yes' or 'no'")
-  if $all_partitions {
-    validate_re($all_partitions, '^(no|yes)$', "all_partitions should be either 'yes' or 'no'")
+  validate_legacy('Optional[String]', 'validate_re', $all_partitions, '^(no|yes)$')
+
+  if $use_mount !~ '^(no|yes)$' {
+    fail('error during compilation')
   }
 
   if !$::datadog_agent::agent5_enable {

--- a/manifests/integrations/dns_check.pp
+++ b/manifests/integrations/dns_check.pp
@@ -25,7 +25,7 @@
 #  }
 #
 class datadog_agent::integrations::dns_check (
-  $checks = [
+  Array $checks = [
     {
       'hostname'   => 'google.com',
       'nameserver' => '8.8.8.8',
@@ -35,7 +35,7 @@ class datadog_agent::integrations::dns_check (
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($checks)
+  validate_legacy('Array', 'validate_array', $checks)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/dns_check.yaml"

--- a/manifests/integrations/elasticsearch.pp
+++ b/manifests/integrations/elasticsearch.pp
@@ -24,31 +24,36 @@
 #  }
 #
 class datadog_agent::integrations::elasticsearch(
-  $cluster_stats      = false,
-  $password           = undef,
-  $pending_task_stats = true,
-  $pshard_stats       = false,
-  $ssl_cert           = undef,
-  $ssl_key            = undef,
-  $ssl_verify         = true,
-  $tags               = [],
-  $url                = 'http://localhost:9200',
-  $username           = undef,
-  $instances          = undef
+  $cluster_stats                       = false,
+  Optional[String] $password           = undef,
+  $pending_task_stats                  = true,
+  $pshard_stats                        = false,
+  Optional[String] $ssl_cert           = undef,
+  Optional[String] $ssl_key            = undef,
+  Variant[Boolean, String] $ssl_verify = true,
+  $tags                                = [],
+  $url                                 = 'http://localhost:9200',
+  Optional[String] $username           = undef,
+  $instances                           = undef
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($tags)
+  validate_legacy(Array, 'validate_array', $tags)
   # $ssl_verify can be a bool or a string
   # https://github.com/DataDog/dd-agent/blob/master/checks.d/elastic.py#L454-L455
-  if is_bool($ssl_verify) {
-    validate_bool($ssl_verify)
-  } elsif $ssl_verify != undef {
-    validate_string($ssl_verify)
+  if validate_legacy('Variant[Boolean, String]', 'is_string', $ssl_verify){
     validate_absolute_path($ssl_verify)
   }
-  validate_bool($cluster_stats, $pending_task_stats, $pshard_stats)
-  validate_string($password, $ssl_cert, $ssl_key, $url, $username)
+
+
+  validate_legacy('Boolean', 'validate_bool', $cluster_stats)
+  validate_legacy('Boolean', 'validate_bool', $pending_task_stats)
+  validate_legacy('Boolean', 'validate_bool', $pshard_stats)
+
+  validate_legacy('Optional[String]', 'validate_string', $password)
+  validate_legacy('Optional[String]', 'validate_string', $ssl_cert)
+  validate_legacy('Optional[String]', 'validate_string', $ssl_key)
+  validate_legacy('Optional[String]', 'validate_string', $username)
 
   if !$instances and $url {
     $_instances = [{

--- a/manifests/integrations/fluentd.pp
+++ b/manifests/integrations/fluentd.pp
@@ -19,11 +19,11 @@
 #
 class datadog_agent::integrations::fluentd(
   $monitor_agent_url = 'http://localhost:24220/api/plugins.json',
-  $plugin_ids = [],
+  Optional[Array] $plugin_ids = [],
 ) inherits datadog_agent::params {
   include ::datadog_agent
 
-  validate_array($plugin_ids)
+  validate_legacy('Optional[Array]', 'validate_array', $plugin_ids)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/fluentd.yaml"

--- a/manifests/integrations/generic.pp
+++ b/manifests/integrations/generic.pp
@@ -18,12 +18,12 @@
 # }
 #
 class datadog_agent::integrations::generic(
-  $integration_name     = undef,
-  $integration_contents = undef,
+  Optional[String] $integration_name     = undef,
+  Optional[String] $integration_contents = undef,
 ) inherits datadog_agent::params {
 
-  validate_string($integration_name)
-  validate_string($integration_contents)
+  validate_legacy('Optional[String]', 'validate_string', $integration_name)
+  validate_legacy('Optional[String]', 'validate_string', $integration_contents)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/${integration_name}.yaml"

--- a/manifests/integrations/kafka.pp
+++ b/manifests/integrations/kafka.pp
@@ -86,7 +86,13 @@ class datadog_agent::integrations::kafka(
     $servers = $instances
   }
 
-  file { "${datadog_agent::params::conf_dir}/kafka.yaml":
+  if !$::datadog_agent::agent5_enable {
+    $dst = "${datadog_agent::conf6_dir}/kafka.yaml"
+  } else {
+    $dst = "${datadog_agent::conf_dir}/kafka.yaml"
+  }
+
+  file { $dst:
     ensure  => file,
     owner   => $datadog_agent::params::dd_user,
     group   => $datadog_agent::params::dd_group,

--- a/manifests/integrations/memcache.pp
+++ b/manifests/integrations/memcache.pp
@@ -31,18 +31,17 @@
 #  }
 #
 class datadog_agent::integrations::memcache (
-  $url                    = 'localhost',
-  $port                   = 11211,
-  $tags                   = [],
-  $items                  = false,
-  $slabs                  = false,
-  $instances = undef,
+  String $url                     = 'localhost',
+  Variant[String, Integer] $port  = 11211,
+  Array $tags                     = [],
+  Variant[Boolean, String] $items = false,
+  Variant[Boolean, String] $slabs = false,
+  Optional[Array] $instances      = undef,
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_string($url)
-  validate_array($tags)
-  validate_integer($port)
+  validate_legacy('String', 'validate_string', $url)
+  validate_legacy('Array', 'validate_array', $tags)
 
   if !$instances and $url {
     $_instances = [{

--- a/manifests/integrations/mongo.pp
+++ b/manifests/integrations/mongo.pp
@@ -61,7 +61,8 @@ class datadog_agent::integrations::mongo(
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($servers)
+
+  validate_legacy('Array', 'validate_array', $servers)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/mongo.yaml"

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -54,24 +54,25 @@
 #
 #
 class datadog_agent::integrations::mysql(
-  $password,
-  $host = 'localhost',
-  $user = 'datadog',
-  $port = 3306,
-  $sock = undef,
-  $tags = [],
-  $replication = '0',
-  $galera_cluster = '0',
-  $extra_status_metrics = false,
-  $extra_innodb_metrics = false,
-  $extra_performance_metrics = false,
-  $schema_size_metrics = false,
-  $disable_innodb_metrics = false,
-  $instances = undef,
+  String $password,
+  String $host                       = 'localhost',
+  String $user                       = 'datadog',
+  Variant[String, Integer] $port     = 3306,
+  Optional[String] $sock             = undef,
+  Array $tags                        = [],
+  $replication                       = '0',
+  $galera_cluster                    = '0',
+  Boolean $extra_status_metrics      = false,
+  Boolean $extra_innodb_metrics      = false,
+  Boolean $extra_performance_metrics = false,
+  Boolean $schema_size_metrics       = false,
+  Boolean $disable_innodb_metrics    = false,
+  Optional[Array] $instances         = undef,
   ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($tags)
+  validate_legacy('Optional[String]', 'validate_string', $sock)
+  validate_legacy('Array', 'validate_array', $tags)
 
   if !$instances and $host {
     $_instances = [{

--- a/manifests/integrations/network.pp
+++ b/manifests/integrations/network.pp
@@ -22,14 +22,14 @@
 #
 #
 class datadog_agent::integrations::network(
-  $collect_connection_state = false,
-  $excluded_interfaces = ['lo','lo0'],
-  $excluded_interface_re = [],
-  $combine_connection_states = true,
+  Boolean $collect_connection_state = false,
+  Array[String] $excluded_interfaces = ['lo','lo0'],
+  Array $excluded_interface_re = [],
+  Boolean $combine_connection_states = true,
 ) inherits datadog_agent::params {
   include ::datadog_agent
 
-  validate_array($excluded_interfaces)
+  validate_legacy('Array', 'validate_array', $excluded_interfaces)
 
   file { "${datadog_agent::params::conf_dir}/network.yaml":
     ensure  => file,

--- a/manifests/integrations/nginx.pp
+++ b/manifests/integrations/nginx.pp
@@ -23,11 +23,11 @@
 #
 #
 class datadog_agent::integrations::nginx(
-  $instances = [],
+  Array $instances = [],
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($instances)
+  validate_legacy('Array', 'validate_array', $instances)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/nginx.yaml"

--- a/manifests/integrations/pgbouncer.pp
+++ b/manifests/integrations/pgbouncer.pp
@@ -44,17 +44,17 @@
 #  }
 #
 class datadog_agent::integrations::pgbouncer(
-  $password = '',
-  $host   = 'localhost',
-  $port   = '6432',
-  $username = 'datadog',
-  $tags = [],
-  $pgbouncers = [],
+  String $password               = '',
+  String $host                   = 'localhost',
+  Variant[String, Integer] $port = '6432',
+  String $username               = 'datadog',
+  Array $tags = [],
+  Array $pgbouncers = [],
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($tags)
-  validate_array($pgbouncers)
+  validate_legacy('Array', 'validate_array', $tags)
+  validate_legacy('Array', 'validate_array', $pgbouncers)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/pgbouncer.yaml"

--- a/manifests/integrations/postfix.pp
+++ b/manifests/integrations/postfix.pp
@@ -29,16 +29,16 @@
 #  }
 #
 class datadog_agent::integrations::postfix (
-  $directory              = '/var/spool/postfix',
-  $queues                 = [ 'active', 'deferred', 'incoming' ],
-  $tags                   = [],
-  $instances = undef,
+  $directory                 = '/var/spool/postfix',
+  Array $queues              = [ 'active', 'deferred', 'incoming' ],
+  Optional[Array] $tags      = [],
+  Optional[Array] $instances = undef,
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_string($directory)
-  validate_array($queues)
-  validate_array($tags)
+  validate_legacy('String', 'validate_string', $directory)
+  validate_legacy('Optional[Array]', 'validate_array', $queues)
+  validate_legacy('Optional[Array]', 'validate_array', $tags)
 
   if !$instances and $directory {
     $_instances = [{

--- a/manifests/integrations/postgres.pp
+++ b/manifests/integrations/postgres.pp
@@ -55,23 +55,23 @@
 #
 #
 class datadog_agent::integrations::postgres(
-  $password,
-  $host   = 'localhost',
-  $dbname = 'postgres',
-  $port   = '5432',
-  $username = 'datadog',
-  $ssl = false,
-  $use_psycopg2 = false,
-  $tags = [],
-  $tables = [],
-  $custom_metrics = {},
-  $instances = undef,
+  String $password,
+  String $host                   = 'localhost',
+  String $dbname                 = 'postgres',
+  Variant[String, Integer] $port = '5432',
+  String $username               = 'datadog',
+  Boolean $ssl                   = false,
+  Boolean $use_psycopg2          = false,
+  Array[String] $tags            = [],
+  Array[String] $tables          = [],
+  Hash $custom_metrics           = {},
+  Optional[Array] $instances     = undef,
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($tags)
-  validate_array($tables)
-  validate_bool($use_psycopg2)
+  validate_legacy('Array[String]', 'validate_array', $tags)
+  validate_legacy('Array[String]', 'validate_array', $tables)
+  validate_legacy('Boolean', 'validate_bool', $use_psycopg2)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/postgres.yaml"

--- a/manifests/integrations/postgres_custom_metric.pp
+++ b/manifests/integrations/postgres_custom_metric.pp
@@ -16,12 +16,15 @@
 #   an array that maps an sql column's to a tag. Each descriptor consists of two
 #   fields -- column name, and datadog tag.
 define datadog_agent::integrations::postgres_custom_metric(
-  $query,
-  $metrics,
-  $relation = false,
-  $descriptors = [],
+  String $query,
+  Hash $metrics,
+  Boolean $relation = false,
+  Array $descriptors = [],
 ) {
-  validate_re($query, '^.*%s.*$', 'custom_metrics require %s for metric substitution')
-  validate_hash($metrics)
-  validate_array($descriptors)
+  validate_legacy('Hash', 'validate_hash', $metrics)
+  validate_legacy('Array', 'validate_array', $descriptors)
+
+  if $query !~ '^.*%s.*$' {
+    fail('custom_metrics require %s for metric substitution')
+  }
 }

--- a/manifests/integrations/process.pp
+++ b/manifests/integrations/process.pp
@@ -41,13 +41,13 @@
 #
 #
 class datadog_agent::integrations::process(
-  $hiera_processes = false,
-  $processes = [],
+  Boolean $hiera_processes = false,
+  Array $processes = [],
   ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_bool( $hiera_processes )
-  validate_array( $processes )
+  validate_legacy('Boolean', 'validate_bool', $hiera_processes)
+  validate_legacy('Array', 'validate_array', $processes)
 
   if $hiera_processes {
     $local_processes = lookup({ 'name' => 'datadog_agent::integrations::process::processes', 'default_value' => []})

--- a/manifests/integrations/rabbitmq.pp
+++ b/manifests/integrations/rabbitmq.pp
@@ -46,28 +46,28 @@
 #
 
 class datadog_agent::integrations::rabbitmq (
-  $url            = undef,
-  $username       = 'guest',
-  $password       = 'guest',
-  $ssl_verify     = true,
-  $tag_families   = false,
-  $nodes          = [],
-  $nodes_regexes  = [],
-  $queues         = [],
-  $queues_regexes = [],
-  $vhosts         = [],
+  Optional[String] $url      = undef,
+  Optional[String] $username = 'guest',
+  Optional[String] $password = 'guest',
+  Boolean $ssl_verify        = true,
+  Boolean $tag_families      = false,
+  Array $nodes               = [],
+  Array $nodes_regexes       = [],
+  Array $queues              = [],
+  Array $queues_regexes      = [],
+  Array $vhosts              = [],
 ) inherits datadog_agent::params {
 
-  validate_string($url)
-  validate_string($username)
-  validate_string($password)
-  validate_bool($ssl_verify)
-  validate_bool($tag_families)
-  validate_array($nodes)
-  validate_array($nodes_regexes)
-  validate_array($queues)
-  validate_array($queues_regexes)
-  validate_array($vhosts)
+  validate_legacy('String', 'validate_string', $url)
+  validate_legacy('Optional[String]', 'validate_string', $username)
+  validate_legacy('Optional[String]', 'validate_string', $password)
+  validate_legacy('Boolean', 'validate_bool', $ssl_verify)
+  validate_legacy('Boolean', 'validate_bool', $tag_families)
+  validate_legacy('Array', 'validate_array', $nodes)
+  validate_legacy('Array', 'validate_array', $nodes_regexes)
+  validate_legacy('Array', 'validate_array', $queues)
+  validate_legacy('Array', 'validate_array', $queues_regexes)
+  validate_legacy('Array', 'validate_array', $vhosts)
   include datadog_agent
 
   if !$::datadog_agent::agent5_enable {

--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -28,23 +28,24 @@
 #
 #
 class datadog_agent::integrations::redis(
-  $host = 'localhost',
-  $password = '',
-  $port = '6379',
-  $ports = undef,
-  $slowlog_max_len = '',
-  $tags = [],
-  $keys = [],
-  $warn_on_missing_keys = true,
-  $command_stats = false,
+  String $host                              = 'localhost',
+  String $password                          = '',
+  Variant[String, Integer] $port            = '6379',
+  Optional[Array] $ports                    = undef,
+  Variant[String, Integer] $slowlog_max_len = '',
+  Array $tags                               = [],
+  Array $keys                               = [],
+  Boolean $warn_on_missing_keys             = true,
+  Boolean $command_stats                    = false,
 
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($tags)
-  validate_array($keys)
-  validate_bool($warn_on_missing_keys)
-  validate_bool($command_stats)
+  validate_legacy('Array', 'validate_array', $tags)
+  validate_legacy('Array', 'validate_array', $keys)
+  validate_legacy('Boolean', 'validate_bool', $warn_on_missing_keys)
+  validate_legacy('Boolean', 'validate_bool', $command_stats)
+  validate_legacy('Optional[Array]', 'validate_array', $ports)
 
   if $ports == undef {
     $_ports = [ $port ]
@@ -52,7 +53,7 @@ class datadog_agent::integrations::redis(
     $_ports = $ports
   }
 
-  validate_array($_ports)
+  validate_legacy('Array', 'validate_array', $_ports)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/redisdb.yaml"

--- a/manifests/integrations/riak.pp
+++ b/manifests/integrations/riak.pp
@@ -19,13 +19,13 @@
 #   }
 #
 class datadog_agent::integrations::riak(
-  $url   = 'http://localhost:8098/stats',
-  $tags  = [],
+  String $url  = 'http://localhost:8098/stats',
+  Array $tags  = [],
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_string($url)
-  validate_array($tags)
+  validate_legacy('String', 'validate_string', $url)
+  validate_legacy('Array', 'validate_array', $tags)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/riak.yaml"

--- a/manifests/integrations/zk.pp
+++ b/manifests/integrations/zk.pp
@@ -32,7 +32,7 @@ class datadog_agent::integrations::zk (
 ) inherits datadog_agent::params {
   include datadog_agent
 
-  validate_array($servers)
+  validate_legacy('Array', 'validate_array', $servers)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/zk.yaml"

--- a/manifests/redhat/agent5.pp
+++ b/manifests/redhat/agent5.pp
@@ -15,19 +15,20 @@
 #
 #
 class datadog_agent::redhat::agent5(
-  $baseurl = $datadog_agent::params::agent5_default_repo,
-  $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
-  $manage_repo = true,
-  $agent_version = 'latest',
-  $service_ensure = 'running',
-  $service_enable = true,
+  String $baseurl = $datadog_agent::params::agent5_default_repo,
+  String $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+  Boolean $manage_repo = true,
+  String $agent_version = 'latest',
+  String $service_ensure = 'running',
+  Boolean $service_enable = true,
 ) inherits datadog_agent::params {
 
-  validate_bool($manage_repo)
+  validate_legacy('Boolean', 'validate_bool', $manage_repo)
+  validate_legacy('Boolean', 'validate_bool', $service_enable)
   if $manage_repo {
     $public_key_local = '/etc/pki/rpm-gpg/DATADOG_RPM_KEY.public'
 
-    validate_string($baseurl)
+    validate_legacy('String', 'validate_string', $baseurl)
 
     file { 'DATADOG_RPM_KEY.public':
         owner  => root,

--- a/manifests/redhat/agent6.pp
+++ b/manifests/redhat/agent6.pp
@@ -4,19 +4,20 @@
 #
 
 class datadog_agent::redhat::agent6(
-  $baseurl = $datadog_agent::params::agent6_default_repo,
-  $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
-  $manage_repo = true,
-  $agent_version = 'latest',
-  $service_ensure = 'running',
-  $service_enable = true,
+  String $baseurl = $datadog_agent::params::agent6_default_repo,
+  String $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+  Boolean $manage_repo = true,
+  String $agent_version = 'latest',
+  String $service_ensure = 'running',
+  Boolean $service_enable = true,
 ) inherits datadog_agent::params {
 
-  validate_bool($manage_repo)
+  validate_legacy('Boolean', 'validate_bool', $manage_repo)
+  validate_legacy('Boolean', 'validate_bool', $service_enable)
   if $manage_repo {
     $public_key_local = '/etc/pki/rpm-gpg/DATADOG_RPM_KEY.public'
 
-    validate_string($baseurl)
+    validate_legacy('String', 'validate_string', $baseurl)
 
     file { 'DATADOG_RPM_KEY.public':
         owner  => root,

--- a/manifests/ubuntu/agent5.pp
+++ b/manifests/ubuntu/agent5.pp
@@ -13,19 +13,19 @@
 #
 
 class datadog_agent::ubuntu::agent5(
-  $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
-  $agent_version = 'latest',
-  $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52'],
-  $location = $datadog_agent::params::agent5_default_repo,
-  $release = $datadog_agent::params::apt_default_release,
-  $repos = 'main',
-  $skip_apt_key_trusting = false,
-  $service_ensure = 'running',
-  $service_enable = true,
+  String $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
+  String $agent_version = 'latest',
+  Array $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52'],
+  String $location = $datadog_agent::params::agent5_default_repo,
+  String $release = $datadog_agent::params::apt_default_release,
+  String $repos = 'main',
+  Boolean $skip_apt_key_trusting = false,
+  String $service_ensure = 'running',
+  Boolean $service_enable = true,
 ) inherits datadog_agent::params{
 
   ensure_packages(['apt-transport-https'])
-  validate_array($other_keys)
+  validate_legacy('Array', 'validate_array', $other_keys)
 
   if !$skip_apt_key_trusting {
     $mykeys = concat($other_keys, [$apt_key])

--- a/metadata.json
+++ b/metadata.json
@@ -59,7 +59,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=4.0.0 <5.0.0"
+      "version_requirement": ">=2.4.0 <5.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",

--- a/spec/classes/datadog_agent_integrations_consul_spec.rb
+++ b/spec/classes/datadog_agent_integrations_consul_spec.rb
@@ -27,6 +27,34 @@ describe 'datadog_agent::integrations::consul' do
       )}
       it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
       it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+      context 'with defaults' do
+        it { should contain_file(conf_file).with_content(%r{url: http://localhost:8500}) }
+        it { should contain_file(conf_file).with_content(%r{catalog_checks: yes}) }
+        it { should contain_file(conf_file).with_content(%r{new_leader_checks: yes}) }
+        it { should contain_file(conf_file).with_content(%r{network_latency_checks: yes}) }
+      end
+
+      context 'with everything disabled' do
+        let(:params) {{
+          'url': 'http://localhost:8005',
+          'catalog_checks': false,
+          'new_leader_checks': false,
+          'network_latency_checks': false,
+        }}
+        it { should contain_file(conf_file).with_content(%r{url: http://localhost:8005}) }
+        it { should contain_file(conf_file).with_content(%r{catalog_checks: no}) }
+        it { should contain_file(conf_file).with_content(%r{new_leader_checks: no}) }
+        it { should contain_file(conf_file).with_content(%r{network_latency_checks: no}) }
+      end
+
+      context 'with service whitelist' do
+        let(:params) {{
+          'service_whitelist': ['foo', 'bar']
+        }}
+        it { should contain_file(conf_file).with_content(%r{url: http://localhost:8500}) }
+        it { should contain_file(conf_file).with_content(%r{service_whitelist:\n\s+- foo\n\s+- bar}) }
+      end
     end
   end
 end

--- a/spec/classes/datadog_agent_integrations_consul_spec.rb
+++ b/spec/classes/datadog_agent_integrations_consul_spec.rb
@@ -37,10 +37,10 @@ describe 'datadog_agent::integrations::consul' do
 
       context 'with everything disabled' do
         let(:params) {{
-          'url': 'http://localhost:8005',
-          'catalog_checks': false,
-          'new_leader_checks': false,
-          'network_latency_checks': false,
+          'url' => 'http://localhost:8005',
+          'catalog_checks' => false,
+          'new_leader_checks' => false,
+          'network_latency_checks' => false,
         }}
         it { should contain_file(conf_file).with_content(%r{url: http://localhost:8005}) }
         it { should contain_file(conf_file).with_content(%r{catalog_checks: no}) }
@@ -50,7 +50,7 @@ describe 'datadog_agent::integrations::consul' do
 
       context 'with service whitelist' do
         let(:params) {{
-          'service_whitelist': ['foo', 'bar']
+          'service_whitelist' => ['foo', 'bar']
         }}
         it { should contain_file(conf_file).with_content(%r{url: http://localhost:8500}) }
         it { should contain_file(conf_file).with_content(%r{service_whitelist:\n\s+- foo\n\s+- bar}) }

--- a/spec/classes/datadog_agent_integrations_kafka_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kafka_spec.rb
@@ -1,85 +1,95 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::kafka' do
-  let(:facts) {{
-    operatingsystem: 'Ubuntu',
-  }}
-  let(:conf_dir) { '/etc/dd-agent/conf.d' }
-  let(:dd_user) { 'dd-agent' }
-  let(:dd_group) { 'root' }
-  let(:dd_package) { 'datadog-agent' }
-  let(:dd_service) { 'datadog-agent' }
-  let(:conf_file) { "#{conf_dir}/kafka.yaml" }
+  context 'supported agents - v5 and v6' do
+    agents = { '5' => true, '6' => false }
+    agents.each do |_, enabled|
+      let(:pre_condition) { "class {'::datadog_agent': agent5_enable => #{enabled}}" }
+      let(:facts) {{
+        operatingsystem: 'Ubuntu',
+      }}
+      if enabled
+        let(:conf_dir) { '/etc/dd-agent/conf.d' }
+      else
+        let(:conf_dir) { '/etc/datadog-agent/conf.d' }
+      end
 
-  it { should compile.with_all_deps }
-  it { should contain_file(conf_file).with(
-    owner: dd_user,
-    group: dd_group,
-    mode: '0600',
-  )}
-  it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
-  it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+      let(:dd_user) { 'dd-agent' }
+      let(:dd_group) { 'root' }
+      let(:dd_package) { 'datadog-agent' }
+      let(:dd_service) { 'datadog-agent' }
+      let(:conf_file) { "#{conf_dir}/kafka.yaml" }
 
-  context 'with default parameters' do
-    it { should contain_file(conf_file).with_content(%r{- host: localhost\s+port: 9999}) }
-    it { should contain_file(conf_file).without_content(%r{tags:}) }
-  end
+      it { should compile.with_all_deps }
+      it { should contain_file(conf_file).with(
+        owner: dd_user,
+        group: dd_group,
+        mode: '0600',
+      )}
+      it { should contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+      it { should contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
 
+      context 'with default parameters' do
+        it { should contain_file(conf_file).with_content(%r{- host: localhost\s+port: 9999}) }
+        it { should contain_file(conf_file).without_content(%r{tags:}) }
+      end
 
-  context 'with one kafka broker' do
-    let(:params) {{
-      instances: [
-        {
-          'host' => 'localhost',
-          'port' => '9997',
-          'tags' => %w{ kafka:broker tag1:value1 },
-        }
-      ]
-    }}
+      context 'with one kafka broker' do
+        let(:params) {{
+          instances: [
+            {
+              'host' => 'localhost',
+              'port' => '9997',
+              'tags' => %w{ kafka:broker tag1:value1 },
+            }
+          ]
+        }}
 
-    it { should contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1}) }
-  end
+        it { should contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1}) }
+      end
 
-  context 'with two kafka brokers' do
-    let(:params) {{
-      instances: [
-        {
-          'host' => 'localhost',
-          'port' => '9997',
-          'tags' => %w{ kafka:broker tag1:value1 },
-        },
-        {
-          'host' => 'remotehost',
-          'port' => '9998',
-          'tags' => %w{ kafka:remote tag2:value2 },
-        }
-      ]
-    }}
+      context 'with two kafka brokers' do
+        let(:params) {{
+          instances: [
+            {
+              'host' => 'localhost',
+              'port' => '9997',
+              'tags' => %w{ kafka:broker tag1:value1 },
+            },
+            {
+              'host' => 'remotehost',
+              'port' => '9998',
+              'tags' => %w{ kafka:remote tag2:value2 },
+            }
+          ]
+        }}
 
-    it { should contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1}) }
-    it { should contain_file(conf_file).with_content(%r{host: remotehost\s+port: 9998\s+tags:\s+- kafka:remote\s+- tag2:value2}) }
+        it { should contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1}) }
+        it { should contain_file(conf_file).with_content(%r{host: remotehost\s+port: 9998\s+tags:\s+- kafka:remote\s+- tag2:value2}) }
 
-  end
+      end
 
-  context 'one kafka broker all options' do
-    let(:params) {{
-      instances: [
-        {
-          'host' => 'localhost',
-          'port' => '9997',
-          'tags' => %w{ kafka:broker tag1:value1 },
-          'username' => 'username',
-          'password' => 'password',
-          'process_name_regex' => 'regex',
-          'tools_jar_path' => 'tools.jar',
-          'name' => 'kafka_instance',
-          'java_bin_path' => '/path/to/java',
-          'trust_store_path' => '/path/to/trustStore.jks',
-          'trust_store_password' => 'password'
-        }
-      ]
-    }}
+      context 'one kafka broker all options' do
+        let(:params) {{
+          instances: [
+            {
+              'host' => 'localhost',
+              'port' => '9997',
+              'tags' => %w{ kafka:broker tag1:value1 },
+              'username' => 'username',
+              'password' => 'password',
+              'process_name_regex' => 'regex',
+              'tools_jar_path' => 'tools.jar',
+              'name' => 'kafka_instance',
+              'java_bin_path' => '/path/to/java',
+              'trust_store_path' => '/path/to/trustStore.jks',
+              'trust_store_password' => 'password'
+            }
+          ]
+        }}
 
-    it { should contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1\s+user: username\s+password: password\s+process_name_regex: regex\s+tools_jar_path: tools.jar\s+name: kafka_instance\s+java_bin_path: /path/to/java\s+trust_store_path: /path/to/trustStore.jks\s+trust_store_password: password}) }
+        it { should contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1\s+user: username\s+password: password\s+process_name_regex: regex\s+tools_jar_path: tools.jar\s+name: kafka_instance\s+java_bin_path: /path/to/java\s+trust_store_path: /path/to/trustStore.jks\s+trust_store_password: password}) }
+      end
+    end
   end
 end


### PR DESCRIPTION
- We have to slowly deprecate all legacy calls, and when we do make legacy calls for validation, let's rely on `validate_legacy`. In general we will move towards setting types for parameters, and we'll do so gradually, customers should not be affected by the changes, and the test suite should keep us honest.
- **Consul**: improved testing
- **Kafka**: added support for Agent6, it must've been left out when support was added for the beta.
- **Functions** for agent6 tagging: remove derecated calls. 