### PR TITLE
Feature/apm non local traffic

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -349,7 +349,7 @@ class datadog_agent(
   validate_legacy(Boolean, 'validate_bool', $sd_jmx_enable)
   validate_legacy(String, 'validate_string', $consul_token)
   validate_legacy(Boolean, 'validate_bool', $apm_enabled)
-  validate_legacy(Bookean, 'validate_bool', $apm_non_local_traffic)
+  validate_legacy(Boolean, 'validate_bool', $apm_non_local_traffic)
   validate_legacy(Boolean, 'validate_bool', $agent5_enable)
   validate_legacy(String, 'validate_string', $apm_env)
   validate_legacy(Boolean, 'validate_bool', $process_enabled)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -518,7 +518,7 @@ class datadog_agent(
     $process_enabled_str = $process_enabled ? { true => 'true' , default => 'disabled' }
     # lint:endignore
     $base_extra_config = {
-        'apm_config' => { 
+        'apm_config' => {
           'apm_enabled'           => $apm_enabled,
           'env'                   => $apm_env,
           'apm_non_local_traffic' => $apm_non_local_traffic

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -520,7 +520,7 @@ class datadog_agent(
     $base_extra_config = {
         'apm_config' => { 
           'apm_enabled'           => $apm_enabled,
-          'apm_env'               => $apm_env,
+          'env'               => $apm_env,
           'apm_non_local_traffic' => $apm_non_local_traffic
         },
         'process_config' => {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,7 +162,7 @@
 #       Boolean. Default: false
 #   $apm_env
 #       String defining the environment for the APM traces
-#       String. Default: empty
+#       String. Default: non
 #   $apm_non_local_traffic
 #       Accept non local apm traffic. Defaults to false.
 #   $process_enabled
@@ -268,7 +268,7 @@ class datadog_agent(
   $dd_group = $datadog_agent::params::dd_group,
   $dd_groups = $datadog_agent::params::dd_groups,
   $apm_enabled = $datadog_agent::params::apm_default_enabled,
-  $apm_env = '',
+  $apm_env = 'none',
   $apm_non_local_traffic = false,
   $process_enabled = $datadog_agent::params::process_default_enabled,
   $scrub_args = $datadog_agent::params::process_default_scrub_args,
@@ -520,7 +520,7 @@ class datadog_agent(
     $base_extra_config = {
         'apm_config' => { 
           'apm_enabled'           => $apm_enabled,
-          'env'               => $apm_env,
+          'env'                   => $apm_env,
           'apm_non_local_traffic' => $apm_non_local_traffic
         },
         'process_config' => {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -497,7 +497,7 @@ class datadog_agent(
       }
     }
 
-    if ($apm_enabled == true) and ($apm_env != '') {
+    if ($apm_enabled == true) and ($apm_env != 'none') {
       concat::fragment{ 'datadog apm footer':
         target  => '/etc/dd-agent/datadog.conf',
         content => template('datadog_agent/datadog_apm_footer.conf.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,6 +163,8 @@
 #   $apm_env
 #       String defining the environment for the APM traces
 #       String. Default: empty
+#   $apm_non_local_traffic
+#       Accept non local apm traffic. Defaults to false.
 #   $process_enabled
 #       String to enable the process/container agent
 #       Boolean. Default: false
@@ -267,6 +269,7 @@ class datadog_agent(
   $dd_groups = $datadog_agent::params::dd_groups,
   $apm_enabled = $datadog_agent::params::apm_default_enabled,
   $apm_env = '',
+  $apm_non_local_traffic = false,
   $process_enabled = $datadog_agent::params::process_default_enabled,
   $scrub_args = $datadog_agent::params::process_default_scrub_args,
   $custom_sensitive_words = $datadog_agent::params::process_default_custom_words,
@@ -346,6 +349,7 @@ class datadog_agent(
   validate_legacy(Boolean, 'validate_bool', $sd_jmx_enable)
   validate_legacy(String, 'validate_string', $consul_token)
   validate_legacy(Boolean, 'validate_bool', $apm_enabled)
+  validate_legacy(Bookean, 'validate_bool', $apm_non_local_traffic)
   validate_legacy(Boolean, 'validate_bool', $agent5_enable)
   validate_legacy(String, 'validate_string', $apm_env)
   validate_legacy(Boolean, 'validate_bool', $process_enabled)
@@ -514,7 +518,11 @@ class datadog_agent(
     $process_enabled_str = $process_enabled ? { true => 'true' , default => 'disabled' }
     # lint:endignore
     $base_extra_config = {
-        'apm_config' => { 'apm_enabled' => $apm_enabled },
+        'apm_config' => { 
+          'apm_enabled'           => $apm_enabled,
+          'apm_env'               => $apm_env,
+          'apm_non_local_traffic' => $apm_non_local_traffic
+        },
         'process_config' => {
           'enabled' => $process_enabled_str,
           'scrub_args' => $scrub_args,

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -883,6 +883,9 @@ describe 'datadog_agent' do
               'content' => /^\ \ apm_enabled: false\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ apm_non_local_traffic: false\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^process_config:\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
@@ -920,6 +923,23 @@ describe 'datadog_agent' do
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^\ \ bar: haz\n/,
+              )}
+            end
+            
+            context 'with APM non local traffic enabled' do
+              let(:params) {{
+                  :apm_enabled => true,
+                  :apm_env => 'foo',
+                  :apm_non_local_traffic => true,
+              }}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^apm_config:\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ apm_enabled: true\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ apm_non_local_traffic: true\n/,
               )}
             end
             context 'with extra_options and Process enabled' do


### PR DESCRIPTION
This PR adds the ability to set the apm config option to accept non local traffic as well as the apm_env in the agent6 configuration.

Please let me know if you'd like to request any changes.

Thanks!