### PR TITLE
Allow manage_repo option for Ubuntu

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -406,6 +406,7 @@ class datadog_agent(
           location              => $agent5_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
+          manage_repo           => $manage_repo,
         }
       } else {
         class { 'datadog_agent::ubuntu::agent6':
@@ -416,6 +417,7 @@ class datadog_agent(
           location              => $agent6_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
+          manage_repo           => $manage_repo,
         }
       }
     }

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -8,36 +8,53 @@ describe 'datadog_agent::ubuntu::agent5' do
     }
   end
 
-  it do
-    contain_file('/etc/apt/sources.list.d/datadog6.list')
-      .with_ensure('absent')
-    contain_file('/etc/apt/sources.list.d/datadog.list')\
-      .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+main})
+  context 'with manage_repo => true' do
+    let(:params){ {:manage_repo => true} }
+    it do
+      contain_file('/etc/apt/sources.list.d/datadog6.list')
+        .with_ensure('absent')
+      contain_file('/etc/apt/sources.list.d/datadog.list')\
+        .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+main})
+    end
+
+    # it should install the mirror
+    it { should_not contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
+    it { should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
+    it do
+      should contain_file('/etc/apt/sources.list.d/datadog.list')\
+        .that_notifies('exec[apt_update]')
+    end
+    it { should contain_exec('apt_update') }
+
+    # it should install the packages
+    it do
+      should contain_package('apt-transport-https')\
+        .that_comes_before('file[/etc/apt/sources.list.d/datadog.list]')
+    end
+
+    it do
+      should contain_package('datadog-agent')\
+        .that_requires('file[/etc/apt/sources.list.d/datadog.list]')\
+        .that_requires('exec[apt_update]')
+    end
   end
 
-  # it should install the mirror
-  it { should_not contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
-  it { should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
-  it do
-    should contain_file('/etc/apt/sources.list.d/datadog.list')\
-      .that_notifies('exec[apt_update]')
-  end
-  it { should contain_exec('apt_update') }
+  context 'with manage_repo => false' do
+    let(:params){ {:manage_repo => false} }
+    it do
+      should_not contain_file('/etc/apt/sources.list.d/datadog6.list')
+      should_not contain_file('/etc/apt/sources.list.d/datadog.list')
+    end
 
-  # it should install the packages
-  it do
-    should contain_package('apt-transport-https')\
-      .that_comes_before('file[/etc/apt/sources.list.d/datadog.list]')
+    it do
+      should contain_package('datadog-agent')
+    end
   end
+
   it do
     should contain_package('datadog-agent-base')\
       .with_ensure('absent')\
       .that_comes_before('package[datadog-agent]')
-  end
-  it do
-    should contain_package('datadog-agent')\
-      .that_requires('file[/etc/apt/sources.list.d/datadog.list]')\
-      .that_requires('exec[apt_update]')
   end
 
   # it should be able to start the service and enable the service by default
@@ -71,37 +88,53 @@ describe 'datadog_agent::ubuntu::agent6' do
     }
   end
 
-  it do
-    contain_file('/etc/apt/sources.list.d/datadog.list')
-      .with_ensure('absent')
-    contain_file('/etc/apt/sources.list.d/datadog6.list')\
-      .with_content(%r{deb\s+https://apt.datadoghq.com/\s+beta\s+main})
+  context 'with manage_repo => true' do
+    let(:params){ {:manage_repo => true} }
+    it do
+      contain_file('/etc/apt/sources.list.d/datadog.list')
+        .with_ensure('absent')
+      contain_file('/etc/apt/sources.list.d/datadog6.list')\
+        .with_content(%r{deb\s+https://apt.datadoghq.com/\s+beta\s+main})
+    end
+
+    # it should install the mirror
+    it { should_not contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
+    it { should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
+    it do
+      should contain_file('/etc/apt/sources.list.d/datadog.list')\
+        .that_notifies('exec[apt_update]')
+    end
+    it { should contain_exec('apt_update') }
+
+    # it should install the packages
+    it do
+      should contain_package('apt-transport-https')\
+        .that_comes_before('file[/etc/apt/sources.list.d/datadog.list]')
+    end
+
+    it do
+      should contain_package('datadog-agent')\
+        .that_requires('file[/etc/apt/sources.list.d/datadog.list]')\
+        .that_requires('exec[apt_update]')
+    end
   end
 
-  # it should install the mirror
-  it { should_not contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
-  it { should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
+  context 'with manage_repo => false' do
+    let(:params){ {:manage_repo => false} }
+    it do
+      should_not contain_file('/etc/apt/sources.list.d/datadog.list')
+      should_not contain_file('/etc/apt/sources.list.d/datadog6.list')
+    end
 
-  it do
-    should contain_file('/etc/apt/sources.list.d/datadog6.list')\
-      .that_notifies('exec[apt_update]')
+    it do
+      should contain_package('datadog-agent')
+    end
   end
-  it { should contain_exec('apt_update') }
 
-  # it should install the packages
-  it do
-    should contain_package('apt-transport-https')\
-      .that_comes_before('file[/etc/apt/sources.list.d/datadog6.list]')
-  end
   it do
     should contain_package('datadog-agent-base')\
       .with_ensure('absent')\
       .that_comes_before('package[datadog-agent]')
-  end
-  it do
-    should contain_package('datadog-agent')\
-      .that_requires('file[/etc/apt/sources.list.d/datadog6.list]')\
-      .that_requires('exec[apt_update]')
   end
 
   # it should be able to start the service and enable the service by default


### PR DESCRIPTION
This allows the `manage_repo` option to be used on Ubuntu like it is used on Redhat currently.

Fixes #240, closes #300 (a prior version of this same change).