### PR TITLE
Support puppet 6

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,6 +13,8 @@ fixtures:
       repo: "git://github.com/puppetlabs/puppetlabs-puppetserver_gem.git"
       ref: "1.0.0"
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
+  forge_modules:
+    yumrepo_core: "puppetlabs/yumrepo_core"
   symlinks:
     custom_datadog: "#{source_dir}/spec/custom_fixtures/custom_datadog"
     datadog_agent: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,28 @@ rvm:
 script:
   - bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 4.6.2" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.7.1" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.8.2" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.9.4" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.10.9" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 5.0.1" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 5.1.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 5.2.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 5.3.3" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 6.0.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 6.5.0" STRICT_VARIABLES=yes
+  global:
+     - STRICT_VARIABLES=yes
+  matrix:
+    - PUPPET_VERSION="~> 4.6.2"
+    - PUPPET_VERSION="~> 4.7.1"
+    - PUPPET_VERSION="~> 4.8.2"
+    - PUPPET_VERSION="~> 4.9.4"
+    - PUPPET_VERSION="~> 4.10.9"
+    - PUPPET_VERSION="~> 5.0.1"
+    - PUPPET_VERSION="~> 5.1.0"
+    - PUPPET_VERSION="~> 5.2.0"
+    - PUPPET_VERSION="~> 5.3.3"
+    - PUPPET_VERSION="~> 6.0.0"
+    - PUPPET_VERSION="~> 6.5.0"
 matrix:
   exclude:
     # Puppet 6 needs ruby 2.3+
     - rvm: 2.1.9
-      env: PUPPET_VERSION="~> 6.0.0" STRICT_VARIABLES=yes
+      env: PUPPET_VERSION="~> 6.0.0"
     - rvm: 2.1.9
-      env: PUPPET_VERSION="~> 6.5.0" STRICT_VARIABLES=yes
+      env: PUPPET_VERSION="~> 6.5.0"
     - rvm: 2.2.3
-      env: PUPPET_VERSION="~> 6.0.0" STRICT_VARIABLES=yes
+      env: PUPPET_VERSION="~> 6.0.0"
     - rvm: 2.2.3
-      env: PUPPET_VERSION="~> 6.5.0" STRICT_VARIABLES=yes
+      env: PUPPET_VERSION="~> 6.5.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.2.3
   - 2.3.6
   - 2.4.3
+  - 2.6.3
 script:
   - bundle exec rake test
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,16 @@ env:
   - PUPPET_VERSION="~> 5.1.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 5.2.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 5.3.3" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 6.0.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 6.5.0" STRICT_VARIABLES=yes
+matrix:
+  exclude:
+    # Puppet 6 needs ruby 2.3+
+    - rvm: 2.1.9
+      env: PUPPET_VERSION="~> 6.0.0" STRICT_VARIABLES=yes
+    - rvm: 2.1.9
+      env: PUPPET_VERSION="~> 6.5.0" STRICT_VARIABLES=yes
+    - rvm: 2.2.3
+      env: PUPPET_VERSION="~> 6.0.0" STRICT_VARIABLES=yes
+    - rvm: 2.2.3
+      env: PUPPET_VERSION="~> 6.5.0" STRICT_VARIABLES=yes

--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,10 @@
     {
       "name": "puppet",
       "version_requirement": ">=4.6.0 <7.0.0"
+    },
+    {
+      "name": "yumrepo_core",
+      "version_requirement": ">=1.0.3 < 2.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
- `yumrepo` has been moved to a separate module in puppetforge.
- Added ruby 2.6 to the travis matrix, and excluded puppet 6 + ruby < 2.3 because it's not supported.