### PR TITLE
Moises.botarro/adding new config fields for process agent scrubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Here are some of the other variables that be set in the datadog_agent class to c
 | agent5_enable | boolean to install agent5 and override agent6 default | 
 | apm_enabled | boolean to enable the APM agent; defaults to true | 
 | process_enabled | boolean to enable the process agent; defaults to true | 
+| scrub_args | boolean to enable the process cmdline scrubbing; defaults to true |
+| custom_sensitive_words| an array to add more words beyond the default ones used by the scrubbing feature; defaults to [] |
 | agent6_extra_options | hash to provide additional configuration options to agent6. | 
 
 _NOTE: `agent6_extra_options` may be used to provide a fine grain control of additional agent6 config options. A deep merge is performed that may override options provided in the `datadog_agent` class parameters_

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -516,9 +516,9 @@ class datadog_agent(
     $base_extra_config = {
         'apm_config' => { 'apm_enabled' => $apm_enabled },
         'process_config' => {
-          'process_enabled' => $process_enabled_str
-          'scrub_args' => $scrub_args
-          'custom_sensitive_words' => $custom_sensitive_words
+          'process_enabled' => $process_enabled_str,
+          'scrub_args' => $scrub_args,
+          'custom_sensitive_words' => $custom_sensitive_words,
         },
     }
     $extra_config = deep_merge($base_extra_config, $agent6_extra_options)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,6 +166,12 @@
 #   $process_enabled
 #       String to enable the process/container agent
 #       Boolean. Default: false
+#   $scrub_args
+#       Boolean to enable or disable the process cmdline scrubbing by the process-agent
+#       Boolean. Default: true
+#   $custom_sensitive_words
+#       Array to add more words to be used on the process cdmline scrubbing by the process-agent
+#       Array. Default: []
 #
 # Actions:
 #
@@ -262,6 +268,8 @@ class datadog_agent(
   $apm_enabled = $datadog_agent::params::apm_default_enabled,
   $apm_env = '',
   $process_enabled = $datadog_agent::params::process_default_enabled,
+  $scrub_args = $datadog_agent::params::process_default_scrub_args,
+  $custom_sensitive_words = $datadog_agent::params::process_default_custom_words,
   Hash[String[1], Data] $agent6_extra_options = {},
   $agent5_repo_uri = $datadog_agent::params::agent5_default_repo,
   $agent6_repo_uri = $datadog_agent::params::agent6_default_repo,
@@ -341,6 +349,8 @@ class datadog_agent(
   validate_legacy(Boolean, 'validate_bool', $agent5_enable)
   validate_legacy(String, 'validate_string', $apm_env)
   validate_legacy(Boolean, 'validate_bool', $process_enabled)
+  validate_legacy(Boolean, 'validate_bool', $scrub_args)
+  validate_legacy(Array, 'validate_array', $custom_sensitive_words)
   validate_legacy(String, 'validate_string', $agent5_repo_uri)
   validate_legacy(String, 'validate_string', $agent6_repo_uri)
   validate_legacy(String, 'validate_string', $apt_release)
@@ -490,6 +500,14 @@ class datadog_agent(
         order   => '07',
       }
     }
+
+    if ($process_enabled == true) {
+      concat::fragment{ 'datadog process agent footer':
+        target  => '/etc/dd-agent/datadog.conf',
+        content => template('datadog_agent/datadog_process_footer.conf.erb'),
+        order   => '08',
+      }
+    }
   } else {
 
     # lint:ignore:quoted_booleans
@@ -497,7 +515,11 @@ class datadog_agent(
     # lint:endignore
     $base_extra_config = {
         'apm_config' => { 'apm_enabled' => $apm_enabled },
-        'process_config' => { 'process_enabled' => $process_enabled_str },
+        'process_config' => {
+          'process_enabled' => $process_enabled_str
+          'scrub_args' => $scrub_args
+          'custom_sensitive_words' => $custom_sensitive_words
+        },
     }
     $extra_config = deep_merge($base_extra_config, $agent6_extra_options)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,19 +15,21 @@
 # Sample Usage:
 #
 class datadog_agent::params {
-  $agent5_enable           = false
-  $conf_dir                = '/etc/dd-agent/conf.d'
-  $conf6_dir               = '/etc/datadog-agent/conf.d'
-  $dd_user                 = 'dd-agent'
-  $dd_group                = 'root'
-  $dd_groups               = undef
-  $package_name            = 'datadog-agent'
-  $service_name            = 'datadog-agent'
-  $dogapi_version          = 'installed'
-  $conf_dir_purge          = false
-  $apt_default_release     = 'stable'
-  $apm_default_enabled     = false
-  $process_default_enabled = false
+  $agent5_enable                  = false
+  $conf_dir                       = '/etc/dd-agent/conf.d'
+  $conf6_dir                      = '/etc/datadog-agent/conf.d'
+  $dd_user                        = 'dd-agent'
+  $dd_group                       = 'root'
+  $dd_groups                      = undef
+  $package_name                   = 'datadog-agent'
+  $service_name                   = 'datadog-agent'
+  $dogapi_version                 = 'installed'
+  $conf_dir_purge                 = false
+  $apt_default_release            = 'stable'
+  $apm_default_enabled            = false
+  $process_default_enabled        = false
+  $process_default_scrub_args     = true
+  $process_default_custom_words   = []
 
   case $::operatingsystem {
     'Ubuntu','Debian' : {

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -308,7 +308,7 @@ describe 'datadog_agent' do
                 )}
             end
             context 'with skip_ssl_validation set to true' do
-                let(:params) {{ :skip_ssl_validation => true, 
+                let(:params) {{ :skip_ssl_validation => true,
                                 :agent5_enable => true,
                 }}
                 it { should contain_concat__fragment('datadog header').with(
@@ -556,7 +556,7 @@ describe 'datadog_agent' do
                 )}
             end
             context 'with ganglia_host set to localhost and ganglia_port set to 12345' do
-                let(:params) {{ :ganglia_host => 'testhost', 
+                let(:params) {{ :ganglia_host => 'testhost',
                                 :ganglia_port => '12345',
                                 :agent5_enable => true,
                 }}
@@ -691,10 +691,10 @@ describe 'datadog_agent' do
                 )}
             end
             context 'with service_discovery enabled' do
-                let(:params) {{ :service_discovery_backend  => 'docker', 
-                                :sd_config_backend          => 'etcd', 
-                                :sd_backend_host            => 'localhost', 
-                                :sd_backend_port            => '8080', 
+                let(:params) {{ :service_discovery_backend  => 'docker',
+                                :sd_config_backend          => 'etcd',
+                                :sd_backend_host            => 'localhost',
+                                :sd_backend_port            => '8080',
                                 :sd_jmx_enable              =>  true,
                                 :agent5_enable => true,
                 }}
@@ -773,7 +773,46 @@ describe 'datadog_agent' do
                 )}
             end
 
+            context 'with data scrubbing disabled' do
+              let(:params) {{
+                  :process_enabled => true,
+                  :agent5_enable => true,
+                  :scrub_args: false
+              }}
+              it { should contain_concat__fragment('datadog process agent footer').with(
+                'content' => /^process_agent_enabled: true\n/,
+              )}
+              it { should contain_concat__fragment('datadog process agent footer').with(
+                'content' => /^[process.config]\n/,
+              )}
+              it { should contain_concat__fragment('datadog process agent footer').with(
+                'content' => /^scrub_args: false\n/,
+              )}
+              it { should contain_concat__fragment('datadog process agent footer').with(
+                'content' => /^custom_sensitive_words: \n/,
+              )}
             end
+
+            context 'with data scrubbing enabled with custom sensitive_words' do
+              let(:params) {{
+                  :process_enabled => true,
+                  :agent5_enable => true,
+                  :custom_sensitive_words: ['consul_token','dd_key']
+              }}
+              it { should contain_concat__fragment('datadog process agent footer').with(
+                'content' => /^process_agent_enabled: true\n/,
+              )}
+              it { should contain_concat__fragment('datadog process agent footer').with(
+                'content' => /^[process.config]\n/,
+              )}
+              it { should contain_concat__fragment('datadog process agent footer').with(
+                'content' => /^scrub_args: true\n/,
+              )}
+              it { should contain_concat__fragment('datadog process agent footer').with(
+                'content' => /^custom_sensitive_words: consul_token,dd_key\n/,
+              )}
+            end
+
         end
 
         if DEBIAN_OS.include?(operatingsystem)
@@ -847,6 +886,12 @@ describe 'datadog_agent' do
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ process_enabled: disabled\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ scrub_args: true\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ custom_sensitive_words:\n/,
               )}
             end
           end
@@ -931,6 +976,51 @@ describe 'datadog_agent' do
               )}
             end
           end
+
+          context 'with data scrubbing custom options' do
+            context 'with data scrubbing disabled' do
+              let(:params) {{
+                  :process_enabled => true
+                  :scrub_args => false
+              }}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^process_config:\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ process_enabled: true\n/,
+              )}
+              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ scrub_args: false\n/,
+              )}
+              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ custom_sensitive_words:\n/,
+              )}
+            end
+
+            context 'with data scrubbing enabled with custom sensitive_words' do
+              let(:params) {{
+                  :process_enabled => true
+                  :custom_sensitive_words => ['consul_token','dd_key']
+              }}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^process_config:\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ process_enabled: true\n/,
+              )}
+              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ scrub_args: true\n/,
+              )}
+              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ -\ consul_token\n/,
+              )}
+              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ -\ dd_key\n/,
+              )}
+
+            end
+          end
+
         end
       end
     end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -777,7 +777,7 @@ describe 'datadog_agent' do
               let(:params) {{
                   :process_enabled => true,
                   :agent5_enable => true,
-                  :scrub_args: false
+                  :scrub_args => false
               }}
               it { should contain_concat__fragment('datadog process agent footer').with(
                 'content' => /^process_agent_enabled: true\n/,
@@ -797,7 +797,7 @@ describe 'datadog_agent' do
               let(:params) {{
                   :process_enabled => true,
                   :agent5_enable => true,
-                  :custom_sensitive_words: ['consul_token','dd_key']
+                  :custom_sensitive_words => ['consul_token','dd_key']
               }}
               it { should contain_concat__fragment('datadog process agent footer').with(
                 'content' => /^process_agent_enabled: true\n/,
@@ -813,6 +813,7 @@ describe 'datadog_agent' do
               )}
             end
 
+          end
         end
 
         if DEBIAN_OS.include?(operatingsystem)
@@ -980,7 +981,7 @@ describe 'datadog_agent' do
           context 'with data scrubbing custom options' do
             context 'with data scrubbing disabled' do
               let(:params) {{
-                  :process_enabled => true
+                  :process_enabled => true,
                   :scrub_args => false
               }}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
@@ -989,17 +990,17 @@ describe 'datadog_agent' do
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ process_enabled: true\n/,
               )}
