### PR TITLE
[agents] allow provider service override

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :test do
 end
 
 group :development do
+  gem "fog-openstack", "0.1.25" if RUBY_VERSION < '2.2.0'
   gem "beaker-rspec"
   gem "beaker", '3.31.0'
   gem "guard-rake"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -285,6 +285,7 @@ class datadog_agent(
   $agent5_repo_uri = $datadog_agent::params::agent5_default_repo,
   $agent6_repo_uri = $datadog_agent::params::agent6_default_repo,
   $apt_release = $datadog_agent::params::apt_default_release,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
   # Allow ports to be passed as integers or strings.
@@ -399,6 +400,7 @@ class datadog_agent(
         class { 'datadog_agent::ubuntu::agent5':
           service_ensure        => $service_ensure,
           service_enable        => $service_enable,
+          service_provider      => $service_provider,
           location              => $agent5_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
@@ -407,6 +409,7 @@ class datadog_agent(
         class { 'datadog_agent::ubuntu::agent6':
           service_ensure        => $service_ensure,
           service_enable        => $service_enable,
+          service_provider      => $service_provider,
           location              => $agent6_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
@@ -416,17 +419,19 @@ class datadog_agent(
     'RedHat','CentOS','Fedora','Amazon','Scientific' : {
       if $agent5_enable {
         class { 'datadog_agent::redhat::agent5':
-          baseurl        => $agent5_repo_uri,
-          manage_repo    => $manage_repo,
-          service_ensure => $service_ensure,
-          service_enable => $service_enable,
+          baseurl          => $agent5_repo_uri,
+          manage_repo      => $manage_repo,
+          service_ensure   => $service_ensure,
+          service_enable   => $service_enable,
+          service_provider => $service_provider,
         }
       } else {
         class { 'datadog_agent::redhat::agent6':
-          baseurl        => $agent6_repo_uri,
-          manage_repo    => $manage_repo,
-          service_ensure => $service_ensure,
-          service_enable => $service_enable,
+          baseurl          => $agent6_repo_uri,
+          manage_repo      => $manage_repo,
+          service_ensure   => $service_ensure,
+          service_enable   => $service_enable,
+          service_provider => $service_provider,
         }
       }
     }

--- a/manifests/redhat/agent5.pp
+++ b/manifests/redhat/agent5.pp
@@ -21,6 +21,7 @@ class datadog_agent::redhat::agent5(
   String $agent_version = 'latest',
   String $service_ensure = 'running',
   Boolean $service_enable = true,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
   validate_legacy('Boolean', 'validate_bool', $manage_repo)
@@ -89,12 +90,23 @@ class datadog_agent::redhat::agent5(
     ensure  => $agent_version,
   }
 
-  service { $datadog_agent::params::service_name:
-    ensure    => $service_ensure,
-    enable    => $service_enable,
-    hasstatus => false,
-    pattern   => 'dd-agent',
-    require   => Package[$datadog_agent::params::package_name],
+  if $service_provider {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
+  } else {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
   }
 
 }

--- a/manifests/redhat/agent6.pp
+++ b/manifests/redhat/agent6.pp
@@ -10,6 +10,7 @@ class datadog_agent::redhat::agent6(
   String $agent_version = 'latest',
   String $service_ensure = 'running',
   Boolean $service_enable = true,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
   validate_legacy('Boolean', 'validate_bool', $manage_repo)
@@ -63,12 +64,23 @@ class datadog_agent::redhat::agent6(
     ensure  => $agent_version,
   }
 
-  service { $datadog_agent::params::service_name:
-    ensure    => $service_ensure,
-    enable    => $service_enable,
-    hasstatus => false,
-    pattern   => 'dd-agent',
-    require   => Package[$datadog_agent::params::package_name],
+  if $service_provider {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
+  } else {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
   }
 
 }

--- a/manifests/ubuntu/agent5.pp
+++ b/manifests/ubuntu/agent5.pp
@@ -21,6 +21,7 @@ class datadog_agent::ubuntu::agent5(
   Boolean $skip_apt_key_trusting = false,
   String $service_ensure = 'running',
   Boolean $service_enable = true,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params{
 
   ensure_packages(['apt-transport-https'])
@@ -79,11 +80,22 @@ class datadog_agent::ubuntu::agent5(
                 Exec['apt_update']],
   }
 
-  service { $datadog_agent::params::service_name:
-    ensure    => $service_ensure,
-    enable    => $service_enable,
-    hasstatus => false,
-    pattern   => 'dd-agent',
-    require   => Package[$datadog_agent::params::package_name],
+  if $service_provider {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
+  } else {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
   }
 }

--- a/manifests/ubuntu/agent6.pp
+++ b/manifests/ubuntu/agent6.pp
@@ -12,6 +12,7 @@ class datadog_agent::ubuntu::agent6(
   $skip_apt_key_trusting = false,
   $service_ensure = 'running',
   $service_enable = true,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
   ensure_packages(['apt-transport-https'])
@@ -45,11 +46,22 @@ class datadog_agent::ubuntu::agent6(
                 Exec['apt_update']],
   }
 
-  service { $datadog_agent::params::service_name:
-    ensure    => $service_ensure,
-    enable    => $service_enable,
-    hasstatus => false,
-    pattern   => 'dd-agent',
-    require   => Package['datadog-agent'],
+  if $service_provider {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package['datadog-agent'],
+    }
+  } else {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package['datadog-agent'],
+    }
   }
 }

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -28,6 +28,21 @@ describe 'datadog_agent::redhat::agent5' do
       should_not contain_yumrepo('datadog6')
     end
   end
+  context 'overriding provider' do
+    let(:params) {{
+      service_provider: 'upstart',
+    }}
+    it do
+      should contain_service('datadog-agent')\
+        .that_requires('package[datadog-agent]')
+    end
+    it do
+      should contain_service('datadog-agent').with(
+        'provider' => 'upstart',
+        'ensure' => 'running',
+      )
+    end
+  end
 
 
   # it should install the packages
@@ -74,6 +89,21 @@ describe 'datadog_agent::redhat::agent6' do
       should_not contain_yumrepo('datadog')
       should_not contain_yumrepo('datadog5')
       should_not contain_yumrepo('datadog6')
+    end
+  end
+  context 'overriding provider' do
+    let(:params) {{
+      service_provider: 'upstart',
+    }}
+    it do
+      should contain_service('datadog-agent')\
+        .that_requires('package[datadog-agent]')
+    end
+    it do
+      should contain_service('datadog-agent').with(
+        'provider' => 'upstart',
+        'ensure' => 'running',
+      )
     end
   end
 

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -813,6 +813,22 @@ describe 'datadog_agent' do
               )}
             end
 
+            context 'with service provider override' do
+              let(:params) {{
+                  :service_provider => 'upstart',
+              }}
+              it do
+                should contain_service('datadog-agent')\
+                  .that_requires('package[datadog-agent]')
+              end
+              it do
+                should contain_service('datadog-agent').with(
+                  'provider' => 'upstart',
+                  'ensure' => 'running',
+                )
+              end
+            end
+
           end
         end
 
@@ -899,7 +915,9 @@ describe 'datadog_agent' do
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^logs_enabled: false\n/,
-              'content' => /^\ \ container_collect_all: false\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^logs_config:\n\ \ container_collect_all: false\n/,
               )}
             end
           end
@@ -1051,8 +1069,26 @@ describe 'datadog_agent' do
               }}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^logs_enabled: true\n/,
-              'content' => /^\ \ container_collect_all: true\n/,
               )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^logs_config:\n\ \ container_collect_all: true\n/,
