### PR TITLE
fix issue #425 Service cannot start on old amazon linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,5 +44,12 @@ class datadog_agent::params {
     }
     default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
   }
+  if $::operatingsystem == 'Amazon' {
+    $service_provider = 'upstart'
+  }
+  else {
+    $service_provider               = undef
+  }
+
 
 }

--- a/manifests/redhat/agent6.pp
+++ b/manifests/redhat/agent6.pp
@@ -68,6 +68,7 @@ class datadog_agent::redhat::agent6(
     enable    => $service_enable,
     hasstatus => false,
     pattern   => 'dd-agent',
+    provider  => $datadog_agent::params::service_provider,
     require   => Package[$datadog_agent::params::package_name],
   }
 


### PR DESCRIPTION
fix issue #425 Service cannot start on old amazon linux
Implement suggested fix, add a provider and override just for amazon linux.