### PR TITLE
[agent6] fix hostname override tag support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -566,6 +566,7 @@ class datadog_agent(
     $_agent_config = {
       'api_key' => $api_key,
       'dd_url' => $dd_url,
+      'hostname' => $host,
       'cmd_port' => 5001,
       'conf_path' => $datadog_agent::params::conf6_dir,
       'enable_metadata_collection' => $collect_instance_metadata,

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -922,7 +922,18 @@ describe 'datadog_agent' do
             end
           end
 
-          context 'with apm_extra_config' do
+          context 'with modified defaults' do
+            context 'hostname override' do
+              let(:params) {{
+                  :host => 'my_custom_hostname',
+              }}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^hostname: my_custom_hostname\n/,
+              )}
+            end
+          end
+
+          context 'with additional agents config' do
             context 'with extra_options and APM enabled' do
               let(:params) {{
                   :apm_enabled => true,


### PR DESCRIPTION
long overdue fix for: https://github.com/DataDog/puppet-datadog-agent/issues/421

apologies for the delay, slipped under the radar.