### PR TITLE
Bug Fix: Faulty check on Redhat causes repeat reinstalls of agent.

### DIFF
--- a/lib/facter/agent_repo.rb
+++ b/lib/facter/agent_repo.rb
@@ -19,13 +19,13 @@ end
 Facter.add('yum_agent6_repo') do
   setcode do
       yumpath = '/etc/yum.repos.d/datadog6.repo'
-      File.exist? yumpath or !File.zero? yumpath
+      File.exist? yumpath and !File.zero? yumpath
   end
 end
 
 Facter.add('yum_datadog_legacy_repo') do
   setcode do
       yumpath = '/etc/yum.repos.d/datadog.repo'
-      File.exist? yumpath  or !File.zero? yumpath
+      File.exist? yumpath and !File.zero? yumpath
   end
 end


### PR DESCRIPTION
The factor check for old legacy datadag repo was incorrect and would always return true if a file exists yet was empty. This results in one Puppet run removing the agent, then the next Puppet run adding it again.

Reproducing:
1. Use Amazon Linux with existing Datadog 5 agent installed from 1.x Puppet module.
2. Upgrade to this new Puppet module
3. Apply Puppet multiple times. It will alternate between removing vs reinstalling the agent.
4. Cry
5. Submit fix to Datadog team to help others 
