### PR TITLE
Remove indentation of the pgbouncer template to match the needed format of configuration file

### DIFF
--- a/templates/agent-conf.d/pgbouncer.yaml.erb
+++ b/templates/agent-conf.d/pgbouncer.yaml.erb
@@ -10,14 +10,14 @@ instances:
     port: <%= @port %>
     username: <%= @username %>
     password: <%= @password %>
-  <% if @tags and ! @tags.empty? -%>
+<% if @tags and ! @tags.empty? -%>
     tags:
-    <%- Array(@tags).each do |tag| -%>
-      <%- if tag != '' -%>
+  <%- Array(@tags).each do |tag| -%>
+    <%- if tag != '' -%>
       - <%= tag %>
-      <%- end -%>
     <%- end -%>
-  <% end -%>
+  <%- end -%>
+<% end -%>
 <%- else -%>
 <%= {'init_config'=>nil, 'instances'=>@pgbouncers}.to_yaml %>
 <%- end -%>


### PR DESCRIPTION
With the current template, the output of the configuration is wrong indented if the tags field was set

Output Example:

```
init_config:

instances:
  - host: localhost
    port: 5678
    username: datadog
    password: some-password
      tags:
      - dbinstanceidentifier:some-instance-identifier
```

In this scenario the pgbouncer integration doesn't work, when run `datadog-agent status` I get the following:
```
Config Errors
  ==============
    pgbouncer
    ---------
      yaml: line 9: mapping values are not allowed in this context
```

With this fix, the format will be the following

```
init_config:

instances:
  - host: localhost
    port: 5678
    username: datadog
    password: some-interesting-password
    tags:
      - dbinstanceidentifier:some-instance-identifier
```

Making the integration works if tags are specified.