### PR TITLE
Add a service provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -277,6 +277,7 @@ class datadog_agent(
   $agent5_repo_uri = $datadog_agent::params::agent5_default_repo,
   $agent6_repo_uri = $datadog_agent::params::agent6_default_repo,
   $apt_release = $datadog_agent::params::apt_default_release,
+  $service_provider = 'service',
 ) inherits datadog_agent::params {
 
   # Allow ports to be passed as integers or strings.
@@ -392,6 +393,7 @@ class datadog_agent(
           location              => $agent5_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
+          service_provider      => $service_provider,
         }
       } else {
         class { 'datadog_agent::ubuntu::agent6':
@@ -400,23 +402,26 @@ class datadog_agent(
           location              => $agent6_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
+          service_provider      => $service_provider,
         }
       }
     }
     'RedHat','CentOS','Fedora','Amazon','Scientific' : {
       if $agent5_enable {
         class { 'datadog_agent::redhat::agent5':
-          baseurl        => $agent5_repo_uri,
-          manage_repo    => $manage_repo,
-          service_ensure => $service_ensure,
-          service_enable => $service_enable,
+          baseurl          => $agent5_repo_uri,
+          manage_repo      => $manage_repo,
+          service_ensure   => $service_ensure,
+          service_enable   => $service_enable,
+          service_provider => $service_provider,
         }
       } else {
         class { 'datadog_agent::redhat::agent6':
-          baseurl        => $agent6_repo_uri,
-          manage_repo    => $manage_repo,
-          service_ensure => $service_ensure,
-          service_enable => $service_enable,
+          baseurl          => $agent6_repo_uri,
+          manage_repo      => $manage_repo,
+          service_ensure   => $service_ensure,
+          service_enable   => $service_enable,
+          service_provider => $service_provider,
         }
       }
     }

--- a/manifests/redhat/agent5.pp
+++ b/manifests/redhat/agent5.pp
@@ -1,4 +1,4 @@
-# Class: datadog_agent::redhat
+# Class: datadog_agent::redhat::agent5
 #
 # This class contains the DataDog agent installation mechanism for Red Hat derivatives
 #
@@ -21,6 +21,7 @@ class datadog_agent::redhat::agent5(
   String $agent_version = 'latest',
   String $service_ensure = 'running',
   Boolean $service_enable = true,
+  String $service_provider = 'redhat',
 ) inherits datadog_agent::params {
 
   validate_legacy('Boolean', 'validate_bool', $manage_repo)
@@ -95,6 +96,7 @@ class datadog_agent::redhat::agent5(
     hasstatus => false,
     pattern   => 'dd-agent',
     require   => Package[$datadog_agent::params::package_name],
+    provider  => $service_provider,
   }
 
 }

--- a/manifests/redhat/agent6.pp
+++ b/manifests/redhat/agent6.pp
@@ -10,6 +10,7 @@ class datadog_agent::redhat::agent6(
   String $agent_version = 'latest',
   String $service_ensure = 'running',
   Boolean $service_enable = true,
+  String $service_provider = 'redhat',
 ) inherits datadog_agent::params {
 
   validate_legacy('Boolean', 'validate_bool', $manage_repo)
@@ -69,6 +70,7 @@ class datadog_agent::redhat::agent6(
     hasstatus => false,
     pattern   => 'dd-agent',
     require   => Package[$datadog_agent::params::package_name],
+    provider  => $service_provider,
   }
 
 }

--- a/manifests/ubuntu/agent5.pp
+++ b/manifests/ubuntu/agent5.pp
@@ -1,4 +1,4 @@
-# Class: datadog_agent::ubuntu
+# Class: datadog_agent::ubuntu::agent5
 #
 # This class contains the DataDog agent installation mechanism for Ubuntu
 #
@@ -21,6 +21,7 @@ class datadog_agent::ubuntu::agent5(
   Boolean $skip_apt_key_trusting = false,
   String $service_ensure = 'running',
   Boolean $service_enable = true,
+  String $service_provider = 'ubuntu',
 ) inherits datadog_agent::params{
 
   ensure_packages(['apt-transport-https'])
@@ -85,5 +86,6 @@ class datadog_agent::ubuntu::agent5(
     hasstatus => false,
     pattern   => 'dd-agent',
     require   => Package[$datadog_agent::params::package_name],
+    provider  => $service_provider,
   }
 }

--- a/manifests/ubuntu/agent6.pp
+++ b/manifests/ubuntu/agent6.pp
@@ -12,6 +12,7 @@ class datadog_agent::ubuntu::agent6(
   $skip_apt_key_trusting = false,
   $service_ensure = 'running',
   $service_enable = true,
+  $service_provider = 'ubuntu',
 ) inherits datadog_agent::params {
 
   ensure_packages(['apt-transport-https'])
@@ -51,5 +52,6 @@ class datadog_agent::ubuntu::agent6(
     hasstatus => false,
     pattern   => 'dd-agent',
     require   => Package['datadog-agent'],
+    provider  => $service_provider,
   }
 }


### PR DESCRIPTION
This PR will allow you to specify a service `provider` in your manifests.

For example:

```
node "ip-127-0-0-1" {
    class { "datadog_agent":
        api_key => "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
        service_provider => 'upstart',
    }
}
```