### PR TITLE
ssh_check.d instead of ssh.d

### DIFF
--- a/manifests/integrations/ssh.pp
+++ b/manifests/integrations/ssh.pp
@@ -39,7 +39,7 @@ class datadog_agent::integrations::ssh(
 
   $legacy_dst = "${datadog_agent::conf_dir}/ssh.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/ssh.d/conf.yaml"
+    $dst = "${datadog_agent::conf6_dir}/ssh_check.d/conf.yaml"
     file { $legacy_dst:
       ensure => 'absent'
     }

--- a/spec/classes/datadog_agent_integrations_ssh_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ssh_spec.rb
@@ -20,7 +20,7 @@ describe 'datadog_agent::integrations::ssh' do
       if enabled
         let(:conf_file) { "#{conf_dir}/ssh.yaml" }
       else
-        let(:conf_file) { "#{conf_dir}/ssh.d/conf.yaml" }
+        let(:conf_file) { "#{conf_dir}/ssh_check.d/conf.yaml" }
       end
 
       context 'with default parameters' do


### PR DESCRIPTION
https://docs.datadoghq.com/integrations/ssh_check

The SSH integration needs to be updated to create the ssh conf.yaml in the correct location.

```
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/datadog-agent/conf.d/ssh.d/conf.yaml20190308-4494-1k41zhp.lock at /etc/puppetlabs/code/environments/production/modules/datadog_agent/manifests/integrations/ssh.pp:50
Error: /Stage[main]/Datadog_agent::Integrations::Ssh/File[/etc/datadog-agent/conf.d/ssh.d/conf.yaml]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/datadog-agent/conf.d/ssh.d/conf.yaml20190308-4494-1k41zhp.lock at /etc/puppetlabs/code/environments/production/modules/datadog_agent/manifests/integrations/ssh.pp:50
```

The correct path is:
`/etc/datadog-agent/conf.d/ssh_check.d/conf.yaml.example`