### PR TITLE
Merges datadog_agent::tags hiera values

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -372,7 +372,7 @@ class datadog_agent(
   validate_legacy(String, 'validate_string', $apt_release)
 
   if $hiera_tags {
-    $local_tags = lookup({ 'name' => 'datadog_agent::tags', 'default_value' => []})
+    $local_tags = lookup({ 'name' => 'datadog_agent::tags', 'merge' => 'unique', 'default_value' => []})
   } else {
     $local_tags = $tags
   }


### PR DESCRIPTION
The 1.x version of the module does a `hiera_array` lookup for `datadog_agent::tags` allowing the tags from different hiera files to be merged together. This adds that same functionality by specifying the `unique` merge behavior to the lookup function.