### PR TITLE
[tomcat] jmx_url support + reports regex extraction should use `undef` (Thanks @evansj)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -238,7 +238,7 @@ class datadog_agent(
   $service_ensure = 'running',
   $service_enable = true,
   $manage_repo = true,
-  $hostname_extraction_regex = nil,
+  $hostname_extraction_regex = undef,
   $hostname_fqdn = false,
   $dogstatsd_port = 8125,
   $dogstatsd_socket = '',

--- a/manifests/integrations/tomcat.pp
+++ b/manifests/integrations/tomcat.pp
@@ -7,6 +7,8 @@
 #       The host tomcat is running on. Defaults to 'localhost'
 #   $port
 #       The JMX port.
+#   $jmx_url
+#       The JMX URL.
 #   $username
 #       The username for connecting to the running JVM. Optional.
 #   $password
@@ -29,6 +31,7 @@
 class datadog_agent::integrations::tomcat(
   $hostname             = 'localhost',
   $port                 = 7199,
+  $jmx_url              = undef,
   $username             = undef,
   $password             = undef,
   $java_bin_path        = undef,

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -17,7 +17,7 @@ class datadog_agent::reports(
   $api_key,
   $puppetmaster_user,
   $dogapi_version,
-  $hostname_extraction_regex = nil,
+  $hostname_extraction_regex = undef
   $datadog_site = 'datadoghq.com',
 ) {
 

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -17,7 +17,7 @@ class datadog_agent::reports(
   $api_key,
   $puppetmaster_user,
   $dogapi_version,
-  $hostname_extraction_regex = undef
+  $hostname_extraction_regex = undef,
   $datadog_site = 'datadoghq.com',
 ) {
 

--- a/templates/agent-conf.d/tomcat.yaml.erb
+++ b/templates/agent-conf.d/tomcat.yaml.erb
@@ -2,6 +2,9 @@
 
 instances:
   - host: <%= @hostname %>
+<% if @jmx_url -%>
+    jmx_url: "<%= @jmx_url %>"
+<% end -%>
     port: <%= @port %>
 <% if @username -%>
     user: <%= @username %>

--- a/templates/agent-conf.d/tomcat.yaml.erb
+++ b/templates/agent-conf.d/tomcat.yaml.erb
@@ -21,10 +21,10 @@ instances:
     trust_store_password: <%= @trust_store_password %>
 <% end -%>
 <% if @tags and ! @tags.empty? -%>
-        tags:
-  <%- @tags.each do |key, val| -%>
-          <%= "#{key}: #{val}" %>
-  <%- end -%>
+    tags:
+<%- @tags.each do |key, val| -%>
+        <%= "#{key}: #{val}" %>
+<%- end -%>
 <% end -%>
 
 

--- a/templates/datadog-reports.yaml.erb
+++ b/templates/datadog-reports.yaml.erb
@@ -3,6 +3,6 @@
 ---
 :datadog_api_key: '<%= @api_key %>'
 :api_url: api.<%= @datadog_site %>
-<% if !@hostname_extraction_regex.nil? -%>
+<% if @hostname_extraction_regex -%>
 :hostname_extraction_regex: '<%= @hostname_extraction_regex %>'
 <% end -%>


### PR DESCRIPTION
This PR is based off #460, all credit goes to @evansj! 

(Apologies for not merging this in when we should've)