### PR TITLE
Fix apm_analyzed_spans config directive.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -621,7 +621,7 @@ class datadog_agent(
     if $apm_analyzed_spans {
         $apm_analyzed_span_config = {
             'apm_config' => {
-                'apm_analyzed_spans' => $apm_analyzed_spans
+                'analyzed_spans' => $apm_analyzed_spans
             }
         }
     } else {

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -1104,7 +1104,7 @@ describe 'datadog_agent' do
               'content' => /^apm_config:\n\ \ enabled: true\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ apm_analyzed_spans:\n\ \ \ \ foo|bar: 0.5\n\ \ \ \ haz|qux: 0.1\n/,
+              'content' => /^\ \ analyzed_spans:\n\ \ \ \ foo|bar: 0.5\n\ \ \ \ haz|qux: 0.1\n/,
               )}
             end
             context 'with extra_options and Process enabled' do


### PR DESCRIPTION
In the current configuration, when this puppet module applies `apm_analyzed_spans` to the resultant `datadog.yaml` file, the agent ignores the configured spans.  The documentation for the agent specifies that the directive should be `analyzed_spans` instead.

More information here:
https://docs.datadoghq.com/agent/apm/?tab=agent630#trace-search