### PR TITLE
Add whitespace surpression to redisdb.yaml.erb to ensure a valid yaml

### DIFF
--- a/templates/agent-conf.d/redisdb.yaml.erb
+++ b/templates/agent-conf.d/redisdb.yaml.erb
@@ -25,7 +25,7 @@ instances:
     <%- if key != '' -%>
       - <%= key %>
     <%- end -%>
-  <% end -%>
+  <%- end -%>
 <% end -%>
 <% if instance['tags']  and unless instance['tags'].empty? -%>
     tags:
@@ -33,7 +33,7 @@ instances:
     <%- if tag != '' -%>
       - <%= tag %>
     <%- end -%>
-  <% end -%>
+  <%- end -%>
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
Add white space suppression to redisdb.yaml.erb to ensure a valid yaml file is output.

Currently multiple keys or tags will break the indentation. EG:
```
class { 'datadog_agent::integrations::redis' :
  host => 'localhost',
  keys => ['foo','bar'],
  tags => ['foo:bar','spam:egg'],
}
```
Will output invalid yaml:
```
### MANAGED BY PUPPET

init_config:

instances:
  - host: localhost
    port: 6379
    warn_on_missing_keys: true
    command_stats: false
    keys:
      - foo
        - bar
      tags:
      - foo:bar
        - spam:egg

```

With this change applied, the output will be valid yaml:
```
### MANAGED BY PUPPET

init_config:

instances:
  - host: localhost
    port: 6379
    warn_on_missing_keys: true
    command_stats: false
    keys:
      - foo
      - bar
    tags:
      - foo:bar
      - spam:egg
```
