### PR TITLE
Change conf_path -> confd_path and make it pick the user config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -720,7 +720,7 @@ class datadog_agent(
       'hostname_fqdn' => $hostname_fqdn,
       'collect_ec2_tags' => $collect_ec2_tags,
       'collect_gce_tags' => $collect_gce_tags,
-      'conf_path' => $datadog_agent::params::conf6_dir,
+      'confd_path' => $conf6_dir,
       'enable_metadata_collection' => $collect_instance_metadata,
       'dogstatsd_port' => $dogstatsd_port,
       'dogstatsd_socket' => $dogstatsd_socket,

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -942,7 +942,7 @@ describe 'datadog_agent' do
               'content' => /^api_key: your_API_key\n/,
               )}
               it { should contain_file(config_yaml_file).with(
-              'content' => Regexp.new('^conf_path: \"{0,1}' + config_dir + '/conf.d' + '"{0,1}\n'),
+              'content' => Regexp.new('^confd_path: \"{0,1}' + config_dir + '/conf.d' + '"{0,1}\n'),
               )}
               it { should contain_file(config_yaml_file).with(
               'content' => /^cmd_port: \"{0,1}5001\"{0,1}\n/,


### PR DESCRIPTION
Probably `conf_path` was a typo, since it's not used by the agent.

`conf6_dir` is an undocumented parameter, but if set it will change where
the check config files are created. `confd_path` in datadog.yaml should
point to that location for the agent to find these config files.
