### PR TITLE
Update concat compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=4.0.0 <5.0.0"
+      "version_requirement": ">=4.0.0 <6.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
Update puppet module concat compatibility to versions under 6.0.0.

With the latest version of concat on datadog_agent 2.5.0, ```puppet module list --tree```
resulted in:

    Warning: Module 'puppetlabs-concat' (v5.3.0) fails to meet some dependencies:
      'datadog-datadog_agent' (v2.5.0) requires 'puppetlabs-concat' (>=4.0.0 <5.0.0)