### PR TITLE
Dependencies cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ group :test do
   gem "public_suffix", "~> 3.0.0"
   gem "listen", "~> 3.0.0"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.6.2'
-  gem "puppet-lint"
-  gem "puppet-syntax"
-  gem "puppetlabs_spec_helper"
+  gem "puppet-lint", "~> 2.3.6"
+  gem "puppet-syntax", "~> 2.5.0"
+  gem "puppetlabs_spec_helper", "~> 2.14.1"
   gem "jwt", "~> 1.5.6"
   gem "rake"
   gem "rspec-puppet", '2.6.9'
@@ -16,10 +16,11 @@ end
 
 group :development do
   gem "fog-openstack", "0.1.25" if RUBY_VERSION < '2.2.0'
-  gem "beaker-rspec"
-  gem "beaker", '3.31.0'
   gem "guard-rake"
-  gem "nokogiri", "~> 1.8.2"
-  gem "puppet-blacksmith"
+  gem "mocha", "~> 1.9.0"
+  gem "rspec-core", "~> 3.8.2"
+  gem "rspec-expectations", "~> 3.8.4"
+  gem "rspec-mocks", "~> 3.8.1"
+  gem "puppet-blacksmith", "~> 4.1.2"
   gem "xmlrpc" if RUBY_VERSION >= '2.3'
 end


### PR DESCRIPTION
## What?

- Remove unused dependencies (beaker is for acceptance tests that we don't have, and nokogiri was a dependency of beaker).
- Re-add dependencies of those dependencies we were actually using in our tests (rspec-*).
- Pin versions of evertyhing.

## Why?

To get rid of nokogiri, which had security issues and although it wasn't used when running the puppet module, it could come up in security scans.