### PR TITLE
Retry on failure when pulling the gpg key from keyserver.ubuntu.com

### DIFF
--- a/manifests/ubuntu/install_key.pp
+++ b/manifests/ubuntu/install_key.pp
@@ -16,5 +16,6 @@ define datadog_agent::ubuntu::install_key() {
   apt::key { $name:
     id     => $name,
     server => 'hkp://keyserver.ubuntu.com:80',
+    retries => '4',
   }
 }


### PR DESCRIPTION
# Motivation
the keyservers are a pool of sks servers with squid in front of them, we should probably retry on failures.