+              )}
+            end
+
+            context 'with service provider override' do
+              let(:params) {{
+                  :service_provider => 'upstart',
+              }}
+              it do
+                should contain_service('datadog-agent')\
+                  .that_requires('package[datadog-agent]')
+              end
+              it do
+                should contain_service('datadog-agent').with(
+                  'provider' => 'upstart',
+                  'ensure' => 'running',
+                )
+              end
             end
 
           end

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -45,6 +45,22 @@ describe 'datadog_agent::ubuntu::agent5' do
     should contain_service('datadog-agent')\
       .that_requires('package[datadog-agent]')
   end
+
+  context 'overriding provider' do
+    let(:params) {{
+      service_provider: 'upstart',
+    }}
+    it do
+      should contain_service('datadog-agent')\
+        .that_requires('package[datadog-agent]')
+    end
+    it do
+      should contain_service('datadog-agent').with(
+        'provider' => 'upstart',
+        'ensure' => 'running',
+      )
+    end
+  end
 end
 
 describe 'datadog_agent::ubuntu::agent6' do
@@ -92,5 +108,21 @@ describe 'datadog_agent::ubuntu::agent6' do
   it do
     should contain_service('datadog-agent')\
       .that_requires('package[datadog-agent]')
+  end
+
+  context 'overriding provider' do
+    let(:params) {{
+      service_provider: 'upstart',
+    }}
+    it do
+      should contain_service('datadog-agent')\
+        .that_requires('package[datadog-agent]')
+    end
+    it do
+      should contain_service('datadog-agent').with(
+        'provider' => 'upstart',
+        'ensure' => 'running',
+      )
+    end
   end
 end


### PR DESCRIPTION
This should help us address some of the issues we're experiencing installing the agent in some distros, Amazon in particular.