-              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ scrub_args: false\n/,
               )}
-              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ custom_sensitive_words:\n/,
               )}
             end
 
             context 'with data scrubbing enabled with custom sensitive_words' do
               let(:params) {{
-                  :process_enabled => true
+                  :process_enabled => true,
                   :custom_sensitive_words => ['consul_token','dd_key']
               }}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
@@ -1008,19 +1009,18 @@ describe 'datadog_agent' do
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ process_enabled: true\n/,
               )}
-              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ scrub_args: true\n/,
               )}
-              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ -\ consul_token\n/,
               )}
-              if { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ -\ dd_key\n/,
               )}
 
             end
           end
-
         end
       end
     end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -779,11 +779,11 @@ describe 'datadog_agent' do
                   :agent5_enable => true,
                   :scrub_args => false
               }}
-              it { should contain_concat__fragment('datadog process agent footer').with(
+              it { should contain_concat__fragment('datadog footer').with(
                 'content' => /^process_agent_enabled: true\n/,
               )}
               it { should contain_concat__fragment('datadog process agent footer').with(
-                'content' => /^[process.config]\n/,
+                'content' => /^\[process.config\]\n/,
               )}
               it { should contain_concat__fragment('datadog process agent footer').with(
                 'content' => /^scrub_args: false\n/,
@@ -799,11 +799,11 @@ describe 'datadog_agent' do
                   :agent5_enable => true,
                   :custom_sensitive_words => ['consul_token','dd_key']
               }}
-              it { should contain_concat__fragment('datadog process agent footer').with(
+              it { should contain_concat__fragment('datadog footer').with(
                 'content' => /^process_agent_enabled: true\n/,
               )}
               it { should contain_concat__fragment('datadog process agent footer').with(
-                'content' => /^[process.config]\n/,
+                'content' => /^\[process.config\]\n/,
               )}
               it { should contain_concat__fragment('datadog process agent footer').with(
                 'content' => /^scrub_args: true\n/,
@@ -892,7 +892,7 @@ describe 'datadog_agent' do
               'content' => /^\ \ scrub_args: true\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ custom_sensitive_words:\n/,
+              'content' => /^\ \ custom_sensitive_words: \[\]\n/,
               )}
             end
           end
@@ -988,13 +988,13 @@ describe 'datadog_agent' do
               'content' => /^process_config:\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ process_enabled: true\n/,
+              'content' => /^\ \ process_enabled: 'true'\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ scrub_args: false\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ custom_sensitive_words:\n/,
+              'content' => /^\ \ custom_sensitive_words: \[\]\n/,
               )}
             end
 
@@ -1007,7 +1007,7 @@ describe 'datadog_agent' do
               'content' => /^process_config:\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ process_enabled: true\n/,
+              'content' => /^\ \ process_enabled: 'true'\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ scrub_args: true\n/,

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -988,7 +988,7 @@ describe 'datadog_agent' do
               'content' => /^process_config:\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ process_enabled: 'true'\n/,
+              'content' => /^\ \ enabled: 'true'\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ scrub_args: false\n/,
@@ -1007,7 +1007,7 @@ describe 'datadog_agent' do
               'content' => /^process_config:\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ process_enabled: 'true'\n/,
+              'content' => /^\ \ enabled: 'true'\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ scrub_args: true\n/,

--- a/templates/datadog_process_footer.conf.erb
+++ b/templates/datadog_process_footer.conf.erb
@@ -1,0 +1,5 @@
+<% if @process_enabled -%>
+[process.config]
+scrub_args: <%= @scrub_args %>
+custom_sensitive_words: <%= @custom_sensitive_words.join(',') %>
+<% end -%>


### PR DESCRIPTION
The fields used by the process-agent's new feature, process args scrubbing, have been added on the templates for datadog.conf and datadog.yaml files. 

* A new footer file's been created to handle the process-agent config section on the datadog.conf file. 
* The default values have also been set.
* Tests have been added on the datadog_spec file.