### PR TITLE
pass in password via hiera

### DIFF
--- a/manifests/integrations/postgres.pp
+++ b/manifests/integrations/postgres.pp
@@ -64,10 +64,26 @@
 #      }
 #    }
 #  }
+# 
+# Hiera Usage:
 #
+#   datadog_agent::integrations::postgres::instances:
+#     - host: 'localhost'
+#       dbname: 'postgres'
+#       username: 'datadog'
+#       password: 'some_pass'
+#       ssl: false
+#       custom_metrics:
+#         a_custom_query:
+#           query: 'select tag_column, %s from table'
+#           relation: false
+#           metrics:
+#             value_column: ["value_column.datadog.tag", "GAUGE"]
+#           descriptors:
+#           - ["tag_column", "tag_column.datadog.tag"]
 #
 class datadog_agent::integrations::postgres(
-  String $password,
+  Optional[String] $password             = undef,
   String $host                           = 'localhost',
   String $dbname                         = 'postgres',
   Variant[String, Integer] $port         = '5432',

--- a/spec/classes/datadog_agent_integrations_postgres_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postgres_spec.rb
@@ -24,7 +24,7 @@ describe 'datadog_agent::integrations::postgres' do
       end
 
       context 'with default parameters' do
-        it { should_not compile }
+        it { should compile }
       end
 
       context 'with password set' do


### PR DESCRIPTION
We should be able to use this class with `include datadog_agent::integrations::postgres`, but without specifying a password, this fails:

Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Class[Datadog_agent::Integrations::Postgres]: expects a value for parameter 'password'