### PR TITLE
[agent6] several improvements relevant to missing/deprecated options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -530,16 +530,16 @@ class datadog_agent(
   } else {
     # notify of broken params on agent6
     if $proxy_host {
-        notify { "Setting proxy_host will have no effect on agent6 please use agent6_extra_options to set your proxy": }
+        notify { 'Setting proxy_host will have no effect on agent6 please use agent6_extra_options to set your proxy': }
     }
     if $_proxy_port {
-        notify { "Setting proxy_port will have no effect on agent6 please use agent6_extra_options to set your proxy": }
+        notify { 'Setting proxy_port will have no effect on agent6 please use agent6_extra_options to set your proxy': }
     }
     if $proxy_user {
-        notify { "Setting proxy_user will have no effect on agent6 please use agent6_extra_options to set your proxy": }
+        notify { 'Setting proxy_user will have no effect on agent6 please use agent6_extra_options to set your proxy': }
     }
     if $proxy_password {
-        notify { "Setting proxy_password will have no effect on agent6 please use agent6_extra_options to set your proxy": }
+        notify { 'Setting proxy_password will have no effect on agent6 please use agent6_extra_options to set your proxy': }
     }
 
     # lint:ignore:quoted_booleans
@@ -561,7 +561,22 @@ class datadog_agent(
           'container_collect_all' => $container_collect_all,
         },
     }
-    $extra_config = deep_merge($base_extra_config, $agent6_extra_options)
+
+    if $statsd_forward_host != '' {
+        if $_statsd_forward_port != '' {
+            $statsd_forward_config = {
+              'statsd_forward_host' => $statsd_forward_host,
+              'statsd_forward_port' => $statsd_forward_port,
+            }
+        } else {
+            $statsd_forward_config = {
+              'statsd_forward_host' => $statsd_forward_host,
+            }
+        }
+    } else {
+        $statsd_forward_config = {}
+    }
+    $extra_config = deep_merge($base_extra_config, $agent6_extra_options, $statsd_forward_config)
 
     file { $conf6_dir:
       ensure  => directory,
@@ -587,8 +602,6 @@ class datadog_agent(
       'dogstatsd_port' => $dogstatsd_port,
       'dogstatsd_socket' => $dogstatsd_socket,
       'dogstatsd_non_local_traffic' => $non_local_traffic,
-      'statsd_forward_host' => $statsd_forward_host,
-      'statsd_forward_port' => $statsd_forward_port,
       'log_file' => $agent6_log_file,
       'log_level' => $log_level,
       'tags' => unique(flatten(union($_local_tags, $_facts_tags))),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -528,6 +528,19 @@ class datadog_agent(
       }
     }
   } else {
+    # notify of broken params on agent6
+    if $proxy_host {
+        notify { "Setting proxy_host will have no effect on agent6 please use agent6_extra_options to set your proxy": }
+    }
+    if $_proxy_port {
+        notify { "Setting proxy_port will have no effect on agent6 please use agent6_extra_options to set your proxy": }
+    }
+    if $proxy_user {
+        notify { "Setting proxy_user will have no effect on agent6 please use agent6_extra_options to set your proxy": }
+    }
+    if $proxy_password {
+        notify { "Setting proxy_password will have no effect on agent6 please use agent6_extra_options to set your proxy": }
+    }
 
     # lint:ignore:quoted_booleans
     $process_enabled_str = $process_enabled ? { true => 'true' , default => 'disabled' }
@@ -568,6 +581,7 @@ class datadog_agent(
       'dd_url' => $dd_url,
       'hostname' => $host,
       'cmd_port' => 5001,
+      'collect_ec2_tags' => $collect_ec2_tags,
       'conf_path' => $datadog_agent::params::conf6_dir,
       'enable_metadata_collection' => $collect_instance_metadata,
       'dogstatsd_port' => $dogstatsd_port,

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -878,6 +878,9 @@ describe 'datadog_agent' do
               'content' => /^cmd_port: \"{0,1}5001\"{0,1}\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^collect_ec2_tags: false\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^dd_url: \"{0,1}https:\/\/app.datadoghq.com\"{0,1}\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
@@ -926,9 +929,13 @@ describe 'datadog_agent' do
             context 'hostname override' do
               let(:params) {{
                   :host => 'my_custom_hostname',
+                  :collect_ec2_tags => true,
               }}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^hostname: my_custom_hostname\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^collect_ec2_tags: true\n/,
               )}
             end
           end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -956,6 +956,26 @@ describe 'datadog_agent' do
               'content' => /^statsd_forward_port: 1234\n/,
               )}
             end
+            context 'deprecated proxy settings' do
+              let(:params) {{
+                  :proxy_host => 'foo',
+                  :proxy_port => 1234,
+                  :proxy_user => 'bar',
+                  :proxy_password => 'abcd1234',
+              }}
+              it { is_expected.to contain_notify(
+                  'Setting proxy_host will have no effect on agent6 please use agent6_extra_options to set your proxy') 
+              }
+              it { is_expected.to contain_notify(
+                  'Setting proxy_port will have no effect on agent6 please use agent6_extra_options to set your proxy') 
+              }
+              it { is_expected.to contain_notify(
+                  'Setting proxy_user will have no effect on agent6 please use agent6_extra_options to set your proxy') 
+              }
+              it { is_expected.to contain_notify(
+                  'Setting proxy_password will have no effect on agent6 please use agent6_extra_options to set your proxy') 
+              }
+            end
           end
 
           context 'with additional agents config' do

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -922,6 +922,12 @@ describe 'datadog_agent' do
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^logs_config:\n\ \ container_collect_all: false\n/,
               )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').without(
+              'content' => /^statsd_forward_host: .*\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').without(
+              'content' => /^statsd_forward_port: ,*\n/,
+              )}
             end
           end
 
@@ -936,6 +942,18 @@ describe 'datadog_agent' do
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
               'content' => /^collect_ec2_tags: true\n/,
+              )}
+            end
+            context 'forward statsd settings set' do
+              let(:params) {{
+                  :statsd_forward_host => 'foo',
+                  :statsd_forward_port => 1234,
+              }}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^statsd_forward_host: foo\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^statsd_forward_port: 1234\n/,
               )}
             end
           end


### PR DESCRIPTION
- improve management of `statsd_forward` related options
- deprecation notices for agent5 proxy options on agent6.
- inclusion of `collect_ec2_tags`config option into base agent6 config.
- improved testing