### PR TITLE
Remove `sudo: false` as required by Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 before_install: rm -f Gemfile.lock
-sudo: false
 bundler_args: --full-index
 cache: bundler
 rvm:


### PR DESCRIPTION
As per Travis CI blog post [Upcoming Required Linux Infrastructure Migration](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
> If you currently specify `sudo: false` in your `.travis.yml`, we recommend removing that configuration soon.