### PR TITLE
Raise if hostname_extraction_regex doesn't capture hostname

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -22,6 +22,9 @@ Puppet::Reports.register_report(:datadog_reports) do
     rescue
       raise(Puppet::ParseError, "Invalid hostname_extraction_regex #{HOSTNAME_REGEX}")
     end
+    unless HOSTNAME_EXTRACTION_REGEX.named_captures.has_key? "hostname"
+      raise(Puppet::ParseError, "hostname_extraction_regex doesn't include a match group named 'hostname': #{HOSTNAME_REGEX}")
+    end
   else
     HOSTNAME_EXTRACTION_REGEX = nil
   end


### PR DESCRIPTION
Accessing `m[:hostname]` later in the code would raise a less clear `IndexError` exception if the match group doesn't exist.