### PR TITLE
Fix facts_to_tags regression in agent6

### DIFF
--- a/functions/tag6.pp
+++ b/functions/tag6.pp
@@ -22,7 +22,7 @@ function datadog_agent::tag6(
       if $value =~ Array {
         $tags = prefix($value, "${tag_names}:")
       } else {
-        $tags = [$tag_names]
+        $tags = ["${tag_names}:${value}"]
       }
     } else {
       $tags = [$tag_names]


### PR DESCRIPTION
Fixing facts_to_tags as per https://github.com/DataDog/puppet-datadog-agent/issues/454