### PR TITLE
Fix duplicate declaration ruby class

### DIFF
--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -32,7 +32,7 @@ class datadog_agent::reports(
     }
   }
 
-  if (! defined(Package['rubygems'])) {
+  if (! defined(Class['ruby'])) {
     # Ensure rubygems is installed
     class { 'ruby':
       rubygems_update => false


### PR DESCRIPTION
The issue is when I try to use the official ruby module with reports in puppet-datadog-agent module on the same server. Ruby class in defined in both modules and puppet fail for duplicate declaration.