### PR TITLE
Render port number in mysql.yaml

### DIFF
--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -13,7 +13,7 @@ instances:
 <% if instance['password'] and instance['password'] != :undef -%>
     pass: <%= instance['password'] %>
 <% end -%>
-<% if instance['port'] and instance['port'] != :undef %>
+<% if instance['port'] and instance['port'] != :undef -%>
     port: <%= instance['port'] %>
 <% end -%>
 <% if instance['sock'] and instance['sock'] != :undef -%>

--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -13,8 +13,8 @@ instances:
 <% if instance['password'] and instance['password'] != :undef -%>
     pass: <%= instance['password'] %>
 <% end -%>
-<% if instance['port'] -%>
-    port: <%= instance['port'] and instance['port'] != :undef %>
+<% if instance['port'] and instance['port'] != :undef %>
+    port: <%= instance['port'] %>
 <% end -%>
 <% if instance['sock'] and instance['sock'] != :undef -%>
     sock: <%= instance['sock'] %>


### PR DESCRIPTION
The current template renders `true` if a port is provided instead of the actual port number. e.g:

```
instances:
  - server: "127.0.0.1"
    user: datadog
    port: true
```