### PR TITLE
1.x update

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -352,11 +352,6 @@ class datadog_agent(
     $local_integrations = $integrations
   }
 
-  datadog_agent::tag{$local_tags: }
-  datadog_agent::tag{$facts_to_tags:
-    lookup_fact => true,
-  }
-
   include datadog_agent::params
   case upcase($log_level) {
     'CRITICAL': { $_loglevel = 'CRITICAL' }
@@ -408,6 +403,11 @@ class datadog_agent(
   }
 
   if !$agent6_enable {
+    datadog_agent::tag{$local_tags: }
+    datadog_agent::tag{$facts_to_tags:
+      lookup_fact => true,
+    }
+
     file { '/etc/dd-agent':
       ensure  => directory,
       owner   => $dd_user,
@@ -491,6 +491,10 @@ class datadog_agent(
       'dogstatsd_non_local_traffic' => $non_local_traffic,
       'log_file' => $agent6_log_file,
       'log_level' => $log_level,
+    }
+
+    if $local_tags {
+      $agent_config['tags'] = $local_tags
     }
 
     file { '/etc/datadog-agent/datadog.yaml':

--- a/manifests/tag.pp
+++ b/manifests/tag.pp
@@ -4,6 +4,7 @@ define datadog_agent::tag(
   $lookup_fact = false,
 ){
 
+  $local_config_dir = '/etc/dd-agent/datadog.conf'
   if $lookup_fact{
     $value = getvar($tag_name)
 
@@ -13,7 +14,7 @@ define datadog_agent::tag(
     } else {
       if $value {
         concat::fragment{ "datadog tag ${tag_name}:${value}":
-          target  => '/etc/dd-agent/datadog.conf',
+          target  => "${local_config_dir}",
           content => "${tag_name}:${value}, ",
           order   => '03',
         }
@@ -21,7 +22,7 @@ define datadog_agent::tag(
     }
   } else {
     concat::fragment{ "datadog tag ${tag_name}":
-      target  => '/etc/dd-agent/datadog.conf',
+      target  => "${local_config_dir}",
       content => "${tag_name}, ",
       order   => '03',
     }

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -90,7 +90,7 @@ class datadog_agent::ubuntu(
     ensure    => $::datadog_agent::service_ensure,
     enable    => $::datadog_agent::service_enable,
     hasstatus => false,
-    pattern   => 'dd-agent',
+    pattern   => "^(dd|datadog)-agent",
     require   => Package[$datadog_agent::params::package_name],
   }
 }

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -39,7 +39,8 @@ class datadog_agent::ubuntu(
   # $facts hash - for compatibility with puppet3.x default behavior
   if $::apt_agent6_beta_repo and $agent_version == 'latest' {
     exec { 'datadog_apt-get_remove_agent6':
-      command     => '/usr/bin/apt-get remove -y -q datadog-agent',
+      command => '/usr/bin/apt-get remove -y -q datadog-agent',
+      onlyif  => '/usr/bin/dpkg -l datadog-agent > /dev/null'
     }
   } else {
     exec { 'datadog_apt-get_remove_agent6':


### PR DESCRIPTION
I found some issues when using the v1.12.1 version.

These focused around tag handling in v5/v6 and some minor other issues.

Changes:
  * moved v5 tag code to appropriate area
  * updated service type pattern
  * updated exec on remove command

