### PR TITLE
Make Debian systems take agent version same as other OSes

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -16,6 +16,13 @@ class datadog_agent::ubuntu(
   Optional[String] $apt_keyserver = undef,
 ) inherits datadog_agent::params {
 
+  if $agent_version =~  /([0-9]+:)?([0-9]+)\.([0-9]+)\.([0-9]+)((?:~|-)[^0-9\s-]+[^-\s]*)?(?:-([0-9]+))?/ {
+    $platform_agent_version = "1:${agent_version}-1"
+  }
+  else {
+    $platform_agent_version = $agent_version
+  }
+
   case $agent_major_version {
     5 : { $repos = 'main' }
     6 : { $repos = '6' }
@@ -65,7 +72,7 @@ class datadog_agent::ubuntu(
   }
 
   package { $datadog_agent::params::package_name:
-    ensure  => $agent_version,
+    ensure  => $platform_agent_version,
     require => [Apt::Source['datadog6'],
                 Class['apt::update']],
   }


### PR DESCRIPTION
### What does this PR do?

Wrap the agent package version to install between `1:` and `-1` on Debian bases systems so, if a user installs the version `7.16.0` of the agent, it installs correctly the version `1:7.16.0-1`.

### Motivation

Make the agent installation use the same parameter `agent_version` for Debian based systems as for other OSes. This way, users won't have to provide a prefix and a suffix on Debian based systems. 