### PR TITLE
Add ignore_ssl_warning to apache

### DIFF
--- a/manifests/integrations/apache.pp
+++ b/manifests/integrations/apache.pp
@@ -31,13 +31,15 @@ class datadog_agent::integrations::apache (
   $username               = undef,
   $password               = undef,
   $tags                   = [],
-  $disable_ssl_validation = false
+  $disable_ssl_validation = false,
+  $ignore_ssl_warning     = false
 ) inherits datadog_agent::params {
   include datadog_agent
 
   validate_legacy('String', 'validate_string', $url)
   validate_legacy('Array', 'validate_array', $tags)
   validate_legacy('Boolean', 'validate_bool', $disable_ssl_validation)
+  validate_legacy('Boolean', 'validate_bool', $ignore_ssl_warning)
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/apache.yaml"

--- a/templates/agent-conf.d/apache.yaml.erb
+++ b/templates/agent-conf.d/apache.yaml.erb
@@ -5,6 +5,9 @@ instances:
 <% if @disable_ssl_validation -%>
         disable_ssl_validation: <%= @disable_ssl_validation %>
 <% end -%>
+<% if @ignore_ssl_warning -%>
+        ignore_ssl_warning: <%= @ignore_ssl_warning %>
+<% end -%>
 <% if @username -%>
         apache_user: <%= @username %>
 <% end -%>
@@ -19,4 +22,3 @@ instances:
     <%- end -%>
   <%- end -%>
 <% end -%>
-


### PR DESCRIPTION
Even with `disable_ssl_validation` enabled, urllib3 still complains, e.g.

```
/opt/datadog-agent/embedded/lib/python2.7/site-packages/urllib3/connectionpool.py:857: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
InsecureRequestWarning)
```

`ignore_ssl_warning` was added the http check (https://docs.datadoghq.com/integrations/http_check/) which seems to hide these warnings.