### PR TITLE
Custom integration defined type bugfix

### DIFF
--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -12,6 +12,13 @@ define datadog_agent::integration (
 
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/${integration}.d/conf.yaml"
+    file { "${datadog_agent::conf6_dir}/${integration}.d":
+      ensure => directory,
+      owner  => $datadog_agent::dd_user,
+      group  => $datadog_agent::dd_group,
+      mode   => '0755',
+      before => File[$dst]
+    }
   } else {
     $dst = "${datadog_agent::conf_dir}/${integration}.yaml"
   }

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -8,7 +8,8 @@ describe "datadog_agent::integration" do
       if enabled
         let(:conf_file) { '/etc/dd-agent/conf.d/test.yaml' }
       else
-        let(:conf_file) { '/etc/datadog-agent/conf.d/test.d/conf.yaml' }
+        let(:conf_dir) { '/etc/datadog-agent/conf.d/test.d' }
+        let(:conf_file) { "#{conf_dir}/conf.yaml" }
       end
 
       let (:title) { "test" }
@@ -23,7 +24,12 @@ describe "datadog_agent::integration" do
               { 'one' => "two" }
           ]
       }}
+
+
       it { should compile }
+      if enabled
+        it { should contain_file("#{conf_dir}").that_comes_before("File[#{conf_file}]") }
+      end
       it { should contain_file("#{conf_file}").with_content(/init_config: /) }
       gem_spec = Gem.loaded_specs['puppet']
       if gem_spec.version >= Gem::Version.new('4.0.0')


### PR DESCRIPTION
Seems like there is a regression in 2.4.0 release. We setup datadog custom integrations via defined type. After upgrade to 2.4.0 puppet fails with following errors:

> Error: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/datadog-agent/conf.d/check_snapshot.d/conf.yaml20190104-21120-1j3khxt.lock (file:
 /etc/puppetlabs/code/modules/datadog_agent/manifests/integration.pp, line: 19)
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/datadog-agent/conf.d/check_snapshot.d/conf.yaml20190104-21120-1j3khxt.lock (file:
 /etc/puppetlabs/code/modules/datadog_agent/manifests/integration.pp, line: 19)
Wrapped exception:
No such file or directory @ dir_s_mkdir - /etc/datadog-agent/conf.d/check_snapshot.d/conf.yaml20190104-21120-1j3khxt.lock
Error: /Stage[main]/Datadog_integrations::Snapshot_monitor/Datadog_agent::Integration[check_snapshot]/File[/etc/datadog-agent/conf.d/check_snapshot.d/conf.yaml]/ensure: change from 'absent' to 'file' failed: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/datadog-agent/conf.d/check_snapshot.d/conf.yaml20190104-21120-1j3khxt.lock (file: /etc/puppetlabs/code/modules/datadog_agent/manifests/integration.pp, line: 19) 

The root cause is puppet fails to create `config.yaml` resource because `/etc/datadog-agent/${integration}.d/` directory is missing. 

With predefined integrations everything is fine though, as necessary integration directories are created by datadog-agent RPM package. 