### PR TITLE
[php-fpm] Add a parameter for ping_reply

### DIFF
--- a/manifests/integrations/php_fpm.pp
+++ b/manifests/integrations/php_fpm.pp
@@ -9,6 +9,9 @@
 #   $ping_url
 #        URL to get a reliable check of the FPM pool. Default: http://localhost/ping
 #
+#   $ping_reply
+#        Expected response from ping_url. Default: pong
+#
 #   $tags
 #        Optional array of tags
 #
@@ -23,6 +26,7 @@
 class datadog_agent::integrations::php_fpm(
   $status_url       = 'http://localhost/status',
   $ping_url         = 'http://localhost/ping',
+  $ping_reply       = 'pong',
   $http_host        = undef,
   $tags             = [],
   $instances        = undef
@@ -34,6 +38,7 @@ class datadog_agent::integrations::php_fpm(
       'http_host' => $http_host,
       'status_url' => $status_url,
       'ping_url' => $ping_url,
+      'ping_reply' => $ping_reply,
       'tags' => $tags,
     }]
   } else {

--- a/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
+++ b/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
@@ -54,7 +54,7 @@ describe 'datadog_agent::integrations::php_fpm' do
         }}
         it { should contain_file(conf_file).with_content(/http_host: php_fpm_server/) }
         it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/fpm_status/) }
-        it { should contain_file(conf_file).with_content(/ping_reply: success/)
+        it { should contain_file(conf_file).with_content(/ping_reply: success/) }
         it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/fpm_ping/) }
       end
 

--- a/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
+++ b/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
@@ -31,25 +31,30 @@ describe 'datadog_agent::integrations::php_fpm' do
       context 'with default parameters' do
         it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/status/) }
         it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/ping/) }
+        it { should contain_file(conf_file).with_content(/ping_reply: pong/) }
       end
 
       context 'with parameters set' do
         let(:params) {{
           status_url: 'http://localhost/fpm_status',
           ping_url: 'http://localhost/fpm_ping',
+          ping_reply: 'success',
         }}
         it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/fpm_status/) }
         it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/fpm_ping/) }
+        it { should contain_file(conf_file).with_content(/ping_reply: success/) }
       end
 
       context 'with http_host set' do
         let(:params) {{
           status_url: 'http://localhost/fpm_status',
           ping_url: 'http://localhost/fpm_ping',
+          ping_reply: 'success',
           http_host: 'php_fpm_server',
         }}
         it { should contain_file(conf_file).with_content(/http_host: php_fpm_server/) }
         it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/fpm_status/) }
+        it { should contain_file(conf_file).with_content(/ping_reply: success/)
         it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/fpm_ping/) }
       end
 
@@ -63,13 +68,16 @@ describe 'datadog_agent::integrations::php_fpm' do
             {
               'status_url'   => 'http://localhost/b/fpm_status',
               'ping_url'   => 'http://localhost/b/fpm_ping',
+              'ping_reply' => 'success',
             },
           ]
         }}
         it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/a\/fpm_status/) }
         it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/a\/fpm_ping/) }
+        it { should contain_file(conf_file).with_content(/ping_reply: pong/) }
         it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/b\/fpm_status/) }
         it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/b\/fpm_ping/) }
+        it { should contain_file(conf_file).with_content(/ping_reply: success/) }
       end
     end
   end

--- a/templates/agent-conf.d/php_fpm.yaml.erb
+++ b/templates/agent-conf.d/php_fpm.yaml.erb
@@ -10,7 +10,7 @@ instances:
     # Get a reliable service check of your FPM pool with that one
     ping_url: <%= instance['ping_url'] %>
     # Set the expected reply to the ping.
-    ping_reply: pong
+    ping_reply: <%= instance['ping_reply'] ? instance['ping_reply'] : 'pong' %>
     <%- if instance['http_host'] -%>
     # Set http host header
     http_host: <%= instance['http_host'] %>


### PR DESCRIPTION
Add ping_reply as a parameter to the php_fpm integration. Defaults to pong if not provided as specified in https://github.com/DataDog/integrations-core/tree/master/php_fpm#configuration.

For backwards compatibility check if the parameter is set with a ternary operator in the .erb file:
```
ping_reply: <%= instance['ping_reply'] ? instance['ping_reply'] : 'pong' %>
```