### PR TITLE
Silence agent6_extra_options notification on default params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -534,16 +534,16 @@ class datadog_agent(
     }
   } else {
     # notify of broken params on agent6
-    if $proxy_host {
+    if !empty($proxy_host) {
         notify { 'Setting proxy_host will have no effect on agent6 please use agent6_extra_options to set your proxy': }
     }
-    if $_proxy_port {
+    if !empty($_proxy_port) {
         notify { 'Setting proxy_port will have no effect on agent6 please use agent6_extra_options to set your proxy': }
     }
-    if $proxy_user {
+    if !empty($proxy_user) {
         notify { 'Setting proxy_user will have no effect on agent6 please use agent6_extra_options to set your proxy': }
     }
-    if $proxy_password {
+    if !empty($proxy_password) {
         notify { 'Setting proxy_password will have no effect on agent6 please use agent6_extra_options to set your proxy': }
     }
 

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -979,6 +979,26 @@ describe 'datadog_agent' do
                   'Setting proxy_password will have no effect on agent6 please use agent6_extra_options to set your proxy') 
               }
             end
+            context 'deprecated proxy settings with default values' do
+              let(:params) {{
+                  :proxy_host => '',
+                  :proxy_port => '',
+                  :proxy_user => '',
+                  :proxy_password => '',
+              }}
+              it { is_expected.not_to contain_notify(
+                  'Setting proxy_host will have no effect on agent6 please use agent6_extra_options to set your proxy')
+              }
+              it { is_expected.not_to contain_notify(
+                  'Setting proxy_port will have no effect on agent6 please use agent6_extra_options to set your proxy')
+              }
+              it { is_expected.not_to contain_notify(
+                  'Setting proxy_user will have no effect on agent6 please use agent6_extra_options to set your proxy')
+              }
+              it { is_expected.not_to contain_notify(
+                  'Setting proxy_password will have no effect on agent6 please use agent6_extra_options to set your proxy')
+              }
+            end
           end
 
           context 'with additional agents config' do


### PR DESCRIPTION
I updated to 2.3.0 of this module today (and just realized it was updated 2 days ago).

Since upgrading, I've had extraneous noise in my puppet run outputs that I tracked down to this.

The default values of these params is an empty string `''`, which is interpreted by Puppet 4+ in boolean situations as `true`, hence these notify's are firing even when those parameters aren't supplied. (https://puppet.com/docs/puppet/4.10/lang_updating_manifests.html#empty-strings-in-boolean-context-are-true)