### PR TITLE
Fix kafka tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ group :test do
   gem "rb-inotify", '< 0.10.0' if RUBY_VERSION < '2.2.0'
   gem "public_suffix", "~> 3.0.0"
   gem "listen", "~> 3.0.0"
-  gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.2.0'
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 5.5.1'
   gem "puppet-lint"
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"

--- a/templates/agent-conf.d/kafka.yaml.erb
+++ b/templates/agent-conf.d/kafka.yaml.erb
@@ -12,8 +12,8 @@ instances:
     port: <%= server['port'] %>
   <%- if !server['tags'].nil? && server['tags'].any? -%>
     tags:
-    <%- server['tags'].each do |tag| -%>
-      - <%= tag %>
+    <%- server['tags'].each do |key,value| -%>
+      <%= key %>: <%= value %>
     <%- end -%>
   <%- end -%>
   <%- if !server['username'].nil? -%>


### PR DESCRIPTION
# WAT

Fix the Kafka configuration template. I'm guessing they did some kind of half-update from 5 to 6 because the comments and template have `tags` as an array while the class has it as `Hash[String[1], String[2]]`. I'm trusting the class although 🤷‍♂️...

# Y THO

It's broken.

