### PR TITLE
Fix Debian agent version regexp for retrocompatibility

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -16,7 +16,7 @@ class datadog_agent::ubuntu(
   Optional[String] $apt_keyserver = undef,
 ) inherits datadog_agent::params {
 
-  if $agent_version =~  /([0-9]+:)?([0-9]+)\.([0-9]+)\.([0-9]+)((?:~|-)[^0-9\s-]+[^-\s]*)?(?:-([0-9]+))?/ {
+  if $agent_version =~ /^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/ {
     $platform_agent_version = "1:${agent_version}-1"
   }
   else {


### PR DESCRIPTION
### What does this PR do?

It fixes a regression included in #591 that made it non retro-compatible with existing puppet manifests that used the old Debian full agent versions with the `1:` prefix and the `-1` suffix.

With this PR, we will be able to support the 3 possible version formats:
* `1:7.16.0-1`
* `7.16.0`
* `latest`