### PR TITLE
Use https:// in datadog-reports.yaml

### DIFF
--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -172,7 +172,7 @@ describe 'datadog_agent::reports' do
         should contain_file(conf_file)\
           .with_owner('puppet')\
           .with_group('root')\
-          .with_content(/:api_url: api.datadoghq.eu/)
+          .with_content(/:api_url: https:\/\/api.datadoghq.eu/)
       end
       it { should contain_file(conf_file).without_content(/hostname_extraction_regex:/)  }
     end

--- a/templates/datadog-reports.yaml.erb
+++ b/templates/datadog-reports.yaml.erb
@@ -2,7 +2,7 @@
 
 ---
 :datadog_api_key: '<%= @api_key %>'
-:api_url: api.<%= @datadog_site %>
+:api_url: https://api.<%= @datadog_site %>
 <% if @hostname_extraction_regex -%>
 :hostname_extraction_regex: '<%= @hostname_extraction_regex %>'
 <% end -%>


### PR DESCRIPTION
Without specifying https://, I get this error:

```
2019-03-07T05:37:16.801Z ERROR [qtp418436983-72] [puppetserver] Puppet Report processor failed: Connection refused - Failed to open TCP connection to :80 (Connection refused - connect(2) for nil port 80)
```

In https://github.com/DataDog/puppet-datadog-agent/issues/488 one user claimed to have success by changing this URL to use HTTPS: https://github.com/krux/puppet-datadog-agent/pull/1

I've also tested this myself and found it resolves the error shown above.

The puppet versions I'm running are:
```
# Puppet agent
puppet --version
6.3.0

# Puppetserver
puppetserver --version
puppetserver version: 6.2.1

# JRuby
puppetserver ruby --version
jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 OpenJDK 64-Bit Server VM 25.191-b12 on 1.8.0_191-8u191-b12-2ubuntu0.16.04.1-b12 +jit [linux-x86_64]
```

@truthbk please have a look!