### PR TITLE
Give Administrator group access to datadog.yaml

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -742,6 +742,7 @@ class datadog_agent(
       file { 'C:/ProgramData/Datadog/datadog.yaml':
         owner   => $dd_user,
         group   => 'S-1-5-32-544', #Administrators
+        mode    => '0660',
         content => template('datadog_agent/datadog6.yaml.erb'),
         notify  => Service[$datadog_agent::params::service_name],
         require => File['C:/ProgramData/Datadog'],


### PR DESCRIPTION
On Windows, Administrator doesn't have access to every file, and if we
remove access to the Administrator user and group, we lock ourself out of
the file. In other places this is already taken into account and explicitly
set, but here we were using the default value for mode. The default worked
well in previous tests, but I run into the lock out problem on a test using
Windows 2008 with puppet 6.10, so better make this explicit here too.