### PR TITLE
Fix trying to call .empty? on an integer

### DIFF
--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -48,7 +48,7 @@ describe 'datadog_agent::integrations::redis' do
           host: 'redis1',
           password: 'hunter2',
           port: 867,
-          slowlog_max_len: '5309',
+          slowlog_max_len: 5309,
           tags: %w{foo bar},
           keys: %w{baz bat},
           warn_on_missing_keys: false,
@@ -69,7 +69,7 @@ describe 'datadog_agent::integrations::redis' do
           host: 'redis1',
           password: 'hunter2',
           ports: %w(2379 2380 2381),
-          slowlog_max_len: '5309',
+          slowlog_max_len: 5309,
           tags: %w{foo bar},
           keys: %w{baz bat},
           warn_on_missing_keys: false,
@@ -85,6 +85,27 @@ describe 'datadog_agent::integrations::redis' do
         it { should contain_file(conf_file).with_content(%r{port: 2379}) }
         it { should contain_file(conf_file).with_content(%r{port: 2380}) }
         it { should contain_file(conf_file).with_content(%r{port: 2381}) }
+      end
+
+      context 'with strings instead of ints' do
+        let(:params) {{
+          host: 'redis1',
+          password: 'hunter2',
+          port: '867',
+          slowlog_max_len: '5309',
+          tags: %w{foo bar},
+          keys: %w{baz bat},
+          warn_on_missing_keys: false,
+          command_stats: true,
+        }}
+        it { should contain_file(conf_file).with_content(%r{host: redis1}) }
+        it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+        it { should contain_file(conf_file).with_content(%r{port: 867}) }
+        it { should contain_file(conf_file).with_content(%r{^[^#]*slowlog-max-len: 5309}) }
+        it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
+        it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
+        it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
+        it { should contain_file(conf_file).with_content(%r{command_stats: true}) }
       end
 
       context 'with instances set' do

--- a/templates/agent-conf.d/redisdb.yaml.erb
+++ b/templates/agent-conf.d/redisdb.yaml.erb
@@ -9,7 +9,7 @@ instances:
 <% if instance['password']  and ! instance['password'].empty? -%>
     password: <%= instance['password'] %>
 <% end -%>
-<% if instance['slowlog_max_len']  and ! instance['slowlog_max_len'].empty? -%>
+<% if instance['slowlog_max_len'] and ! instance['slowlog_max_len'].to_s.empty? -%>
     # unix_socket_path: /var/run/redis/redis.sock # optional, can be used in lieu of host/port
     slowlog-max-len: <%= instance['slowlog_max_len'] %>
 <% end -%>


### PR DESCRIPTION
`slowlog_max_len` can be either int or string. Always cast it to string.

I haven't been able to run the tests locally. I hope this is the correct way to cast to string in puppet and the tests pass on the CI.