### PR TITLE
Re-naming 'no_proxy' to 'skip_proxy' as 'no_proxy' has been deprecated

### DIFF
--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -64,8 +64,8 @@
 #       This defaults to True because this is being deprecated.
 #       (See https://github.com/DataDog/dd-agent/blob/master/checks/network_checks.py#L178-L180)
 #
-#   no_proxy
-#       The (optional) no_proxy parameter would bypass any proxy settings enabled
+#   skip_proxy
+#       The (optional) skip_proxy parameter would bypass any proxy settings enabled
 #       and attempt to reach the the URL directly.
 #       If no proxy is defined at any level, this flag bears no effect.
 #       Defaults to False.
@@ -162,7 +162,7 @@ class datadog_agent::integrations::http_check (
   $collect_response_time = true,
   $disable_ssl_validation = false,
   $skip_event = true,
-  $no_proxy  = false,
+  $skip_proxy  = false,
   $check_certificate_expiration = true,
   $days_warning = undef,
   $days_critical = undef,
@@ -190,7 +190,7 @@ class datadog_agent::integrations::http_check (
       'collect_response_time'        => $collect_response_time,
       'disable_ssl_validation'       => $disable_ssl_validation,
       'skip_event'                   => $skip_event,
-      'no_proxy'                     => $no_proxy,
+      'skip_proxy'                   => $skip_proxy,
       'check_certificate_expiration' => $check_certificate_expiration,
       'days_warning'                 => $days_warning,
       'days_critical'                => $days_critical,

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -46,7 +46,7 @@ describe 'datadog_agent::integrations::http_check' do
         it { should contain_file(conf_file).without_content(%r{http_response_status_code: }) }
         it { should contain_file(conf_file).without_content(%r{disable_ssl_validation: false}) }
         it { should contain_file(conf_file).without_content(%r{skip_event: }) }
-        it { should contain_file(conf_file).without_content(%r{no_proxy: }) }
+        it { should contain_file(conf_file).without_content(%r{skip_proxy: }) }
         it { should contain_file(conf_file).without_content(%r{check_certificate_expiration: }) }
         it { should contain_file(conf_file).without_content(%r{days_warning: }) }
         it { should contain_file(conf_file).without_content(%r{days_critical: }) }
@@ -69,7 +69,7 @@ describe 'datadog_agent::integrations::http_check' do
           disable_ssl_validation: true,
           skip_event: true,
           http_response_status_code: '503',
-          no_proxy: true,
+          skip_proxy: true,
           check_certificate_expiration: true,
           days_warning: 14,
           days_critical: 7,
@@ -90,7 +90,7 @@ describe 'datadog_agent::integrations::http_check' do
         it { should contain_file(conf_file).with_content(%r{disable_ssl_validation: true}) }
         it { should contain_file(conf_file).with_content(%r{skip_event: true}) }
         it { should contain_file(conf_file).with_content(%r{http_response_status_code: 503}) }
-        it { should contain_file(conf_file).with_content(%r{no_proxy: true}) }
+        it { should contain_file(conf_file).with_content(%r{skip_proxy: true}) }
         it { should contain_file(conf_file).with_content(%r{check_certificate_expiration: true}) }
         it { should contain_file(conf_file).with_content(%r{days_warning: 14}) }
         it { should contain_file(conf_file).with_content(%r{days_critical: 7}) }

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -39,8 +39,8 @@ instances:
 <% unless instance['skip_event'].nil? -%>
     skip_event: <%= instance['skip_event'] %>
 <% end -%>
-<% unless instance['no_proxy'].nil? -%>
-    no_proxy: <%= instance['no_proxy'] %>
+<% unless instance['skip_proxy'].nil? -%>
+    skip_proxy: <%= instance['skip_proxy'] %>
 <% end -%>
 <% if instance['ca_certs'] -%>
     ca_certs: <%= instance['ca_certs'] %>


### PR DESCRIPTION
According to the DataDog UI, `no_proxy` has been deprecated and replaced with `skip_proxy`. This PR replaces `no_proxy` with `skip_proxy`.