### PR TITLE
Remove apt-transport-https package install

### DIFF
--- a/manifests/ubuntu/agent5.pp
+++ b/manifests/ubuntu/agent5.pp
@@ -25,10 +25,6 @@ class datadog_agent::ubuntu::agent5(
   Optional[String] $apt_keyserver = undef,
 ) inherits datadog_agent::params{
 
-  exec { 'apt-transport-https':
-    command => '/usr/bin/apt-get install -y -q apt-transport-https'
-  }
-
   if !$skip_apt_key_trusting {
     $key = {
       'id' => $apt_key,
@@ -72,7 +68,7 @@ class datadog_agent::ubuntu::agent5(
     release  => $release,
     repos    => $repos,
     key      => $key,
-    require  => Exec['apt-transport-https'],
+    require  => Class['apt'],
     notify   => Exec['datadog_apt-get_remove_agent6'],
   }
 

--- a/manifests/ubuntu/agent6.pp
+++ b/manifests/ubuntu/agent6.pp
@@ -16,10 +16,6 @@ class datadog_agent::ubuntu::agent6(
   Optional[String] $apt_keyserver = undef,
 ) inherits datadog_agent::params {
 
-  exec { 'apt-transport-https':
-    command => '/usr/bin/apt-get install -y -q apt-transport-https'
-  }
-
   if !$skip_apt_key_trusting {
     $key = {
       'id' => $apt_key,
@@ -39,7 +35,7 @@ class datadog_agent::ubuntu::agent6(
     release  => $release,
     repos    => $repos,
     key      => $key,
-    require  => Exec['apt-transport-https'],
+    require  => Class['apt'],
   }
 
   package { 'datadog-agent-base':

--- a/metadata.json
+++ b/metadata.json
@@ -59,7 +59,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.4.0 <5.0.0"
+      "version_requirement": ">=4.4.0 <5.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -38,10 +38,6 @@ describe 'datadog_agent::ubuntu::agent5' do
 
   # it should install the packages
   it do
-    should contain_exec('apt-transport-https')\
-      .that_comes_before('file[/etc/apt/sources.list.d/datadog.list]')
-  end
-  it do
     should contain_package('datadog-agent-base')\
       .with_ensure('absent')\
       .that_comes_before('package[datadog-agent]')
@@ -100,10 +96,6 @@ describe 'datadog_agent::ubuntu::agent6' do
   it { should contain_exec('apt_update') }
 
   # it should install the packages
-  it do
-    should contain_exec('apt-transport-https')\
-      .that_comes_before('file[/etc/apt/sources.list.d/datadog6.list]')
-  end
   it do
     should contain_package('datadog-agent-base')\
       .with_ensure('absent')\


### PR DESCRIPTION
Since `puppetlabs/apt` `4.4.0` is already managed in the `apt` module.

Also fixes #491 