### PR TITLE
Make it possible to enable PostgreSQL extra metrics collection

### DIFF
--- a/manifests/integrations/postgres.pp
+++ b/manifests/integrations/postgres.pp
@@ -5,7 +5,7 @@
 # Parameters:
 #   $password
 #       The password for the datadog user
-#   $host:
+#   $host
 #       The host postgres is running on
 #   $dbname
 #       The postgres database name
@@ -18,6 +18,18 @@
 #   $use_psycopg2
 #       Boolean to flag connecting to postgres with psycopg2 instead of pg8000.
 #       Warning, psycopg2 doesn't support ssl mode.
+#   $collect_function_metrics
+#       Boolean to enable collecting metrics regarding PL/pgSQL functions from pg_stat_user_functions.
+#   $collect_count_metrics
+#       Boolean to enable collecting count metrics, default value is True for backward compatibility but they might be slow,
+#       suggested value is False.
+#   $collect_activity_metrics
+#       Boolean to enable collecting metrics regarding transactions from pg_stat_activity, default value is False.
+#       Please make sure the user has sufficient privileges to read from pg_stat_activity before enabling this option.
+#   $collect_database_size_metrics
+#       Boolean to enable collecting database size metrics. Default value is True but they might be slow with large databases
+#   $collect_default_database
+#       Boolean to enable collecting statistics from the default database 'postgres' in the check metrics, default to false
 #   $tags
 #       Optional array of tags
 #   $tables
@@ -56,16 +68,21 @@
 #
 class datadog_agent::integrations::postgres(
   String $password,
-  String $host                   = 'localhost',
-  String $dbname                 = 'postgres',
-  Variant[String, Integer] $port = '5432',
-  String $username               = 'datadog',
-  Boolean $ssl                   = false,
-  Boolean $use_psycopg2          = false,
-  Array[String] $tags            = [],
-  Array[String] $tables          = [],
-  Hash $custom_metrics           = {},
-  Optional[Array] $instances     = undef,
+  String $host                           = 'localhost',
+  String $dbname                         = 'postgres',
+  Variant[String, Integer] $port         = '5432',
+  String $username                       = 'datadog',
+  Boolean $ssl                           = false,
+  Boolean $use_psycopg2                  = false,
+  Boolean $collect_function_metrics      = false,
+  Boolean $collect_count_metrics         = false,
+  Boolean $collect_activity_metrics      = false,
+  Boolean $collect_database_size_metrics = false,
+  Boolean $collect_default_database      = false,
+  Array[String] $tags                    = [],
+  Array[String] $tables                  = [],
+  Hash $custom_metrics                   = {},
+  Optional[Array] $instances             = undef,
 ) inherits datadog_agent::params {
   include datadog_agent
 
@@ -85,16 +102,21 @@ class datadog_agent::integrations::postgres(
 
   if !$instances and $host {
     $_instances = [{
-      'host'           => $host,
-      'password'       => $password,
-      'dbname'         => $dbname,
-      'port'           => $port,
-      'username'       => $username,
-      'ssl'            => $ssl,
-      'use_psycopg2'   => $use_psycopg2,
-      'tags'           => $tags,
-      'tables'         => $tables,
-      'custom_metrics' => $custom_metrics,
+      'host'                          => $host,
+      'password'                      => $password,
+      'dbname'                        => $dbname,
+      'port'                          => $port,
+      'username'                      => $username,
+      'ssl'                           => $ssl,
+      'use_psycopg2'                  => $use_psycopg2,
+      'tags'                          => $tags,
+      'tables'                        => $tables,
+      'custom_metrics'                => $custom_metrics,
+      'collect_function_metrics'      => $collect_function_metrics,
+      'collect_count_metrics'         => $collect_count_metrics,
+      'collect_activity_metrics'      => $collect_activity_metrics,
+      'collect_database_size_metrics' => $collect_database_size_metrics,
+      'collect_default_database'      => $collect_default_database,
     }]
   } elsif !$instances{
     $_instances = []

--- a/spec/classes/datadog_agent_integrations_postgres_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postgres_spec.rb
@@ -48,8 +48,32 @@ describe 'datadog_agent::integrations::postgres' do
           it { should contain_file(conf_file).with_content(%r{port: 5432}) }
           it { should contain_file(conf_file).with_content(%r{username: datadog}) }
           it { should contain_file(conf_file).without_content(%r{^\s*use_psycopg2: }) }
+          it { should contain_file(conf_file).with_content(%r{collect_function_metrics: false}) }
+          it { should contain_file(conf_file).with_content(%r{collect_count_metrics: false}) }
+          it { should contain_file(conf_file).with_content(%r{collect_activity_metrics: false}) }
+          it { should contain_file(conf_file).with_content(%r{collect_database_size_metrics: false}) }
+          it { should contain_file(conf_file).with_content(%r{collect_default_database: false}) }
           it { should contain_file(conf_file).without_content(%r{tags: })}
           it { should contain_file(conf_file).without_content(%r{^[^#]*relations: }) }
+        end
+
+        context 'with extra metrics collection enabled' do
+          let(:params) {{
+            password: 'abc123',
+            collect_function_metrics: true,
+            collect_count_metrics: true,
+            collect_activity_metrics: true,
+            collect_database_size_metrics: true,
+            collect_default_database: true,
+          }}
+          it {
+            should contain_file(conf_file)
+              .with_content(%r{collect_function_metrics: true})
+              .with_content(%r{collect_count_metrics: true})
+              .with_content(%r{collect_activity_metrics: true})
+              .with_content(%r{collect_database_size_metrics: true})
+              .with_content(%r{collect_default_database: true})
+          }
         end
 
         context 'with use_psycopg2 enabled' do

--- a/templates/agent-conf.d/postgres.yaml.erb
+++ b/templates/agent-conf.d/postgres.yaml.erb
@@ -20,6 +20,11 @@ instances:
     username: <%= instance['username']  %>
     password: <%= instance['password']  %>
     dbname: <%= instance['dbname']  %>
+    collect_function_metrics: <%= instance['collect_function_metrics']  %>
+    collect_count_metrics: <%= instance['collect_count_metrics']  %>
+    collect_activity_metrics: <%= instance['collect_activity_metrics']  %>
+    collect_database_size_metrics: <%= instance['collect_database_size_metrics']  %>
+    collect_default_database: <%= instance['collect_default_database']  %>
 <% if instance['ssl']  == true -%>
     ssl: true
 <% end -%>


### PR DESCRIPTION
The current version of the PostgresSQL module integration doesn't
handle the following parameters for the Datadog PostgreSQL integration:
  * collect_function_metrics
  * collect_count_metrics
  * collect_activity_metrics
  * collect_database_size_metrics

This way metrics like postgresql.active_queries and postgresql.waiting_queries,
for example, were not available.
This change aims to make them available whenever desired.