### PR TITLE
Only download MSI if needed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -319,7 +319,7 @@ class datadog_agent(
   $apt_backup_keyserver = $datadog_agent::params::apt_backup_keyserver,
   $apt_keyserver = $datadog_agent::params::apt_keyserver,
   $apt_release = $datadog_agent::params::apt_default_release,
-  String $win_msi_location = 'c:/tmp', # Temporary directory where the msi file is downloaded
+  String $win_msi_location = 'C:/Windows/temp', # Temporary directory where the msi file is downloaded, must exist
   Enum['present', 'absent'] $win_ensure = 'present', #TODO: Implement uninstall also for apt and rpm install methods
   Optional[String] $service_provider = undef,
   Optional[String] $agent_version = $datadog_agent::params::agent_version,

--- a/manifests/windows/agent6.pp
+++ b/manifests/windows/agent6.pp
@@ -7,7 +7,7 @@ class datadog_agent::windows::agent6(
   String $agent_version = $datadog_agent::params::agent_version,
   String $service_ensure = 'running',
   String $baseurl = $datadog_agent::params::agent6_default_repo,
-  String $msi_location = 'c:/tmp',
+  String $msi_location = 'C:/Windows/temp',
   String $api_key = $datadog_agent::api_key,
   String $hostname = $datadog_agent::host,
   String $service_name = $datadog_agent::service_name_win,
@@ -19,14 +19,10 @@ class datadog_agent::windows::agent6(
   $msi_full_path = "${msi_location}/datadog-agent-6-${agent_version}.amd64.msi"
 
   if $ensure == 'present' {
-    file { $msi_location:
-      ensure => directory,
-      notify => Exec['downloadmsi']
-    }
 
-    exec { 'downloadmsi':
+    exec { 'downloadmsi': # Using exec instead of file so we can specify an onlyif condition
       command  => "Invoke-WebRequest ${baseurl} -outfile ${msi_full_path}",
-      onlyif   => "if ((test-path ${msi_full_path}) -eq \$true) {exit 1}",
+      onlyif   => "if ((Get-Package \"${datadog_agent::params::package_name}\") -or (test-path ${msi_full_path})) { exit 1 }",
       provider => powershell,
       notify   => Package[$datadog_agent::params::package_name]
     }
@@ -45,15 +41,9 @@ class datadog_agent::windows::agent6(
     }
   } else {
 
-    file { $msi_location:
-      ensure => absent,
-      notify => Package[$datadog_agent::params::package_name]
-    }
-
     package { $datadog_agent::params::package_name:
       ensure            => absent,
       provider          => 'windows',
-      source            => $msi_full_path,
       uninstall_options => ['/quiet']
     }
 


### PR DESCRIPTION
- Only download MSI if needed (ie: agent is not installed and MSI not downloaded already)
- Use system's temp directory instead of creating our own.