### PR TITLE
[disk] add support for new options

### DIFF
--- a/manifests/integrations/disk.pp
+++ b/manifests/integrations/disk.pp
@@ -32,13 +32,19 @@
 #      excluded_disk_re     => '/dev/sd[e-z]*'
 #  }
 class datadog_agent::integrations::disk (
-  String $use_mount       = 'no',
-  $excluded_filesystems   = undef,
-  $excluded_disks         = undef,
-  $excluded_disk_re       = undef,
-  $excluded_mountpoint_re = undef,
-  $all_partitions         = undef,
-  $tag_by_filesystem      = undef
+  String $use_mount                              = 'no',
+  $all_partitions                                = undef,
+  $tag_by_filesystem                             = undef,
+  Optional[Array[String]] $filesystem_blacklist  = undef,
+  Optional[Array[String]] $device_blacklist      = undef,
+  Optional[Array[String]] $mountpoint_blacklist  = undef,
+  Optional[Array[String]] $filesystem_whitelist  = undef,
+  Optional[Array[String]] $device_whitelist      = undef,
+  Optional[Array[String]] $mountpoint_whitelist  = undef,
+  Optional[Variant[String, Array[String]]] $excluded_filesystems   = undef,  # deprecated in agent versions >6.9
+  Optional[Variant[String, Array[String]]] $excluded_disks         = undef,  # deprecated in agent versions >6.9
+  Optional[Variant[String, Array[String]]] $excluded_disk_re       = undef,  # deprecated in agent versions >6.9
+  Optional[Variant[String, Array[String]]] $excluded_mountpoint_re = undef,  # deprecated in agent versions >6.9
 ) inherits datadog_agent::params {
   include datadog_agent
 

--- a/manifests/integrations/disk.pp
+++ b/manifests/integrations/disk.pp
@@ -43,8 +43,8 @@ class datadog_agent::integrations::disk (
   Optional[Array[String]] $mountpoint_whitelist  = undef,
   Optional[Variant[String, Array[String]]] $excluded_filesystems   = undef,  # deprecated in agent versions >6.9
   Optional[Variant[String, Array[String]]] $excluded_disks         = undef,  # deprecated in agent versions >6.9
-  Optional[Variant[String, Array[String]]] $excluded_disk_re       = undef,  # deprecated in agent versions >6.9
-  Optional[Variant[String, Array[String]]] $excluded_mountpoint_re = undef,  # deprecated in agent versions >6.9
+  Optional[String] $excluded_disk_re       = undef,  # deprecated in agent versions >6.9
+  Optional[String] $excluded_mountpoint_re = undef,  # deprecated in agent versions >6.9
 ) inherits datadog_agent::params {
   include datadog_agent
 

--- a/spec/classes/datadog_agent_integrations_disk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_disk_spec.rb
@@ -72,6 +72,51 @@ instances:
          }
         it { is_expected.to contain_file(conf_file).with_content(yaml_conf) }
       end
+
+      context 'we handle new disk configuration option' do
+        let(:params) {{
+          use_mount: 'yes',
+          filesystem_blacklist: ['tmpfs', 'dev'],
+          device_blacklist: ['/dev/sda1'],
+          mountpoint_blacklist: ['/mnt/foo'],
+          filesystem_whitelist: ['ext4', 'hdfs', 'reiserfs'],
+          device_whitelist: ['/dev/sdc1', '/dev/sdc2', '/dev/sdd2'],
+          mountpoint_whitelist: ['/mnt/logs', '/mnt/builds'],
+          all_partitions: 'yes',
+          tag_by_filesystem: 'no'
+        }}
+        let(:yaml_conf) {
+           <<-HEREDOC
+### MANAGED BY PUPPET
+
+init_config:
+
+instances:
+  - use_mount: yes
+    file_system_blacklist:
+      - tmpfs
+      - dev
+    device_blacklist:
+      - /dev/sda1
+    mount_point_blacklist:
+      - /mnt/foo
+    file_system_whitelist:
+      - ext4
+      - hdfs
+      - reiserfs
+    device_whitelist:
+      - /dev/sdc1
+      - /dev/sdc2
+      - /dev/sdd2
+    mount_point_whitelist:
+      - /mnt/logs
+      - /mnt/builds
+    all_partitions: yes
+    tag_by_filesystem: no
+        HEREDOC
+         }
+        it { is_expected.to contain_file(conf_file).with_content(yaml_conf) }
+      end
     end
   end
 end

--- a/templates/agent-conf.d/disk.yaml.erb
+++ b/templates/agent-conf.d/disk.yaml.erb
@@ -4,6 +4,42 @@ init_config:
 
 instances:
   - use_mount: <%= @use_mount %>
+<% if @filesystem_blacklist -%>
+    file_system_blacklist:
+<% (Array(@filesystem_blacklist)).each do |fs| -%>
+      - <%= fs %>
+<%- end -%>
+<% end -%>
+<% if @device_blacklist -%>
+    device_blacklist:
+<% (Array(@device_blacklist)).each do |disk| -%>
+      - <%= disk %>
+<% end -%>
+<% end -%>
+<% if @mountpoint_blacklist -%>
+    mount_point_blacklist:
+<% (Array(@mountpoint_blacklist)).each do |mount| -%>
+      - <%= mount %>
+<% end -%>
+<% end -%>
+<% if @filesystem_whitelist -%>
+    file_system_whitelist:
+<% (Array(@filesystem_whitelist)).each do |fs| -%>
+      - <%= fs %>
+<%- end -%>
+<% end -%>
+<% if @device_whitelist -%>
+    device_whitelist:
+<% (Array(@device_whitelist)).each do |disk| -%>
+      - <%= disk %>
+<% end -%>
+<% end -%>
+<% if @mountpoint_whitelist -%>
+    mount_point_whitelist:
+<% (Array(@mountpoint_whitelist)).each do |mount| -%>
+      - <%= mount %>
+<% end -%>
+<% end -%>
 <% if @excluded_filesystems -%>
     excluded_filesystems:
 <% (Array(@excluded_filesystems)).each do |fs| -%>


### PR DESCRIPTION
Some options have been deprecated for the disk integration in recent versions of the agent. This PR adds support for the newer options, all while keeping the old ones for customers who may still be pinned to prior versions.