### PR TITLE
Pin rake version to 12.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem "puppet-syntax", "~> 2.5.0"
   gem "puppetlabs_spec_helper", "~> 2.14.1"
   gem "jwt", "~> 1.5.6"
-  gem "rake"
+  gem "rake", "~> 12.3.3"
   gem "rspec-puppet", '2.6.9'
   gem 'rspec-puppet-facts', '~> 1.7', :require => false
 end


### PR DESCRIPTION
rake 13 got released a week ago, and drops support of ruby < 2.2, which makes the travis tests fail because we test ruby 2.1.9.

As long as we support ruby 2.1.9, we should pin rake to version 12.