### PR TITLE
[http_check] add support for http_check method and data

### DIFF
--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -12,6 +12,13 @@
 #   timeout
 #       The (optional) timeout in seconds.
 #
+#   method
+#    	The (optional) HTTP method. This setting defaults to GET, though many
+#    	other HTTP methods are supported, including POST and PUT.
+#   data
+#       The (optional) data option. Data should be a string or an array of
+#       key-value pairs and will be sent in the body of the request.
+#
 #   username
 #   password
 #       If your service uses basic authentication, you can optionally
@@ -154,6 +161,8 @@ class datadog_agent::integrations::http_check (
   $username  = undef,
   $password  = undef,
   $timeout   = 1,
+  $method    = 'get',
+  $data      = undef,
   $threshold = undef,
   $window    = undef,
   $content_match = undef,
@@ -182,6 +191,8 @@ class datadog_agent::integrations::http_check (
       'username'                     => $username,
       'password'                     => $password,
       'timeout'                      => $timeout,
+      'method'                       => $method,
+      'data'                         => $data,
       'threshold'                    => $threshold,
       'window'                       => $window,
       'content_match'                => $content_match,

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -38,6 +38,7 @@ describe 'datadog_agent::integrations::http_check' do
         it { should contain_file(conf_file).without_content(%r{username: }) }
         it { should contain_file(conf_file).without_content(%r{password: }) }
         it { should contain_file(conf_file).without_content(%r{timeout: 1}) }
+        it { should contain_file(conf_file).without_content(%r{data: }) }
         it { should contain_file(conf_file).without_content(%{threshold: }) }
         it { should contain_file(conf_file).without_content(%r{window: }) }
         it { should contain_file(conf_file).without_content(%r{content_match: }) }
@@ -61,6 +62,8 @@ describe 'datadog_agent::integrations::http_check' do
           username: 'foouser',
           password: 'barpassword',
           timeout: 123,
+          method: 'post',
+          data: 'key=value',
           threshold: 456,
           window: 789,
           content_match: 'foomatch',
@@ -82,6 +85,8 @@ describe 'datadog_agent::integrations::http_check' do
         it { should contain_file(conf_file).with_content(%r{username: foouser}) }
         it { should contain_file(conf_file).with_content(%r{password: barpassword}) }
         it { should contain_file(conf_file).with_content(%r{timeout: 123}) }
+        it { should contain_file(conf_file).with_content(%r{method: post}) }
+        it { should contain_file(conf_file).with_content(%r{data: key=value}) }
         it { should contain_file(conf_file).with_content(%r{threshold: 456}) }
         it { should contain_file(conf_file).with_content(%r{window: 789}) }
         it { should contain_file(conf_file).with_content(%r{content_match: 'foomatch'}) }
@@ -96,6 +101,19 @@ describe 'datadog_agent::integrations::http_check' do
         it { should contain_file(conf_file).with_content(%r{days_critical: 7}) }
         it { should contain_file(conf_file).with_content(%r{allow_redirects: true}) }
         it { should contain_file(conf_file).with_content(%r{ca_certs: /dev/null}) }
+      end
+
+      context 'with json post data' do
+        let(:params) {{
+          sitename: 'foo.bar.baz',
+          url: 'http://foo.bar.baz:4096',
+          method: 'post',
+          data: ['key: value'],
+          headers: ['Content-Type: application/json'],
+        }}
+        it { should contain_file(conf_file).with_content(%r{method: post}) }
+        it { should contain_file(conf_file).with_content(/data:\s+key:\s+value/) }
+        it { should contain_file(conf_file).with_content(/headers:\s+Content-Type:\s+application\/json/) }
       end
 
       context 'with headers parameter array' do

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -9,6 +9,17 @@ instances:
 <% if instance['timeout'] -%>
     timeout: <%= instance['timeout'] %>
 <% end -%>
+<% if instance['method'] -%>
+    method: <%= instance['method'] %>
+<% end -%>
+<% if instance['data'].is_a?(String) -%>
+    data: <%= instance['data'] %>
+<% elsif instance['data'].is_a?(Array) -%>
+    data:
+    <%- instance['data'].each do |data| -%>
+      <%= data %>
+    <%- end -%>
+<% end -%>
 <% if instance['username'] -%>
     username: <%= instance['username'] %>
 <% end -%>


### PR DESCRIPTION
This adds support for the method and data parameters as specified in the [http_check](https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example#L26).

The data parameter in http_check can be either a string or an array of strings.
If it's a string, datadog-agent will interpret this as the entire body of the post data.  For example:
```
init_config:
instances:
  - name: datadog
    url: https://www.datadoghq.com/
    method: post
    data: foo=bar
```
would result in a post body of:
```foo=bar```

If an array of strings is given, each string must be in `key: value` format. The agent will convert these into the json post data. For example:
```
init_config:
instances:
  - name: datadog
    url: https://www.datadoghq.com/
    method: post
    data:
      foo: bar
      spam: eggs
```
would result in a post body of:
```{"foo": "bar", "spam": "eggs"}```