### PR TITLE
Fix Windows tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,16 @@ matrix:
       env: PUPPET_VERSION="~> 6.5.0"
   include:
       os: windows
+      rvm: 2.5.3 # Has no effect, but without this Travis shows 2.1.9 in the GUI, which is incorrect
       language: bash # There is no support for ruby on windows yet (2019/09)
       install:
-      - choco install ruby
-      - choco install msys2
+      - choco uninstall ruby # Otherwise we end up with two rubys installed
+      - choco install ruby --allow-downgrade -y --version 2.5.3.101 # Keep version in sync with next command!
+      - export PATH=/c/tools/ruby25/bin:$PATH # Installing ruby doesn't set the path, we need to do this manually
+      - ruby --version
+      - choco install msys2 --allow-downgrade -y --version 20180531.0.0
       - ridk.cmd exec pacman -S --noconfirm --needed base-devel mingw-w64-x86_64-toolchain
       - powershell kill -n gpg-agent # Started by msys, if we don't kill it the travis job stays running forever (found by running 'ps -W')
-      - gem install bundler
+      - gem install bundler -v 1.17.3
       - bundle install
       env: PUPPET_VERSION="~> 6.5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem "puppet-syntax", "~> 2.5.0"
   gem "puppetlabs_spec_helper", "~> 2.14.1"
   gem "jwt", "~> 1.5.6"
-  gem "rake", "~> 12.3.3" if RUBY_VERSION < '2.6.0'
+  gem "rake", "~> 12.3.3" # last version to support ruby < 2.6
   gem "rspec-puppet", '2.6.9'
   gem 'rspec-puppet-facts', '~> 1.7', :require => false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem "puppet-syntax", "~> 2.5.0"
   gem "puppetlabs_spec_helper", "~> 2.14.1"
   gem "jwt", "~> 1.5.6"
-  gem "rake", "~> 12.3.3"
+  gem "rake", "~> 12.3.3" if RUBY_VERSION < '2.6.0'
   gem "rspec-puppet", '2.6.9'
   gem 'rspec-puppet-facts', '~> 1.7', :require => false
 end


### PR DESCRIPTION
- Use the ruby we install!
- Pin versions of everything

Travis updated their pre-installed version of ruby, and even though we manually installed a specific version, the pre-installed version was being used because it's set earlier in the PATH.