### PR TITLE
[apt] Stop installing old apt key

### DIFF
--- a/manifests/ubuntu/agent5.pp
+++ b/manifests/ubuntu/agent5.pp
@@ -24,7 +24,6 @@ class datadog_agent::ubuntu::agent5(
 ) inherits datadog_agent::params{
 
   ensure_packages(['apt-transport-https'])
-  validate_legacy('Array', 'validate_array', $other_keys)
 
   if !$skip_apt_key_trusting {
     ::datadog_agent::ubuntu::install_key { [$apt_key]:

--- a/manifests/ubuntu/agent5.pp
+++ b/manifests/ubuntu/agent5.pp
@@ -15,7 +15,6 @@
 class datadog_agent::ubuntu::agent5(
   String $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
   String $agent_version = 'latest',
-  Array $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52'],
   String $location = $datadog_agent::params::agent5_default_repo,
   String $release = $datadog_agent::params::apt_default_release,
   String $repos = 'main',
@@ -28,9 +27,7 @@ class datadog_agent::ubuntu::agent5(
   validate_legacy('Array', 'validate_array', $other_keys)
 
   if !$skip_apt_key_trusting {
-    $mykeys = concat($other_keys, [$apt_key])
-
-    ::datadog_agent::ubuntu::install_key { $mykeys:
+    ::datadog_agent::ubuntu::install_key { [$apt_key]:
       before  => Apt::Source['datadog'],
     }
   }

--- a/manifests/ubuntu/agent6.pp
+++ b/manifests/ubuntu/agent6.pp
@@ -6,7 +6,6 @@
 class datadog_agent::ubuntu::agent6(
   $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
   $agent_version = 'latest',
-  $other_keys = ['935F5A436A5A6E8788F0765B226AE980C7A7DA52'],
   $location = $datadog_agent::params::agent6_default_repo,
   $release = $datadog_agent::params::apt_default_release,
   $repos = '6',
@@ -16,12 +15,8 @@ class datadog_agent::ubuntu::agent6(
 ) inherits datadog_agent::params {
 
   ensure_packages(['apt-transport-https'])
-  validate_legacy(Array, 'validate_array', $other_keys)
-
   if !$skip_apt_key_trusting {
-    $mykeys = concat($other_keys, [$apt_key])
-
-    ::datadog_agent::ubuntu::install_key { $mykeys:
+    ::datadog_agent::ubuntu::install_key { [$apt_key]:
       before  => Apt::Source['datadog6'],
     }
   }

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -16,7 +16,7 @@ describe 'datadog_agent::ubuntu::agent5' do
   end
 
   # it should install the mirror
-  it { should contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
+  it { should_not contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
   it { should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
   it do
     should contain_file('/etc/apt/sources.list.d/datadog.list')\
@@ -63,7 +63,7 @@ describe 'datadog_agent::ubuntu::agent6' do
   end
 
   # it should install the mirror
-  it { should contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
+  it { should_not contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
   it { should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
 
   it do


### PR DESCRIPTION
That key is not used anymore, let's stop installing it.

(not sure the tests pass, will fix if they're broken)