### PR TITLE
[Fix] dd_url is not set with the right value

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -496,6 +496,12 @@ class datadog_agent(
     require => Package[$datadog_agent::params::package_name],
   }
 
+  if ($dd_url == '') {
+    $_dd_url = 'https://app.datadoghq.com'
+  } else {
+    $_dd_url = $dd_url
+  }
+
   if $agent5_enable {
 
     file { '/etc/dd-agent':
@@ -524,11 +530,6 @@ class datadog_agent(
       require => File['/etc/dd-agent'],
     }
 
-    if ($dd_url == '') {
-      $_dd_url = 'https://app.datadoghq.com'
-    } else {
-      $_dd_url = $dd_url
-    }
     concat::fragment{ 'datadog header':
       target  => '/etc/dd-agent/datadog.conf',
       content => template('datadog_agent/datadog_header.conf.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -664,7 +664,7 @@ class datadog_agent(
 
     $_agent_config = {
       'api_key' => $api_key,
-      'dd_url' => $dd_url,
+      'dd_url' => $_dd_url,
       'site' => $datadog_site,
       'cmd_port' => $cmd_port,
       'hostname_fqdn' => $hostname_fqdn,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -497,7 +497,7 @@ class datadog_agent(
   }
 
   if ($dd_url == '') {
-    $_dd_url = 'https://app.datadoghq.com'
+    $_dd_url = $datadog_agent::params::dd_url
   } else {
     $_dd_url = $dd_url
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@
 # Sample Usage:
 #
 class datadog_agent::params {
+  $dd_url                         = 'https://app.datadoghq.com'
   $datadog_site                   = 'datadoghq.com'
   $agent5_enable                  = false
   $conf_dir                       = '/etc/dd-agent/conf.d'


### PR DESCRIPTION
Module is evaluating with an if/else statement and if the dd_url is '' then it sets by default https://app.datadoghq.com as value of _dd_url. In the _agent_config it is expected to use _dd_url but module is using dd_url by error.