### PR TITLE
Remove include from system_probe.pp

### DIFF
--- a/manifests/system_probe.pp
+++ b/manifests/system_probe.pp
@@ -1,4 +1,3 @@
-include datadog_agent::params
 class datadog_agent::system_probe(
   Boolean $enabled = false,
   Optional[String] $log_file = undef,


### PR DESCRIPTION
Fix "This Function Call is unacceptable as a top level construct in this location" on Puppet 6.7