### PR TITLE
Custom integration with logs collection

### DIFF
--- a/lib/puppet/parser/functions/to_instances_yaml.rb
+++ b/lib/puppet/parser/functions/to_instances_yaml.rb
@@ -4,10 +4,14 @@ module Puppet::Parser::Functions
     newfunction(:to_instances_yaml, :type => :rvalue) do |args|
         init_config = args[0]
         instances = args[1]
+        logs = args[2]
         default_values = {
             'init_config'  => init_config.is_a?(String) ? nil: init_config,
             'instances' => instances
         }
+        if !logs.nil? && !logs.empty? then
+          default_values.merge({'logs' => logs})
+        end
         YAML::dump(default_values)
     end
 end

--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -1,6 +1,7 @@
 define datadog_agent::integration (
   $instances,
   $init_config = undef,
+  $logs        = undef,
   $integration = $title,
 ){
 
@@ -8,6 +9,7 @@ define datadog_agent::integration (
 
   validate_legacy(Array, 'validate_array', $instances)
   validate_legacy(Optional[Hash], 'validate_hash', $init_config)
+  validate_legacy(Optional[Array], 'validate_array', $logs)
   validate_legacy(String, 'validate_string', $integration)
 
   if !$::datadog_agent::agent5_enable {
@@ -28,7 +30,7 @@ define datadog_agent::integration (
     owner   => $datadog_agent::dd_user,
     group   => $datadog_agent::dd_group,
     mode    => '0644',
-    content => to_instances_yaml($init_config, $instances),
+    content => to_instances_yaml($init_config, $instances, $logs),
     notify  => Service[$datadog_agent::service_name]
   }
 


### PR DESCRIPTION
This PR allows the integration class to optionally use a third parameter "logs" for log collection. Like it is described in the datadog documentation: 

https://docs.datadoghq.com/logs/log_collection/?tab=tailexistingfiles

