### PR TITLE
[redis] mutli-instance support

### DIFF
--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -37,6 +37,7 @@ class datadog_agent::integrations::redis(
   Array $keys                               = [],
   Boolean $warn_on_missing_keys             = true,
   Boolean $command_stats                    = false,
+  Optional[Array] $instances                = undef,
 
 ) inherits datadog_agent::params {
   include datadog_agent
@@ -55,6 +56,19 @@ class datadog_agent::integrations::redis(
 
   validate_legacy('Array', 'validate_array', $_ports)
 
+  $_port_instances = $_ports.map |$instance_port| {
+     {
+      'host'                          => $host,
+      'password'                      => $password,
+      'port'                          => $instance_port,
+      'slowlog_max_len'               => $slowlog_max_len,
+      'tags'                          => $tags,
+      'keys'                          => $keys,
+      'warn_on_missing_keys'          => $warn_on_missing_keys,
+      'command_stats'                 => $command_stats,
+    }
+  }
+
   $legacy_dst = "${datadog_agent::conf_dir}/redisdb.yaml"
   if !$::datadog_agent::agent5_enable {
     $dst = "${datadog_agent::conf6_dir}/redisdb.d/conf.yaml"
@@ -63,6 +77,14 @@ class datadog_agent::integrations::redis(
     }
   } else {
     $dst = $legacy_dst
+  }
+
+  if !$instances and $host {
+    $_instances = $_port_instances
+  } elsif !$instances{
+    $_instances = []
+  } else {
+    $_instances = $instances
   }
 
   file { $dst:

--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -19,6 +19,10 @@
 #       Optional array of keys to check length
 #   $command_stats
 #       Collect INFO COMMANDSTATS output as metrics
+#   $instances
+#       Optional array of hashes should you wish to specify multiple instances.
+#       If this option is specified all other parameters will be overriden.
+#       This parameter may also be used to specify instances with hiera.
 #
 # Sample Usage:
 #
@@ -26,6 +30,15 @@
 #    host => 'localhost',
 #  }
 #
+# Hiera Usage:
+#
+#   datadog_agent::integrations::redis::instances:
+#     - host: 'localhost'
+#       password: 'datadog'
+#       port: 6379
+#       slowlog_max_len: 1000
+#       warn_on_missing_keys: true
+#       command_stats: false
 #
 class datadog_agent::integrations::redis(
   String $host                              = 'localhost',

--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -57,15 +57,15 @@ class datadog_agent::integrations::redis(
   validate_legacy('Array', 'validate_array', $_ports)
 
   $_port_instances = $_ports.map |$instance_port| {
-     {
-      'host'                          => $host,
-      'password'                      => $password,
-      'port'                          => $instance_port,
-      'slowlog_max_len'               => $slowlog_max_len,
-      'tags'                          => $tags,
-      'keys'                          => $keys,
-      'warn_on_missing_keys'          => $warn_on_missing_keys,
-      'command_stats'                 => $command_stats,
+    {
+      'host'                 => $host,
+      'password'             => $password,
+      'port'                 => $instance_port,
+      'slowlog_max_len'      => $slowlog_max_len,
+      'tags'                 => $tags,
+      'keys'                 => $keys,
+      'warn_on_missing_keys' => $warn_on_missing_keys,
+      'command_stats'        => $command_stats,
     }
   }
 

--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -86,6 +86,36 @@ describe 'datadog_agent::integrations::redis' do
         it { should contain_file(conf_file).with_content(%r{port: 2380}) }
         it { should contain_file(conf_file).with_content(%r{port: 2381}) }
       end
+
+      context 'with instances set' do
+        let(:params) {{
+          instances: [
+              {
+                  'host'     => 'redis1',
+                  'password' => 'hunter2',
+                  'port'     => 2379,
+                  'tags'     => %w(foo bar),
+                  'keys'     => %w(baz bat),
+              },
+              {
+                  'host'     => 'redis1',
+                  'password' => 'hunter2',
+                  'port'     => 2380,
+                  'tags'     => %w(foo bar),
+                  'keys'     => %w(baz bat),
+              },
+          ],
+        }}
+        it { should contain_file(conf_file).with_content(%r{host: redis1}) }
+        it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+        it { should contain_file(conf_file).with_content(%r{port: 2379}) }
+        it { should contain_file(conf_file).with_content(%r{port: 2380}) }
+        it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
+        it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
+        it { should contain_file(conf_file).without_content(%r{^[^#]*slowlog-max-len: 5309}) }
+        it { should contain_file(conf_file).without_content(%r{warn_on_missing_keys: false}) }
+        it { should contain_file(conf_file).without_content(%r{command_stats: true}) }
+      end
     end
   end
 end

--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -34,8 +34,8 @@ describe 'datadog_agent::integrations::redis' do
 
       context 'with default parameters' do
         it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-        it { should contain_file(conf_file).without_content(%r{^[^#]*password: }) }
         it { should contain_file(conf_file).with_content(%r{port: 6379}) }
+        it { should contain_file(conf_file).without_content(%r{^[^#]*password: }) }
         it { should contain_file(conf_file).without_content(%r{^[^#]*slowlog-max-len: }) }
         it { should contain_file(conf_file).without_content(%r{tags:}) }
         it { should contain_file(conf_file).without_content(%r{\bkeys:}) }
@@ -62,6 +62,29 @@ describe 'datadog_agent::integrations::redis' do
         it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
         it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
         it { should contain_file(conf_file).with_content(%r{command_stats: true}) }
+      end
+
+      context 'with ports parameters set' do
+        let(:params) {{
+          host: 'redis1',
+          password: 'hunter2',
+          ports: %w(2379 2380 2381),
+          slowlog_max_len: '5309',
+          tags: %w{foo bar},
+          keys: %w{baz bat},
+          warn_on_missing_keys: false,
+          command_stats: true,
+        }}
+        it { should contain_file(conf_file).with_content(%r{host: redis1}) }
+        it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+        it { should contain_file(conf_file).with_content(%r{^[^#]*slowlog-max-len: 5309}) }
+        it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
+        it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
+        it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
+        it { should contain_file(conf_file).with_content(%r{command_stats: true}) }
+        it { should contain_file(conf_file).with_content(%r{port: 2379}) }
+        it { should contain_file(conf_file).with_content(%r{port: 2380}) }
+        it { should contain_file(conf_file).with_content(%r{port: 2381}) }
       end
     end
   end

--- a/templates/agent-conf.d/redisdb.yaml.erb
+++ b/templates/agent-conf.d/redisdb.yaml.erb
@@ -3,24 +3,39 @@
 init_config:
 
 instances:
-<% @_ports.each do |port| -%>
-  - host: <%= @host %>
-    port: <%= port %>
-    warn_on_missing_keys: <%= @warn_on_missing_keys %>
-    command_stats: <%= @command_stats %>
-    <% if @password.empty? %># <%end %>password: <%= @password %>
+<%- (Array(@_instances)).each do |instance| -%>
+  - host: <%= instance['host'] %>
+    port: <%= instance['port']  %>
+<% if instance['password']  and ! instance['password'].empty? -%>
+    password: <%= instance['password'] %>
+<% end -%>
+<% if instance['slowlog_max_len']  and ! instance['slowlog_max_len'].empty? -%>
     # unix_socket_path: /var/run/redis/redis.sock # optional, can be used in lieu of host/port
-    <% if @slowlog_max_len.empty? %># <%end %>slowlog-max-len: <%= @slowlog_max_len %>
-<% unless @tags.empty? -%>
-    tags:                  # Optional
-<% @tags.each do |tag| -%>
-        - <%= tag %>
+    slowlog-max-len: <%= instance['slowlog_max_len'] %>
+<% end -%>
+<% if !instance['warn_on_missing_keys'].nil? -%>
+    warn_on_missing_keys: <%= instance['warn_on_missing_keys'] %>
+<% end -%>
+<% if !instance['command_stats'].nil? -%>
+    command_stats: <%= instance['command_stats'] %>
+<% end -%>
+<% if instance['keys']  and unless instance['keys'].empty? -%>
+    keys:
+  <%- Array(instance['keys'] ).each do |key| -%>
+    <%- if key != '' -%>
+      - <%= key %>
+    <%- end -%>
+  <% end -%>
+<% end -%>
+<% if instance['tags']  and unless instance['tags'].empty? -%>
+    tags:
+  <%- Array(instance['tags'] ).each do |tag| -%>
+    <%- if tag != '' -%>
+      - <%= tag %>
+    <%- end -%>
+  <% end -%>
 <% end -%>
 <% end -%>
-<% unless @keys.empty? -%>
-    keys:  # check the length of these keys
-<% @keys.each do |key| -%>
-        - <%= key %>
-<% end -%>
+
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This PR adds multiple instance support to the manifest while maintaining backward compatibility.

spec tests could be more precise validating the YAML structure.