### PR TITLE
Bugfix process check

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -497,7 +497,7 @@ class datadog_agent(
     # lint:endignore
     $base_extra_config = {
         'apm_config' => { 'apm_enabled' => $apm_enabled },
-        'process_config' => { 'process_enabled' => $process_enabled_str },
+        'process_config' => { 'enabled' => $process_enabled_str },
     }
     $extra_config = deep_merge($base_extra_config, $agent6_extra_options)
 

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -897,7 +897,7 @@ describe 'datadog_agent' do
               'content' => /^process_config:\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ process_enabled: 'true'\n/,
+              'content' => /^\ \ enabled: 'true'\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ foo: bar\n/,
@@ -911,7 +911,7 @@ describe 'datadog_agent' do
                   :process_enabled => true,
                   :agent6_extra_options => {
                       'process_config' => {
-                          'process_enabled' => 'disabled',
+                          'enabled' => 'disabled',
                           'foo' => 'bar',
                           'bar' => 'haz',
                       }
@@ -921,7 +921,7 @@ describe 'datadog_agent' do
               'content' => /^process_config:\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ process_enabled: disabled\n/,
+              'content' => /^\ \ enabled: disabled\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ foo: bar\n/,

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -846,7 +846,7 @@ describe 'datadog_agent' do
               'content' => /^process_config:\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ process_enabled: disabled\n/,
+              'content' => /^\ \ enabled: disabled\n/,
               )}
             end
           end


### PR DESCRIPTION
The module is incorrectly setting the config for enabling the process integration. The correct config is 
```
process_config:
  enabled: 'true'```
While the module is currently putting
```
process_config:
  process_enabled: 'true'
```

Let me know if I need to make any additional changes