### PR TITLE
Track integration configuration directories

### DIFF
--- a/manifests/integrations/apache.pp
+++ b/manifests/integrations/apache.pp
@@ -41,10 +41,20 @@ class datadog_agent::integrations::apache (
 
   $legacy_dst = "${datadog_agent::conf_dir}/apache.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/apache.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/apache.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/cacti.pp
+++ b/manifests/integrations/cacti.pp
@@ -22,10 +22,20 @@ class datadog_agent::integrations::cacti(
 
   $legacy_dst = "${datadog_agent::conf_dir}/cacti.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/cacti.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/cacti.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/cassandra.pp
+++ b/manifests/integrations/cassandra.pp
@@ -38,11 +38,20 @@ class datadog_agent::integrations::cassandra(
 
   $legacy_dst = "${datadog_agent::conf_dir}/cassandra.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/cassandra.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/cassandra.d"
 
     file { $legacy_dst:
       ensure => 'absent'
     }
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/ceph.pp
+++ b/manifests/integrations/ceph.pp
@@ -28,10 +28,20 @@ class datadog_agent::integrations::ceph(
 
   $legacy_dst = "${datadog_agent::conf_dir}/ceph.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/ceph.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/ceph.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/consul.pp
+++ b/manifests/integrations/consul.pp
@@ -42,10 +42,20 @@ class datadog_agent::integrations::consul(
 
   $legacy_dst = "${datadog_agent::conf_dir}/consul.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/consul.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/consul.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/directory.pp
+++ b/manifests/integrations/directory.pp
@@ -95,10 +95,20 @@ class datadog_agent::integrations::directory (
 
   $legacy_dst = "${datadog_agent::conf_dir}/directory.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/directory.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/directory.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/disk.pp
+++ b/manifests/integrations/disk.pp
@@ -56,10 +56,20 @@ class datadog_agent::integrations::disk (
 
   $legacy_dst = "${datadog_agent::conf_dir}/disk.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/disk.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/disk.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/dns_check.pp
+++ b/manifests/integrations/dns_check.pp
@@ -39,10 +39,20 @@ class datadog_agent::integrations::dns_check (
 
   $legacy_dst = "${datadog_agent::conf_dir}/dns_check.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/dns_check.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/dns_check.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/docker_daemon.pp
+++ b/manifests/integrations/docker_daemon.pp
@@ -65,7 +65,17 @@ class datadog_agent::integrations::docker_daemon(
   }
 
   if !$::datadog_agent::agent5_enable {
-    $legacy_conf = "${datadog_agent::conf6_dir}/docker_daemon.d/conf.yaml"
+    $legacy_dir = "${datadog_agent::conf6_dir}/docker_daemon.d"
+
+    file { $legacy_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $legacy_conf = "${legacy_dir}/conf.yaml"
   } else {
     $legacy_conf = "${datadog_agent::conf_dir}/docker.yaml"
   }
@@ -75,7 +85,17 @@ class datadog_agent::integrations::docker_daemon(
   }
 
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/docker.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/docker.d"
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = "${datadog_agent::conf_dir}/docker_daemon.yaml"
   }

--- a/manifests/integrations/elasticsearch.pp
+++ b/manifests/integrations/elasticsearch.pp
@@ -76,10 +76,20 @@ class datadog_agent::integrations::elasticsearch(
 
   $legacy_dst = "${datadog_agent::conf_dir}/elastic.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/elastic.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/elastic.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/fluentd.pp
+++ b/manifests/integrations/fluentd.pp
@@ -27,10 +27,20 @@ class datadog_agent::integrations::fluentd(
 
   $legacy_dst = "${datadog_agent::conf_dir}/fluentd.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/fluentd.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/fluentd.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/generic.pp
+++ b/manifests/integrations/generic.pp
@@ -27,10 +27,20 @@ class datadog_agent::integrations::generic(
 
   $legacy_dst = "${datadog_agent::conf_dir}/${integration_name}.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/${integration_name}.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/${integration_name}.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/haproxy.pp
+++ b/manifests/integrations/haproxy.pp
@@ -38,10 +38,20 @@ class datadog_agent::integrations::haproxy(
 
   $legacy_dst = "${datadog_agent::conf_dir}/haproxy.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/haproxy.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/haproxy.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -208,10 +208,20 @@ class datadog_agent::integrations::http_check (
 
   $legacy_dst = "${datadog_agent::conf_dir}/http_check.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/http_check.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/http_check.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/jenkins.pp
+++ b/manifests/integrations/jenkins.pp
@@ -20,10 +20,20 @@ class datadog_agent::integrations::jenkins(
 
   $legacy_dst = "${datadog_agent::conf_dir}/jenkins.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/jenkins.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/jenkins.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/jmx.pp
+++ b/manifests/integrations/jmx.pp
@@ -69,10 +69,20 @@ class datadog_agent::integrations::jmx(
 
   $legacy_dst = "${datadog_agent::conf_dir}/jmx.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/jmx.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/jmx.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/kafka.pp
+++ b/manifests/integrations/kafka.pp
@@ -88,10 +88,20 @@ class datadog_agent::integrations::kafka(
 
   $legacy_dst = "${datadog_agent::conf_dir}/kafka.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/kafka.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/kafka.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/kong.pp
+++ b/manifests/integrations/kong.pp
@@ -36,10 +36,20 @@ class datadog_agent::integrations::kong (
 
   $legacy_dst = "${datadog_agent::conf_dir}/kong.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/kong.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/kong.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/kubernetes.pp
+++ b/manifests/integrations/kubernetes.pp
@@ -34,10 +34,20 @@ class datadog_agent::integrations::kubernetes(
 
   $legacy_dst = "${datadog_agent::conf_dir}/kubernetes.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/kubernetes.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/kubernetes.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/kubernetes_state.pp
+++ b/manifests/integrations/kubernetes_state.pp
@@ -26,10 +26,20 @@ class datadog_agent::integrations::kubernetes_state(
 
   $legacy_dst = "${datadog_agent::conf_dir}/kubernetes_state.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/kubernetes_state.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/kubernetes_state.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/linux_proc_extras.pp
+++ b/manifests/integrations/linux_proc_extras.pp
@@ -20,10 +20,20 @@ class datadog_agent::integrations::linux_proc_extras(
 
   $legacy_dst = "${datadog_agent::conf_dir}/linux_proc_extras.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/linux_proc_extras.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/linux_proc_extras.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/marathon.pp
+++ b/manifests/integrations/marathon.pp
@@ -20,10 +20,20 @@ class datadog_agent::integrations::marathon(
 
   $legacy_dst = "${datadog_agent::conf_dir}/marathon.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/marathon.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/marathon.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/memcache.pp
+++ b/manifests/integrations/memcache.pp
@@ -59,10 +59,20 @@ class datadog_agent::integrations::memcache (
 
   $legacy_dst = "${datadog_agent::conf_dir}/mcache.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/mcache.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/mcache.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/mesos_master.pp
+++ b/manifests/integrations/mesos_master.pp
@@ -19,7 +19,17 @@ class datadog_agent::integrations::mesos_master(
   include datadog_agent
 
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/mesos.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/mesos.d"
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = "${datadog_agent::conf_dir}/mesos.yaml"
   }
@@ -30,10 +40,20 @@ class datadog_agent::integrations::mesos_master(
 
   $legacy_dst_master = "${datadog_agent::conf_dir}/mesos_master.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst_master = "${datadog_agent::conf6_dir}/mesos_master.d/conf.yaml"
+    $dst_master_dir = "${datadog_agent::conf6_dir}/mesos_master.d"
     file { $legacy_dst_master:
       ensure => 'absent'
     }
+
+    file { $dst_master_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst_master = "${dst_master_dir}/conf.yaml"
   } else {
     $dst_master = $legacy_dst_master
   }

--- a/manifests/integrations/mesos_slave.pp
+++ b/manifests/integrations/mesos_slave.pp
@@ -19,10 +19,20 @@ class datadog_agent::integrations::mesos_slave(
 
   $legacy_dst = "${datadog_agent::conf_dir}/mesos_slave.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/mesos_slave.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/mesos_slave.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/mongo.pp
+++ b/manifests/integrations/mongo.pp
@@ -66,10 +66,20 @@ class datadog_agent::integrations::mongo(
 
   $legacy_dst = "${datadog_agent::conf_dir}/mongo.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/mongo.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/mongo.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -115,10 +115,20 @@ class datadog_agent::integrations::mysql(
 
   $legacy_dst = "${datadog_agent::conf_dir}/mysql.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/mysql.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/mysql.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/network.pp
+++ b/manifests/integrations/network.pp
@@ -33,10 +33,20 @@ class datadog_agent::integrations::network(
 
   $legacy_dst = "${datadog_agent::conf_dir}/network.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/network.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/network.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/nginx.pp
+++ b/manifests/integrations/nginx.pp
@@ -31,10 +31,20 @@ class datadog_agent::integrations::nginx(
 
   $legacy_dst = "${datadog_agent::conf_dir}/nginx.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/nginx.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/nginx.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/ntp.pp
+++ b/manifests/integrations/ntp.pp
@@ -34,10 +34,20 @@ class datadog_agent::integrations::ntp(
 
   $legacy_dst = "${datadog_agent::conf_dir}/ntp.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/ntp.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/ntp.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/pgbouncer.pp
+++ b/manifests/integrations/pgbouncer.pp
@@ -58,10 +58,20 @@ class datadog_agent::integrations::pgbouncer(
 
   $legacy_dst = "${datadog_agent::conf_dir}/pgbouncer.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/pgbouncer.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/pgbouncer.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/php_fpm.pp
+++ b/manifests/integrations/php_fpm.pp
@@ -47,10 +47,20 @@ class datadog_agent::integrations::php_fpm(
 
   $legacy_dst = "${datadog_agent::conf_dir}/php_fpm.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/php_fpm.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/php_fpm.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/postfix.pp
+++ b/manifests/integrations/postfix.pp
@@ -54,10 +54,20 @@ class datadog_agent::integrations::postfix (
 
   $legacy_dst = "${datadog_agent::conf_dir}/postfix.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/postfix.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/postfix.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/postgres.pp
+++ b/manifests/integrations/postgres.pp
@@ -92,10 +92,20 @@ class datadog_agent::integrations::postgres(
 
   $legacy_dst = "${datadog_agent::conf_dir}/postgres.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/postgres.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/postgres.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/process.pp
+++ b/manifests/integrations/process.pp
@@ -57,10 +57,20 @@ class datadog_agent::integrations::process(
 
   $legacy_dst = "${datadog_agent::conf_dir}/process.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/process.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/process.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/rabbitmq.pp
+++ b/manifests/integrations/rabbitmq.pp
@@ -81,10 +81,20 @@ class datadog_agent::integrations::rabbitmq (
 
   $legacy_dst = "${datadog_agent::conf_dir}/rabbitmq.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/rabbitmq.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/rabbitmq.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -57,10 +57,20 @@ class datadog_agent::integrations::redis(
 
   $legacy_dst = "${datadog_agent::conf_dir}/redisdb.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/redisdb.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/redisdb.d/conf.yaml"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -57,7 +57,7 @@ class datadog_agent::integrations::redis(
 
   $legacy_dst = "${datadog_agent::conf_dir}/redisdb.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst_dir = "${datadog_agent::conf6_dir}/redisdb.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/redisdb.d"
     file { $legacy_dst:
       ensure => 'absent'
     }

--- a/manifests/integrations/riak.pp
+++ b/manifests/integrations/riak.pp
@@ -29,10 +29,20 @@ class datadog_agent::integrations::riak(
 
   $legacy_dst = "${datadog_agent::conf_dir}/riak.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/riak.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/riak.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/snmp.pp
+++ b/manifests/integrations/snmp.pp
@@ -71,10 +71,20 @@ class datadog_agent::integrations::snmp (
 
   $legacy_dst = "${datadog_agent::conf_dir}/snmp.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/snmp.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/snmp.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/solr.pp
+++ b/manifests/integrations/solr.pp
@@ -40,10 +40,20 @@ class datadog_agent::integrations::solr(
 
   $legacy_dst = "${datadog_agent::conf_dir}/solr.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/solr.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/solr.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/ssh.pp
+++ b/manifests/integrations/ssh.pp
@@ -39,10 +39,20 @@ class datadog_agent::integrations::ssh(
 
   $legacy_dst = "${datadog_agent::conf_dir}/ssh.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/ssh_check.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/ssh_check.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/supervisord.pp
+++ b/manifests/integrations/supervisord.pp
@@ -48,10 +48,20 @@ class datadog_agent::integrations::supervisord (
 
   $legacy_dst = "${datadog_agent::conf_dir}/supervisord.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/supervisord.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/supervisord.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/system_core.pp
+++ b/manifests/integrations/system_core.pp
@@ -11,10 +11,20 @@ class datadog_agent::integrations::system_core inherits datadog_agent::params {
 
   $legacy_dst = "${datadog_agent::conf_dir}/system_core.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/system_core.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/system_core.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/tcp_check.pp
+++ b/manifests/integrations/tcp_check.pp
@@ -119,10 +119,20 @@ class datadog_agent::integrations::tcp_check (
 
   $legacy_dst = "${datadog_agent::conf_dir}/tcp_check.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/tcp_check.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/tcp_check.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/tomcat.pp
+++ b/manifests/integrations/tomcat.pp
@@ -44,10 +44,20 @@ class datadog_agent::integrations::tomcat(
 
   $legacy_dst = "${datadog_agent::conf_dir}/tomcat.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/tomcat.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/tomcat.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/twemproxy.pp
+++ b/manifests/integrations/twemproxy.pp
@@ -43,10 +43,20 @@ class datadog_agent::integrations::twemproxy(
 
   $legacy_dst = "${datadog_agent::conf_dir}/twemproxy.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/twemproxy.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/twemproxy.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/varnish.pp
+++ b/manifests/integrations/varnish.pp
@@ -30,10 +30,20 @@ class datadog_agent::integrations::varnish (
 
   $legacy_dst = "${datadog_agent::conf_dir}/varnish.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/varnish.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/varnish.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }

--- a/manifests/integrations/zk.pp
+++ b/manifests/integrations/zk.pp
@@ -36,10 +36,20 @@ class datadog_agent::integrations::zk (
 
   $legacy_dst = "${datadog_agent::conf_dir}/zk.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/zk.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/zk.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }


### PR DESCRIPTION
As described in https://github.com/DataDog/puppet-datadog-agent/issues/512, when $conf_dir_purge is true, but $agent5_enable is false, puppet errors because it purges the untracked integration conf.d files, which are expected to be present.

This change tracks all conf.d files in the all the integration classes. This ensures they won't be purge by puppet when $conf_dir_purge is true.