### PR TITLE
Revert "Avoid potential dependency cycles when used with other modules"

### DIFF
--- a/manifests/ubuntu/install_key.pp
+++ b/manifests/ubuntu/install_key.pp
@@ -1,0 +1,20 @@
+# Resource type: datadog_agent::ubuntu::install_key
+#
+# This resource type install repository keys in Ubuntu
+#
+# Parameters:
+#
+# Actions:
+#
+# Requires:
+#
+# Sample Usage:
+#
+#
+#
+define datadog_agent::ubuntu::install_key($server) {
+  apt::key { $name:
+    id     => $name,
+    server => $server,
+  }
+}

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -16,16 +16,16 @@ describe 'datadog_agent::ubuntu::agent5' do
   end
 
   # it should install the mirror
-  it { should_not contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
+  it { should_not contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
   it do
-    should contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog')
+    should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE')\
   end
   context 'overriding keyserver' do
     let(:params) {{
       apt_keyserver: 'hkp://pool.sks-keyservers.net:80',
     }}
     it do
-      should contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog')\
+      should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE')\
         .with_server('hkp://pool.sks-keyservers.net:80')
     end
   end
@@ -38,7 +38,7 @@ describe 'datadog_agent::ubuntu::agent5' do
 
   # it should install the packages
   it do
-    should contain_exec('apt-transport-https')\
+    should contain_package('apt-transport-https')\
       .that_comes_before('file[/etc/apt/sources.list.d/datadog.list]')
   end
   it do
@@ -91,7 +91,8 @@ describe 'datadog_agent::ubuntu::agent6' do
   end
 
   # it should install the mirror
-  it { should contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog6') }
+  it { should_not contain_datadog_agent__ubuntu__install_key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
+  it { should contain_datadog_agent__ubuntu__install_key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
 
   it do
     should contain_file('/etc/apt/sources.list.d/datadog6.list')\
@@ -101,7 +102,7 @@ describe 'datadog_agent::ubuntu::agent6' do
 
   # it should install the packages
   it do
-    should contain_exec('apt-transport-https')\
+    should contain_package('apt-transport-https')\
       .that_comes_before('file[/etc/apt/sources.list.d/datadog6.list]')
   end
   it do


### PR DESCRIPTION
Reverts DataDog/puppet-datadog-agent#463 - should've never been merged.