### PR TITLE
report procesor: passes @msg_host to Dogapi::Client host arg on init

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -110,8 +110,10 @@ Puppet::Reports.register_report(:datadog_reports) do
       event_data << "\n@@@\n"
     end
 
+    # instantiate DogAPI client
+    @dog = Dogapi::Client.new(API_KEY, nil, @msg_host, nil, nil, nil, API_URL)
+
     Puppet.debug "Sending metrics for #{@msg_host} to Datadog"
-    @dog = Dogapi::Client.new(API_KEY, nil, nil, nil, nil, nil, API_URL)
     @dog.batch_metrics do
       self.metrics.each { |metric,data|
         data.values.each { |val|


### PR DESCRIPTION
Hey! :wave: 

This adds the `host` argument when creating an instance of `Dogapi::Client` when sending Puppet reports to Datadog, instead of passing `nil`.

We were seeing errors like this each time Puppet tried to send a report:
```
[...] ERROR [...] [puppetserver] Puppet Report processor failed: Cannot determine local hostname via hostname -f
/opt/puppetlabs/server/data/puppetserver/jruby-gems/gems/dogapi-1.31.0/lib/dogapi/common.rb:171:in `find_localhost'
/opt/puppetlabs/server/data/puppetserver/jruby-gems/gems/dogapi-1.31.0/lib/dogapi/facade.rb:27:in `initialize'
/etc/puppetlabs/code/environments/production/modules/datadog_agent/lib/puppet/reports/datadog_reports.rb:114:in `process'
[...]
```

Adding in this arg fixed the issue for us.

It looks like Dogapi tries to figure out the reporting hostname if it doesn't get one passed to it -- so this change passes the hostname (or the extracted regex group) from the `Puppet::Transaction::Report` object's `host` property instead, and avoids of depending on running `hostname` each time.

