### PR TITLE
Bring module up to using > 5.0.0 stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -59,7 +59,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=4.4.0 <5.0.0"
+      "version_requirement": ">=4.4.0 <6.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.24.0 <5.0.0"
+      "version_requirement": ">=4.24.0 <6.0.0"
     },
     {
       "name": "puppetlabs/ruby",

--- a/metadata.json
+++ b/metadata.json
@@ -55,11 +55,11 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=4.0.0 <5.0.0"
+      "version_requirement": ">=4.0.0 <6.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=4.4.0 <6.0.0"
+      "version_requirement": ">=4.4.0 <=6.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",


### PR DESCRIPTION
Need to bump these modules as their max version of stdlib is < 5
* apt
* concat

Concat was bumped in a previous PR https://github.com/DataDog/puppet-datadog-agent/pull/516 , however to get this to install correct, I needed to include the same change. 