### PR TITLE
Add ignore_ssl_warning to HTTP check

### DIFF
--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -70,6 +70,10 @@
 #       problematic SSL server certificates. To maintain backwards
 #       compatibility this defaults to false.
 #
+#   ignore_ssl_warning
+#       When SSL certificate validation is enabled (see setting above), this
+#       setting will allow you to disable security warnings.
+#
 #   skip_event
 #       The (optional) skip_event parameter will instruct the check to not
 #       create any event to avoid duplicates with a server side service check.
@@ -176,6 +180,7 @@ class datadog_agent::integrations::http_check (
   $http_response_status_code = undef,
   $collect_response_time = true,
   $disable_ssl_validation = false,
+  $ignore_ssl_warning = false,
   $skip_event = true,
   $no_proxy  = false,
   $check_certificate_expiration = true,
@@ -207,6 +212,7 @@ class datadog_agent::integrations::http_check (
       'http_response_status_code'    => $http_response_status_code,
       'collect_response_time'        => $collect_response_time,
       'disable_ssl_validation'       => $disable_ssl_validation,
+      'ignore_ssl_warning'           => $ignore_ssl_warning,
       'skip_event'                   => $skip_event,
       'no_proxy'                     => $no_proxy,
       'check_certificate_expiration' => $check_certificate_expiration,

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -50,6 +50,9 @@ instances:
 <% unless instance['disable_ssl_validation'].nil? -%>
     disable_ssl_validation: <%= instance['disable_ssl_validation'] %>
 <% end -%>
+<% unless instance['ignore_ssl_warning'].nil? -%>
+    ignore_ssl_warning: <%= instance['ignore_ssl_warning'] %>
+<% end -%>
 <% unless instance['skip_event'].nil? -%>
     skip_event: <%= instance['skip_event'] %>
 <% end -%>


### PR DESCRIPTION
This parameter and its description comes from Datadog's documentation here:

https://docs.datadoghq.com/integrations/http_check/