### PR TITLE
Hacky Bug Fix to support Amazon Linux and Datadog agent 6

### DIFF
--- a/manifests/redhat/agent6.pp
+++ b/manifests/redhat/agent6.pp
@@ -68,6 +68,7 @@ class datadog_agent::redhat::agent6(
     enable    => $service_enable,
     hasstatus => false,
     pattern   => 'dd-agent',
+    provider  => 'upstart', # Needed for Amazon Linux
     require   => Package[$datadog_agent::params::package_name],
   }
 


### PR DESCRIPTION
This isn't a good fix. Submitting this not as a PR intending to be merged, but as a discussion point for how to fix this problem.


The problem is that Amazon Linux doesn't have systemd, but it does have Upstart. The Datadog RPM installs an upstart configuration, but Puppet tries to use the service command to start/stop/status the service which fails on Amazon Linux.

By setting the provider to Upstart, we can ensure that on Amazon Linux Puppet is able to start the agent using Upstart correctly.

Personally I'd consider this a bug in Amazon Linux really, but it's going to fix itself when people move to Amazon Linux 2 that was recently released which now moves to using systemd.

I believe this might also be an issue for RHEL 6 which also pre-dates systemd and ships with a weird upstart-sysvinit hybrid.

Ideal fix would be setting the provider to upstart for RHEL 6 and Amazon Linux 1, and systemd for RHEL 7 and Amazon Linux 2.... Leaving this as an exercise to the Datadog team since I only run Amazon Linux 1 right now and thus this hacky fix was more than enough to solve my problem.