### PR TITLE
Remove triple-dash from rendered yaml

### DIFF
--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -52,4 +52,4 @@ instances:
 
 <% end -%>
 
-<%= {'logs'=>@logs}.to_yaml.lines[1..-1].join %>
+<%= (Array({'logs'=>@logs}.to_yaml.lines))[1..-1].join %>

--- a/templates/agent-conf.d/mysql.yaml.erb
+++ b/templates/agent-conf.d/mysql.yaml.erb
@@ -52,4 +52,4 @@ instances:
 
 <% end -%>
 
-<%= {'logs'=>@logs}.to_yaml %>
+<%= {'logs'=>@logs}.to_yaml.lines[1..-1].join %>


### PR DESCRIPTION
Tripple-dash ("---") causes the following section of the configuration to be ignored by the Datadog agent

i.e:
```
    options:               # Optional
        replication: 1
        galera_cluster: 0
        extra_status_metrics: false
        extra_innodb_metrics: false
        extra_performance_metrics: false
        schema_size_metrics: false
        disable_innodb_metrics: false



---
logs:
- type: file
  path: "/var/lib/mysql/mysqld.log"
  service: mysql
  source: mysql
```