### PR TITLE
Fix the Redis integration template

### DIFF
--- a/templates/agent-conf.d/redisdb.yaml.erb
+++ b/templates/agent-conf.d/redisdb.yaml.erb
@@ -27,6 +27,7 @@ instances:
     <%- end -%>
   <%- end -%>
 <% end -%>
+<% end -%>
 <% if instance['tags']  and unless instance['tags'].empty? -%>
     tags:
   <%- Array(instance['tags'] ).each do |tag| -%>
@@ -37,5 +38,4 @@ instances:
 <% end -%>
 <% end -%>
 
-<% end -%>
 <% end -%>


### PR DESCRIPTION
The "unless" clause of the "instance['keys']" loop wasn't closed
in the right place. The tags weren't evaluated when the "keys" param
was empty.