### PR TITLE
Add a class variable that gives you the ability to override package s…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -218,6 +218,7 @@ class datadog_agent(
   $log_to_syslog = true,
   $service_ensure = 'running',
   $service_enable = true,
+  $manage_packages = true,
   $manage_repo = true,
   $hostname_extraction_regex = nil,
   $dogstatsd_port = 8125,
@@ -404,54 +405,56 @@ class datadog_agent(
     $_apt_keyserver = $apt_keyserver
   }
 
-  case $::operatingsystem {
-    'Ubuntu','Debian' : {
-      if $agent5_enable {
-        class { 'datadog_agent::ubuntu::agent5':
-          agent_version         => $agent_version,
-          service_ensure        => $service_ensure,
-          service_enable        => $service_enable,
-          service_provider      => $service_provider,
-          location              => $agent5_repo_uri,
-          release               => $apt_release,
-          skip_apt_key_trusting => $skip_apt_key_trusting,
-          apt_keyserver         => $_apt_keyserver,
-        }
-      } else {
-        class { 'datadog_agent::ubuntu::agent6':
-          agent_version         => $agent_version,
-          service_ensure        => $service_ensure,
-          service_enable        => $service_enable,
-          service_provider      => $service_provider,
-          location              => $agent6_repo_uri,
-          release               => $apt_release,
-          skip_apt_key_trusting => $skip_apt_key_trusting,
-          apt_keyserver         => $_apt_keyserver,
-        }
-      }
-    }
-    'RedHat','CentOS','Fedora','Amazon','Scientific' : {
-      if $agent5_enable {
-        class { 'datadog_agent::redhat::agent5':
-          baseurl          => $agent5_repo_uri,
-          manage_repo      => $manage_repo,
-          agent_version    => $agent_version,
-          service_ensure   => $service_ensure,
-          service_enable   => $service_enable,
-          service_provider => $service_provider,
-        }
-      } else {
-        class { 'datadog_agent::redhat::agent6':
-          baseurl          => $agent6_repo_uri,
-          manage_repo      => $manage_repo,
-          agent_version    => $agent_version,
-          service_ensure   => $service_ensure,
-          service_enable   => $service_enable,
-          service_provider => $service_provider,
+  if $manage_packages {
+    case $::operatingsystem {
+      'Ubuntu','Debian' : {
+        if $agent5_enable {
+          class { 'datadog_agent::ubuntu::agent5':
+            agent_version         => $agent_version,
+            service_ensure        => $service_ensure,
+            service_enable        => $service_enable,
+            service_provider      => $service_provider,
+            location              => $agent5_repo_uri,
+            release               => $apt_release,
+            skip_apt_key_trusting => $skip_apt_key_trusting,
+            apt_keyserver         => $_apt_keyserver,
+          }
+        } else {
+          class { 'datadog_agent::ubuntu::agent6':
+            agent_version         => $agent_version,
+            service_ensure        => $service_ensure,
+            service_enable        => $service_enable,
+            service_provider      => $service_provider,
+            location              => $agent6_repo_uri,
+            release               => $apt_release,
+            skip_apt_key_trusting => $skip_apt_key_trusting,
+            apt_keyserver         => $_apt_keyserver,
+          }
         }
       }
+      'RedHat','CentOS','Fedora','Amazon','Scientific' : {
+        if $agent5_enable {
+          class { 'datadog_agent::redhat::agent5':
+            baseurl          => $agent5_repo_uri,
+            manage_repo      => $manage_repo,
+            agent_version    => $agent_version,
+            service_ensure   => $service_ensure,
+            service_enable   => $service_enable,
+            service_provider => $service_provider,
+          }
+        } else {
+          class { 'datadog_agent::redhat::agent6':
+            baseurl          => $agent6_repo_uri,
+            manage_repo      => $manage_repo,
+            agent_version    => $agent_version,
+            service_ensure   => $service_ensure,
+            service_enable   => $service_enable,
+            service_provider => $service_provider,
+          }
+        }
+      }
+      default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
     }
-    default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
   }
 
   if ($dd_groups) {


### PR DESCRIPTION
…ource, package, and service management by this class (i.e. if you want to manage it on your own)

Looking for some feedback on whether something like this is reasonable to implement. We ran into an issue when trying to upgrade to agent v3. We imported this Puppet module and ran into some dependency cycles with our existing Puppet infrastructure due to the way the puppet_agent::ubuntu classes from this module reference apt_update.

Our own classes make use of Puppet stages to enforce certain behaviors (i.e. that apt keys are present before any package operations happen) which led to the aforementioned dependency cycles.

I was able to work around it by removing the package source, package installation, and service management from this class and handling it ourselves. We can then just use this class for config and integration management and the like.

This PR would make this easier to track on our end but feel like it crosses over with the $manage_repos class variable that is being used in the redhat agent classes. Any thoughts on any better ways to handle this?

Thanks