### PR TITLE
Update names of the keys to avoid confusion

### DIFF
--- a/manifests/redhat/agent6.pp
+++ b/manifests/redhat/agent6.pp
@@ -16,11 +16,11 @@ class datadog_agent::redhat::agent6(
   validate_legacy('Boolean', 'validate_bool', $manage_repo)
   validate_legacy('Boolean', 'validate_bool', $service_enable)
   if $manage_repo {
-    $public_key_local = '/etc/pki/rpm-gpg/DATADOG_RPM_KEY.public'
+    $public_key_local = '/etc/pki/rpm-gpg/DATADOG_RPM_KEY_E09422B3.public'
 
     validate_legacy('String', 'validate_string', $baseurl)
 
-    file { 'DATADOG_RPM_KEY.public':
+    file { 'DATADOG_RPM_KEY_E09422B3.public':
         owner  => root,
         group  => root,
         mode   => '0600',
@@ -32,7 +32,7 @@ class datadog_agent::redhat::agent6(
         command => "/bin/rpm --import ${public_key_local}",
         onlyif  => "/usr/bin/gpg --quiet --with-fingerprint -n ${public_key_local} | grep \'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3\'",
         unless  => '/bin/rpm -q gpg-pubkey-e09422b3',
-        require => File['DATADOG_RPM_KEY.public'],
+        require => File['DATADOG_RPM_KEY_E09422B3.public'],
     }
 
     yumrepo {'datadog':


### PR DESCRIPTION
Following two keys that are referred in this manifest are bit confusing. Just renamed it with its relevant name.

DATADOG_RPM_KEY.public
DATADOG_RPM_KEY_E09422B3.public

https://yum.datadoghq.com