### PR TITLE
[activemq_xml] fix manifest when A6 and purge enabled

### DIFF
--- a/manifests/integrations/activemq_xml.pp
+++ b/manifests/integrations/activemq_xml.pp
@@ -56,10 +56,20 @@ class datadog_agent::integrations::activemq_xml(
 
   $legacy_dst = "${datadog_agent::conf_dir}/activemq_xml.yaml"
   if !$::datadog_agent::agent5_enable {
-    $dst = "${datadog_agent::conf6_dir}/activemq_xml.d/conf.yaml"
+    $dst_dir = "${datadog_agent::conf6_dir}/activemq_xml.d"
     file { $legacy_dst:
       ensure => 'absent'
     }
+
+    file { $dst_dir:
+      ensure  => directory,
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0755',
+      require => Package[$datadog_agent::params::package_name],
+      notify  => Service[$datadog_agent::params::service_name]
+    }
+    $dst = "${dst_dir}/conf.yaml"
   } else {
     $dst = $legacy_dst
   }


### PR DESCRIPTION
After the merge of #512 we ended up having `activemq_xml` out of sync we the purge management fix. This addresses that.