### PR TITLE
remove unnecessary restart using Exec

### DIFF
--- a/manifests/windows/agent6.pp
+++ b/manifests/windows/agent6.pp
@@ -38,11 +38,6 @@ class datadog_agent::windows::agent6(
       install_options => ['/quiet', {'APIKEY' => $api_key, 'HOSTNAME' => $hostname, 'TAGS' => $tags}]
     }
 
-    exec { 'DatadogRestart':
-      command  => "& 'C:/Program Files/Datadog/Datadog Agent/embedded/agent.exe' restart-service",
-      provider => powershell
-    }
-
     service { $service_name:
       ensure  => $service_ensure,
       enable  => $service_enable,


### PR DESCRIPTION
Currently the restart breaks whenever Datadog is not running yet. 

Looking at the code, the restart seems to be unnecessary. No config changes are made between the installation of the package and the definition of the service. 

If the Datadog service is not running (but installed) the exec will return a failure. 

```
Notice: /Stage[main]/Datadog_agent::Windows::Agent6/Exec[DatadogRestart]/returns: could not send control=1: The service has not been started.
```