### PR TITLE
Rubocop + fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,3 +133,5 @@ Style/SymbolProc:
   Enabled: false
 Style/NumericPredicate:
   Enabled: false
+Layout/FirstHashElementLineBreak:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,3 +131,5 @@ Style/IfUnlessModifier:
   Enabled: false
 Style/SymbolProc:
   Enabled: false
+Style/NumericPredicate:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ group :development do
     gem "puppet-lint", "~> 2.4.2"
     gem "metadata-json-lint", "~> 1.2.2"
     gem "puppet-syntax", "~> 2.5.0"
-    gem "rspec-puppet", '2.6.9'
+    gem "rspec-puppet", "~> 2.6.9"
+    gem "rubocop", "~> 0.49.1"
+    gem "rubocop-i18n", "~> 1.2.0"
+    gem "rubocop-rspec", "~> 1.16.0"
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
 require 'puppet-lint/tasks/puppet-lint'
+require 'rubocop/rake_task'
 
 exclude_paths = [
   "pkg/**/*",
@@ -19,5 +20,6 @@ task :test => [
   'check:symlinks',
   'check:git_ignore',
   'check:dot_underscore',
+  'rubocop',
   'spec',
 ]

--- a/lib/puppet/parser/functions/to_instances_yaml.rb
+++ b/lib/puppet/parser/functions/to_instances_yaml.rb
@@ -1,17 +1,17 @@
 require 'yaml'
 
 module Puppet::Parser::Functions
-    newfunction(:to_instances_yaml, :type => :rvalue) do |args|
-        init_config = args[0]
-        instances = args[1]
-        logs = args[2]
-        default_values = {
-            'init_config'  => init_config.is_a?(String) ? nil: init_config,
-            'instances' => instances
-        }
-        if !logs.nil? && !logs.empty? then
-          default_values.merge!({'logs' => logs})
-        end
-        YAML::dump(default_values)
+  newfunction(:to_instances_yaml, type: :rvalue) do |args|
+    init_config = args[0]
+    instances = args[1]
+    logs = args[2]
+    default_values = {
+      'init_config' => init_config.is_a?(String) ? nil : init_config,
+      'instances' => instances,
+    }
+    if !logs.nil? && !logs.empty?
+      default_values['logs'] = logs
     end
+    YAML.dump(default_values)
+  end
 end

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -3,13 +3,12 @@ require 'yaml'
 
 begin
   require 'dogapi'
-rescue LoadError => e
-  Puppet.info "You need the `dogapi` gem to use the Datadog report (run puppet with puppet_run_reports on your master)"
+rescue LoadError
+  Puppet.info 'You need the `dogapi` gem to use the Datadog report (run puppet with puppet_run_reports on your master)'
 end
 
 Puppet::Reports.register_report(:datadog_reports) do
-
-  configfile = "/etc/datadog-agent/datadog-reports.yaml"
+  configfile = '/etc/datadog-agent/datadog-reports.yaml'
   raise(Puppet::ParseError, "Datadog report config file #{configfile} not readable") unless File.readable?(configfile)
   config = YAML.load_file(configfile)
   API_KEY = config[:datadog_api_key]
@@ -22,7 +21,7 @@ Puppet::Reports.register_report(:datadog_reports) do
     rescue
       raise(Puppet::ParseError, "Invalid hostname_extraction_regex #{HOSTNAME_REGEX}")
     end
-    unless HOSTNAME_EXTRACTION_REGEX.named_captures.has_key? "hostname"
+    unless HOSTNAME_EXTRACTION_REGEX.named_captures.key? 'hostname'
       raise(Puppet::ParseError, "hostname_extraction_regex doesn't include a match group named 'hostname': #{HOSTNAME_REGEX}")
     end
   else
@@ -34,25 +33,22 @@ Puppet::Reports.register_report(:datadog_reports) do
   DESC
 
   def pluralize(number, noun)
-    begin
-      if number == 0 then
-        "no #{noun}"
-      elsif number < 1 then
-        "less than 1 #{noun}"
-      elsif number == 1 then
-        "1 #{noun}"
-      else
-        "#{number.round} #{noun}s"
-      end
-    rescue
-      "#{number} #{noun}(s)"
+    if number == 0
+      "no #{noun}"
+    elsif number < 1
+      "less than 1 #{noun}"
+    elsif number == 1
+      "1 #{noun}"
+    else
+      "#{number.round} #{noun}s"
     end
+  rescue
+    "#{number} #{noun}(s)"
   end
 
-
   def process
-    @summary = self.summary
-    @msg_host = self.host
+    @summary = summary
+    @msg_host = host
     unless HOSTNAME_EXTRACTION_REGEX.nil?
       m = @msg_host.match(HOSTNAME_EXTRACTION_REGEX)
       if !m.nil? && !m[:hostname].nil?
@@ -65,23 +61,23 @@ Puppet::Reports.register_report(:datadog_reports) do
     event_priority = 'low'
     event_data = ''
 
-    if defined?(self.status)
+    if defined?(status)
       # for puppet log format 2 and above
-      @status = self.status
+      @status = status
       if @status == 'failed'
         event_title = "Puppet failed on #{@msg_host}"
-        alert_type = "error"
-        event_priority = "normal"
+        alert_type = 'error'
+        event_priority = 'normal'
       elsif @status == 'changed'
         event_title = "Puppet changed resources on #{@msg_host}"
-        alert_type = "success"
-        event_priority = "normal"
-      elsif @status == "unchanged"
+        alert_type = 'success'
+        event_priority = 'normal'
+      elsif @status == 'unchanged'
         event_title = "Puppet ran on, and left #{@msg_host} unchanged"
-        alert_type = "success"
+        alert_type = 'success'
       else
         event_title = "Puppet ran on #{@msg_host}"
-        alert_type = "success"
+        alert_type = 'success'
       end
 
     else
@@ -90,49 +86,48 @@ Puppet::Reports.register_report(:datadog_reports) do
     end
 
     # Extract statuses
-    total_resource_count = self.resource_statuses.length
-    changed_resources    = self.resource_statuses.values.find_all {|s| s.changed }
-    failed_resources     = self.resource_statuses.values.find_all {|s| s.failed }
+    total_resource_count = resource_statuses.length
+    changed_resources    = resource_statuses.values.select { |s| s.changed }
+    failed_resources     = resource_statuses.values.select { |s| s.failed }
 
     # Little insert if we know the config
-    config_version_blurb = if defined?(self.configuration_version) then "applied version #{self.configuration_version} and" else "" end
+    config_version_blurb = defined?(configuration_version) ? "applied version #{configuration_version} and" : ''
 
     event_data << "Puppet #{config_version_blurb} changed #{pluralize(changed_resources.length, 'resource')} out of #{total_resource_count}."
 
     # List changed resources
-    if changed_resources.length > 0
+    unless changed_resources.empty?
       event_data << "\nThe resources that changed are:\n@@@\n"
-      changed_resources.each {|s| event_data << "#{s.title} in #{s.file}:#{s.line}\n" }
+      changed_resources.each { |s| event_data << "#{s.title} in #{s.file}:#{s.line}\n" }
       event_data << "\n@@@\n"
     end
 
     # List failed resources
-    if failed_resources.length > 0
+    unless failed_resources.empty?
       event_data << "\nThe resources that failed are:\n@@@\n"
-      failed_resources.each {|s| event_data << "#{s.title} in #{s.file}:#{s.line}\n" }
+      failed_resources.each { |s| event_data << "#{s.title} in #{s.file}:#{s.line}\n" }
       event_data << "\n@@@\n"
     end
 
     Puppet.debug "Sending metrics for #{@msg_host} to Datadog"
     @dog = Dogapi::Client.new(API_KEY, nil, nil, nil, nil, nil, API_URL)
     @dog.batch_metrics do
-      self.metrics.each { |metric,data|
-        data.values.each { |val|
-          name = "puppet.#{val[1].gsub(/ /, '_')}.#{metric}".downcase
+      metrics.each do |metric, data|
+        data.values.each do |val|
+          name = "puppet.#{val[1].tr(' ', '_')}.#{metric}".downcase
           value = val[2]
-          @dog.emit_point("#{name}", value, :host => "#{@msg_host}")
-        }
-      }
+          @dog.emit_point(name.to_s, value, host: @msg_host.to_s)
+        end
+      end
     end
 
     Puppet.debug "Sending events for #{@msg_host} to Datadog"
     @dog.emit_event(Dogapi::Event.new(event_data,
-                                      :msg_title => event_title,
-                                      :event_type => 'config_management.run',
-                                      :event_object => @msg_host,
-                                      :alert_type => alert_type,
-                                      :priority => event_priority,
-                                      :source_type_name => 'puppet'
-                                      ), :host => @msg_host)
+                                      msg_title: event_title,
+                                      event_type: 'config_management.run',
+                                      event_object: @msg_host,
+                                      alert_type: alert_type,
+                                      priority: event_priority,
+                                      source_type_name: 'puppet'), host: @msg_host)
   end
 end

--- a/manifests/tag5.pp
+++ b/manifests/tag5.pp
@@ -9,7 +9,7 @@ define datadog_agent::tag5(
 
     if is_array($value){
       $tags = prefix($value, "${tag_name}:")
-      datadog_agent::tag{$tags: }
+      datadog_agent::tag5{$tags: }
     } else {
       if $value {
         concat::fragment{ "datadog tag ${tag_name}:${value}":

--- a/spec/classes/datadog_agent_integrations_activemq_xml_spec.rb
+++ b/spec/classes/datadog_agent_integrations_activemq_xml_spec.rb
@@ -4,53 +4,61 @@ describe 'datadog_agent::integrations::activemq_xml' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/activemq_xml.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/activemq_xml.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/activemq_xml.d/conf.yaml" }
       end
 
       context 'with default parameters' do
-        it { should compile }
+        it { is_expected.to compile }
       end
 
       context 'with password set' do
-        let(:params) {{
-          username: 'foo',
-          password: 'abc123',
-        }}
+        let(:params) do
+          {
+            username: 'foo',
+            password: 'abc123',
+          }
+        end
 
-        it { should compile.with_all_deps }
-        it { should contain_file(conf_file).with(
-          owner: DD_USER,
-          group: DD_GROUP,
-          mode: PERMISSIONS_PROTECTED_FILE,
-        )}
-        it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-        it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
-        it { should contain_file(conf_file).with_content(/username: foo/) }
-        it { should contain_file(conf_file).with_content(/password: abc123/) }
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file(conf_file).with(
+            owner: DD_USER,
+            group: DD_GROUP,
+            mode: PERMISSIONS_PROTECTED_FILE,
+          )
+        }
+        it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).with_content(%r{username: foo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: abc123}) }
 
         context 'with default parameters' do
           it {
-            should contain_file(conf_file)
-                .with_content(%r{http://localhost:8161})
-                .with_content(%r{supress_errors: false})
-                .without_content(%r{detailed_queues:})
-                .without_content(%r{detailed_topics:})
-                .without_content(%r{detailed_subscribers:})
+            is_expected.to contain_file(conf_file)
+              .with_content(%r{http://localhost:8161})
+              .with_content(%r{supress_errors: false})
+              .without_content(%r{detailed_queues:})
+              .without_content(%r{detailed_topics:})
+              .without_content(%r{detailed_subscribers:})
           }
         end
 
         context 'with extra detailed parameters' do
-          let(:params) {{
-            supress_errors: true,
-            detailed_queues: %w(queue1 queue2),
-            detailed_topics: %w(topic1 topic2),
-            detailed_subscribers: %w(subscriber1 subscriber2),
-          }}
+          let(:params) do
+            {
+              supress_errors: true,
+              detailed_queues: ['queue1', 'queue2'],
+              detailed_topics: ['topic1', 'topic2'],
+              detailed_subscribers: ['subscriber1', 'subscriber2'],
+            }
+          end
+
           it {
-            should contain_file(conf_file)
+            is_expected.to contain_file(conf_file)
               .with_content(%r{http://localhost:8161})
               .with_content(%r{supress_errors: true})
               .with_content(%r{detailed_queues:.*\s+- queue1\s+- queue2})
@@ -60,28 +68,31 @@ describe 'datadog_agent::integrations::activemq_xml' do
         end
 
         context 'with instances set' do
-          let(:params) {{
-            instances: [
+          let(:params) do
+            {
+              instances: [
                 {
-                    'url'     => 'http://localhost:8161',
-                    'username' => 'joe',
-                    'password' => 'hunter1',
-                    'detailed_queues' => %w(queue1 queue2),
-                    'detailed_topics' => %w(topic1 topic2),
-                    'detailed_subscribers' => %w(subscriber1 subscriber2),
+                  'url' => 'http://localhost:8161',
+                  'username' => 'joe',
+                  'password' => 'hunter1',
+                  'detailed_queues' => ['queue1', 'queue2'],
+                  'detailed_topics' => ['topic1', 'topic2'],
+                  'detailed_subscribers' => ['subscriber1', 'subscriber2'],
                 },
                 {
-                    'url'     => 'http://remotehost:8162',
-                    'username' => 'moe',
-                    'password' => 'hunter2',
-                    'detailed_queues' => %w(queue3 queue4),
-                    'detailed_topics' => %w(topic3 topic4),
-                    'detailed_subscribers' => %w(subscriber3 subscriber4),
+                  'url' => 'http://remotehost:8162',
+                  'username' => 'moe',
+                  'password' => 'hunter2',
+                  'detailed_queues' => ['queue3', 'queue4'],
+                  'detailed_topics' => ['topic3', 'topic4'],
+                  'detailed_subscribers' => ['subscriber3', 'subscriber4'],
                 },
-            ],
-          }}
+              ],
+            }
+          end
+
           it {
-            should contain_file(conf_file)
+            is_expected.to contain_file(conf_file)
               .with_content(%r{url: http://localhost:8161})
               .without_content(%r{supress_errors:})
               .with_content(%r{username: joe})

--- a/spec/classes/datadog_agent_integrations_apache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_apache_spec.rb
@@ -1,87 +1,104 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::apache' do
-
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/apache.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/apache.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/apache.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
+      it { is_expected.to compile.with_all_deps }
 
-      it { should contain_class('datadog_agent') }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to contain_class('datadog_agent') }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{apache_status_url: http://localhost/server-status\?auto}) }
-        it { should contain_file(conf_file).without_content(/tags:/) }
-        it { should contain_file(conf_file).without_content(/apache_user:/) }
-        it { should contain_file(conf_file).without_content(/apache_password:/) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{apache_status_url: http://localhost/server-status\?auto}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{apache_user:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{apache_password:}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          url: 'http://foobar',
-          username: 'userfoo',
-          password: 'passfoo',
-          tags: %w{foo bar baz},
-        }}
-        it { should contain_file(conf_file).with_content(%r{apache_status_url: http://foobar}) }
-        it { should contain_file(conf_file).with_content(/apache_user: userfoo/) }
-        it { should contain_file(conf_file).with_content(/apache_password: passfoo/) }
+        let(:params) do
+          {
+            url: 'http://foobar',
+            username: 'userfoo',
+            password: 'passfoo',
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{apache_status_url: http://foobar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{apache_user: userfoo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{apache_password: passfoo}) }
       end
 
       context 'with tags parameter single value' do
-        let(:params) {{
-          tags: 'foo',
-        }}
-        it { should_not compile }
+        let(:params) do
+          {
+            tags: 'foo',
+          }
+        end
 
-        skip "this is currently unimplemented behavior" do
-          it { should contain_file(conf_file).with_content(/tags:\s+- foo\s*?[^-]/m) }
+        it { is_expected.not_to compile }
+
+        skip 'this is currently unimplemented behavior' do
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s*?[^-]}m) }
         end
       end
 
       context 'with tags parameter array' do
-        let(:params) {{
-          tags: %w{ foo bar baz },
-        }}
-        it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+        let(:params) do
+          {
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz\s*?[^-]}m) }
       end
 
       context 'with tags parameter empty values' do
         context 'mixed in with other tags' do
-          let(:params) {{
-            tags: [ 'foo', '', 'baz' ]
-          }}
+          let(:params) do
+            {
+              tags: ['foo', '', 'baz'],
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- baz\s*?[^-]}m) }
         end
 
         context 'single element array of an empty string' do
-          let(:params) {{
-            tags: [''],
-          }}
+          let(:params) do
+            {
+              tags: [''],
+            }
+          end
 
-          skip("undefined behavior")
+          skip('undefined behavior')
         end
 
         context 'single value empty string' do
-          let(:params) {{
-            tags: '',
-          }}
+          let(:params) do
+            {
+              tags: '',
+            }
+          end
 
-          skip("doubly undefined behavior")
+          skip('doubly undefined behavior')
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_cacti_spec.rb
+++ b/spec/classes/datadog_agent_integrations_cacti_spec.rb
@@ -4,27 +4,31 @@ describe 'datadog_agent::integrations::cacti' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/cacti.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/cacti.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/cacti.d/conf.yaml" }
       end
 
       context 'with default parameters' do
-        it { should compile }
+        it { is_expected.to compile }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          mysql_host: 'localhost',
-          mysql_user: 'foo',
-          mysql_password: 'bar',
-          rrd_path: 'path',
-        }}
-        it { should contain_file(conf_file).with_content(/mysql_host: localhost/) }
-        it { should contain_file(conf_file).with_content(/mysql_user: foo/) }
-        it { should contain_file(conf_file).with_content(/mysql_password: bar/) }
-        it { should contain_file(conf_file).with_content(/rrd_path: path/) }
+        let(:params) do
+          {
+            mysql_host: 'localhost',
+            mysql_user: 'foo',
+            mysql_password: 'bar',
+            rrd_path: 'path',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{mysql_host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{mysql_user: foo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{mysql_password: bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{rrd_path: path}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_cassandra_spec.rb
+++ b/spec/classes/datadog_agent_integrations_cassandra_spec.rb
@@ -4,67 +4,79 @@ describe 'datadog_agent::integrations::cassandra' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/cassandra.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/cassandra.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/cassandra.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_class('datadog_agent') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('datadog_agent') }
 
       context 'with password set' do
-        let(:params) {{
-          user: 'datadog',
-          password: 'foobar',
-        }}
+        let(:params) do
+          {
+            user: 'datadog',
+            password: 'foobar',
+          }
+        end
 
-        it { should contain_file(conf_file).with(
-          owner: DD_USER,
-          group: DD_GROUP,
-          mode: PERMISSIONS_PROTECTED_FILE,
-        )}
-        it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-        it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+        it {
+          is_expected.to contain_file(conf_file).with(
+            owner: DD_USER,
+            group: DD_GROUP,
+            mode: PERMISSIONS_PROTECTED_FILE,
+          )
+        }
+        it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
-        it { should contain_file(conf_file).with_content(%r{password: foobar}) }
-        it { should contain_file(conf_file).without_content(%r{tags: }) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: foobar}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags: }) }
 
         context 'with defaults' do
-          it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-          it { should contain_file(conf_file).with_content(%r{user: datadog}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{user: datadog}) }
         end
 
         context 'with parameters set' do
-          let(:params) {{
-            password: 'foobar',
-            host: 'cassandra1',
-            user: 'baz',
-          }}
+          let(:params) do
+            {
+              password: 'foobar',
+              host: 'cassandra1',
+              user: 'baz',
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(%r{password: foobar}) }
-          it { should contain_file(conf_file).with_content(%r{host: cassandra1}) }
-          it { should contain_file(conf_file).with_content(%r{user: baz}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{password: foobar}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{host: cassandra1}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{user: baz}) }
         end
 
         context 'with tags parameter hash' do
-          let(:params) {{
-            password: 'foobar',
-            tags: {
-                    'foo'=> 'bar',
-                    'baz'=> 'ama',
+          let(:params) do
+            {
+              password: 'foobar',
+              tags: {
+                'foo' => 'bar',
+                'baz' => 'ama',
+              },
             }
-          }}
-          it { should contain_file(conf_file).with_content(/tags:\s+foo: bar\s+baz: ama\s*?[^-]/m) }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+foo: bar\s+baz: ama\s*?[^-]}m) }
         end
 
         context 'tags not hash' do
-          let(:params) {{
-            password: 'foobar',
-            tags: 'aoeu',
-          }}
+          let(:params) do
+            {
+              password: 'foobar',
+              tags: 'aoeu',
+            }
+          end
 
-          it { should_not compile }
+          it { is_expected.not_to compile }
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_ceph_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ceph_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::ceph' do
-
   if RSpec::Support::OS.windows?
     # Check not supported on Windows
     return
@@ -11,46 +10,54 @@ describe 'datadog_agent::integrations::ceph' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/ceph.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/ceph.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/ceph.d/conf.yaml" }
       end
       let(:sudo_conf_file) { '/etc/sudoers.d/datadog_ceph' }
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(/tags:\s+- name:ceph_cluster\s*?[^-]/m) }
-        it { should contain_file(conf_file).with_content(/^\s*ceph_cmd:\s*\/usr\/bin\/ceph\s*?[^-]/m) }
-        it { should contain_file(conf_file).with_content(/^\s*use_sudo:\sTrue[\r]*$/) }
-        it { should contain_file(sudo_conf_file).with_content(/^dd-agent\sALL=.*NOPASSWD:\/usr\/bin\/ceph[\r]*$/) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- name:ceph_cluster\s*?[^-]}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^\s*ceph_cmd:\s*/usr/bin/ceph\s*?[^-]}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^\s*use_sudo:\sTrue[\r]*$}) }
+        it { is_expected.to contain_file(sudo_conf_file).with_content(%r{^dd-agent\sALL=.*NOPASSWD:/usr/bin/ceph[\r]*$}) }
       end
 
       context 'with specified tag' do
-        let(:params) {{
-          tags: ['name:my_ceph_cluster'],
-        }}
-        it { should contain_file(conf_file).with_content(/tags:\s+- name:my_ceph_cluster\s*?[^-]/m) }
-        it { should contain_file(conf_file).with_content(/^\s*ceph_cmd:\s*\/usr\/bin\/ceph\s*?[^-]/m) }
-        it { should contain_file(conf_file).with_content(/^\s*use_sudo:\sTrue[\r]*$/) }
-        it { should contain_file(sudo_conf_file).with_content(/^dd-agent\sALL=.*NOPASSWD:\/usr\/bin\/ceph[\r]*$/) }
+        let(:params) do
+          {
+            tags: ['name:my_ceph_cluster'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- name:my_ceph_cluster\s*?[^-]}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^\s*ceph_cmd:\s*/usr/bin/ceph\s*?[^-]}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^\s*use_sudo:\sTrue[\r]*$}) }
+        it { is_expected.to contain_file(sudo_conf_file).with_content(%r{^dd-agent\sALL=.*NOPASSWD:/usr/bin/ceph[\r]*$}) }
       end
 
       context 'with specified ceph_cmd' do
-        let(:params) {{
-          ceph_cmd: '/usr/local/myceph',
-        }}
-        it { should contain_file(conf_file).with_content(/tags:\s+- name:ceph_cluster\s*?[^-]/m) }
-        it { should contain_file(conf_file).with_content(/^\s*ceph_cmd:\s*\/usr\/local\/myceph\s*?[^-]/m) }
-        it { should contain_file(conf_file).with_content(/^\s*use_sudo:\sTrue[\r]*$/) }
-        it { should contain_file(sudo_conf_file).with_content(/^dd-agent\sALL=.*NOPASSWD:\/usr\/bin\/ceph[\r]*$/) }
+        let(:params) do
+          {
+            ceph_cmd: '/usr/local/myceph',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- name:ceph_cluster\s*?[^-]}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^\s*ceph_cmd:\s*/usr/local/myceph\s*?[^-]}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^\s*use_sudo:\sTrue[\r]*$}) }
+        it { is_expected.to contain_file(sudo_conf_file).with_content(%r{^dd-agent\sALL=.*NOPASSWD:/usr/bin/ceph[\r]*$}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_consul_spec.rb
+++ b/spec/classes/datadog_agent_integrations_consul_spec.rb
@@ -4,47 +4,56 @@ describe 'datadog_agent::integrations::consul' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/consul.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/consul.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/consul.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with defaults' do
-        it { should contain_file(conf_file).with_content(%r{url: http://localhost:8500}) }
-        it { should contain_file(conf_file).with_content(%r{catalog_checks: yes}) }
-        it { should contain_file(conf_file).with_content(%r{new_leader_checks: yes}) }
-        it { should contain_file(conf_file).with_content(%r{network_latency_checks: yes}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://localhost:8500}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{catalog_checks: yes}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{new_leader_checks: yes}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{network_latency_checks: yes}) }
       end
 
       context 'with everything disabled' do
-        let(:params) {{
-          'url' => 'http://localhost:8005',
-          'catalog_checks' => false,
-          'new_leader_checks' => false,
-          'network_latency_checks' => false,
-        }}
-        it { should contain_file(conf_file).with_content(%r{url: http://localhost:8005}) }
-        it { should contain_file(conf_file).with_content(%r{catalog_checks: no}) }
-        it { should contain_file(conf_file).with_content(%r{new_leader_checks: no}) }
-        it { should contain_file(conf_file).with_content(%r{network_latency_checks: no}) }
+        let(:params) do
+          {
+            'url' => 'http://localhost:8005',
+            'catalog_checks' => false,
+            'new_leader_checks' => false,
+            'network_latency_checks' => false,
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://localhost:8005}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{catalog_checks: no}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{new_leader_checks: no}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{network_latency_checks: no}) }
       end
 
       context 'with service whitelist' do
-        let(:params) {{
-          'service_whitelist' => ['foo', 'bar']
-        }}
-        it { should contain_file(conf_file).with_content(%r{url: http://localhost:8500}) }
-        it { should contain_file(conf_file).with_content(%r{service_whitelist:[\r\n]+\s+- foo[\r\n]+\s+- bar}) }
+        let(:params) do
+          {
+            'service_whitelist' => ['foo', 'bar'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://localhost:8500}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{service_whitelist:[\r\n]+\s+- foo[\r\n]+\s+- bar}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_directory_spec.rb
+++ b/spec/classes/datadog_agent_integrations_directory_spec.rb
@@ -4,59 +4,66 @@ describe 'datadog_agent::integrations::directory' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/directory.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/directory.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/directory.d/conf.yaml" }
       end
 
       context 'with default parameters' do
-        it { should_not compile }
+        it { is_expected.not_to compile }
       end
 
       context 'with directory parameter set' do
-        let(:params) {{
-          directory: '/var/log/datadog',
-        }}
+        let(:params) do
+          {
+            directory: '/var/log/datadog',
+          }
+        end
 
-        it { should compile.with_all_deps }
-        it { should contain_file(conf_file).with(
-          owner: DD_USER,
-          group: DD_GROUP,
-          mode: PERMISSIONS_PROTECTED_FILE,
-        )}
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file(conf_file).with(
+            owner: DD_USER,
+            group: DD_GROUP,
+            mode: PERMISSIONS_PROTECTED_FILE,
+          )
+        }
 
-        it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-        it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
-
+        it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
         context 'with default parameters' do
-          it { should contain_file(conf_file).with_content(%r{directory: /var/log/datadog}) }
-          it { should contain_file(conf_file).with_content(%r{filegauges: false}) }
-          it { should contain_file(conf_file).with_content(%r{recursive: true}) }
-          it { should contain_file(conf_file).with_content(%r{countonly: false}) }
-          it { should contain_file(conf_file).without_content(/name:/) }
-          it { should contain_file(conf_file).without_content(/dirtagname:/) }
-          it { should contain_file(conf_file).without_content(/filetagname:/) }
-          it { should contain_file(conf_file).without_content(/pattern:/) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{directory: /var/log/datadog}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{filegauges: false}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{recursive: true}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{countonly: false}) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{name:}) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{dirtagname:}) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{filetagname:}) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{pattern:}) }
         end
 
         context 'with parameters set' do
-          let(:params) {{
-            directory: '/var/log/datadog',
-            nametag: 'doggielogs',
-            dirtagname: 'doggiedirtag',
-            filetagname: 'doggiefiletag',
-          }}
-          it { should contain_file(conf_file).with_content(%r{directory: /var/log/datadog}) }
-          it { should contain_file(conf_file).with_content(/name: doggielogs/) }
-          it { should contain_file(conf_file).with_content(/dirtagname: doggiedirtag/) }
-          it { should contain_file(conf_file).with_content(/filetagname: doggiefiletag/) }
+          let(:params) do
+            {
+              directory: '/var/log/datadog',
+              nametag: 'doggielogs',
+              dirtagname: 'doggiedirtag',
+              filetagname: 'doggiefiletag',
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{directory: /var/log/datadog}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{name: doggielogs}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{dirtagname: doggiedirtag}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{filetagname: doggiefiletag}) }
         end
       end
 
       context 'with multiple instances set' do
-        let(:params) {
+        let(:params) do
           {
             instances: [
               {
@@ -64,13 +71,14 @@ describe 'datadog_agent::integrations::directory' do
               },
               {
                 'directory'   => '/var/log/syslog',
-              }
-            ]
+              },
+            ],
           }
-        }
-        it { should contain_file(conf_file).with_content(%r{instances:}) }
-        it { should contain_file(conf_file).with_content(%r{  - directory: /var/log/datadog}) }
-        it { should contain_file(conf_file).with_content(%r{  - directory: /var/log/syslog}) }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{instances:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{  - directory: /var/log/datadog}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{  - directory: /var/log/syslog}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_disk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_disk_spec.rb
@@ -4,42 +4,48 @@ describe 'datadog_agent::integrations::disk' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/disk.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/disk.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/disk.d/conf.yaml" }
       end
 
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to  contain_file(conf_file).with_content(
-        %r{\s+use_mount:\s+no[\r]*$}
-      ).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
+      it {
+        is_expected.to contain_file(conf_file).with_content(
+          %r{\s+use_mount:\s+no[\r]*$},
+        ).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
       it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
       it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'compile errors for incorrect values' do
-        let(:params) {{ use_mount: 'heaps' }}
+        let(:params) { { use_mount: 'heaps' } }
+
         it do
-          expect { is_expected.to compile }.to raise_error(/error\s+during\s+compilation/)
+          expect { is_expected.to compile }.to raise_error(%r{error\s+during\s+compilation})
         end
       end
 
       context 'we handle strings and arrays the same' do
-        let(:params) {{
-          use_mount: 'yes',
-          excluded_filesystems: [ 'tmpfs', 'dev' ],
-          excluded_disks: '/dev/sda1',
-          excluded_disk_re: '/dev/sdb.*',
-          excluded_mountpoint_re: '/mnt/other.*',
-          all_partitions: 'yes',
-          tag_by_filesystem: 'no'
-        }}
-        let(:yaml_conf) {
-           <<-HEREDOC
+        let(:params) do
+          {
+            use_mount: 'yes',
+            excluded_filesystems: ['tmpfs', 'dev'],
+            excluded_disks: '/dev/sda1',
+            excluded_disk_re: '/dev/sdb.*',
+            excluded_mountpoint_re: '/mnt/other.*',
+            all_partitions: 'yes',
+            tag_by_filesystem: 'no',
+          }
+        end
+        let(:yaml_conf) do
+          <<-HEREDOC
 ### MANAGED BY PUPPET
 
 init_config:
@@ -56,29 +62,29 @@ instances:
     all_partitions: yes
     tag_by_filesystem: no
         HEREDOC
-         }
+        end
+
         it {
-          if RSpec::Support::OS.windows?
-            yaml_conf.gsub!(/\n/, "\r\n")
-          end
           is_expected.to contain_file(conf_file).with_content(yaml_conf)
         }
       end
 
       context 'we handle new disk configuration option' do
-        let(:params) {{
-          use_mount: 'yes',
-          filesystem_blacklist: ['tmpfs', 'dev'],
-          device_blacklist: ['/dev/sda1'],
-          mountpoint_blacklist: ['/mnt/foo'],
-          filesystem_whitelist: ['ext4', 'hdfs', 'reiserfs'],
-          device_whitelist: ['/dev/sdc1', '/dev/sdc2', '/dev/sdd2'],
-          mountpoint_whitelist: ['/mnt/logs', '/mnt/builds'],
-          all_partitions: 'yes',
-          tag_by_filesystem: 'no'
-        }}
-        let(:yaml_conf) {
-           <<-HEREDOC
+        let(:params) do
+          {
+            use_mount: 'yes',
+            filesystem_blacklist: ['tmpfs', 'dev'],
+            device_blacklist: ['/dev/sda1'],
+            mountpoint_blacklist: ['/mnt/foo'],
+            filesystem_whitelist: ['ext4', 'hdfs', 'reiserfs'],
+            device_whitelist: ['/dev/sdc1', '/dev/sdc2', '/dev/sdd2'],
+            mountpoint_whitelist: ['/mnt/logs', '/mnt/builds'],
+            all_partitions: 'yes',
+            tag_by_filesystem: 'no',
+          }
+        end
+        let(:yaml_conf) do
+          <<-HEREDOC
 ### MANAGED BY PUPPET
 
 init_config:
@@ -106,11 +112,9 @@ instances:
     all_partitions: yes
     tag_by_filesystem: no
         HEREDOC
-         }
+        end
+
         it {
-          if RSpec::Support::OS.windows?
-            yaml_conf.gsub!(/\n/, "\r\n")
-          end
           is_expected.to contain_file(conf_file).with_content(yaml_conf)
         }
       end

--- a/spec/classes/datadog_agent_integrations_disk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_disk_spec.rb
@@ -25,7 +25,11 @@ describe 'datadog_agent::integrations::disk' do
       it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'compile errors for incorrect values' do
-        let(:params) { { use_mount: 'heaps' } }
+        let(:params) do
+          {
+            use_mount: 'heaps',
+          }
+        end
 
         it do
           expect { is_expected.to compile }.to raise_error(%r{error\s+during\s+compilation})
@@ -64,9 +68,7 @@ instances:
         HEREDOC
         end
 
-        it {
-          is_expected.to contain_file(conf_file).with_content(yaml_conf)
-        }
+        it { is_expected.to contain_file(conf_file).with_content(yaml_conf) }
       end
 
       context 'we handle new disk configuration option' do
@@ -114,9 +116,7 @@ instances:
         HEREDOC
         end
 
-        it {
-          is_expected.to contain_file(conf_file).with_content(yaml_conf)
-        }
+        it { is_expected.to contain_file(conf_file).with_content(yaml_conf) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_dns_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_dns_check_spec.rb
@@ -4,49 +4,54 @@ describe 'datadog_agent::integrations::dns_check' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/dns_check.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/dns_check.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/dns_check.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{hostname: google.com}) }
-        it { should contain_file(conf_file).with_content(%r{nameserver: 8.8.8.8}) }
-        it { should contain_file(conf_file).with_content(%r{timeout: 5}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{hostname: google.com}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{nameserver: 8.8.8.8}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{timeout: 5}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          checks: [
-            {
-              'hostname'   => 'example.com',
-              'nameserver' => '1.2.3.4',
-              'timeout'    => 5,
-            },
-            {
-              'hostname'   => 'localdomain.com',
-              'nameserver' => '4.3.2.1',
-              'timeout'    => 3,
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            checks: [
+              {
+                'hostname'   => 'example.com',
+                'nameserver' => '1.2.3.4',
+                'timeout'    => 5,
+              },
+              {
+                'hostname'   => 'localdomain.com',
+                'nameserver' => '4.3.2.1',
+                'timeout'    => 3,
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{hostname: example.com}) }
-        it { should contain_file(conf_file).with_content(%r{nameserver: 1.2.3.4}) }
-        it { should contain_file(conf_file).with_content(%r{timeout: 5}) }
-        it { should contain_file(conf_file).with_content(%r{hostname: localdomain.com}) }
-        it { should contain_file(conf_file).with_content(%r{nameserver: 4.3.2.1}) }
-        it { should contain_file(conf_file).with_content(%r{timeout: 3}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{hostname: example.com}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{nameserver: 1.2.3.4}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{timeout: 5}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{hostname: localdomain.com}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{nameserver: 4.3.2.1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{timeout: 3}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::docker_daemon' do
-
   if RSpec::Support::OS.windows?
     # Check not supported on Windows
     return
@@ -10,65 +9,77 @@ describe 'datadog_agent::integrations::docker_daemon' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/docker.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/docker.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/docker.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{url: unix://var/run/docker.sock}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: unix://var/run/docker.sock}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          url: 'unix://foo/bar/baz.sock',
-        }}
-        it { should contain_file(conf_file).with_content(%r{url: unix://foo/bar/baz.sock}) }
+        let(:params) do
+          {
+            url: 'unix://foo/bar/baz.sock',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: unix://foo/bar/baz.sock}) }
       end
 
       context 'with tags parameter array' do
-        let(:params) {{
-          tags: %w{ foo bar baz },
-        }}
-        it { should contain_file(conf_file).with_content(%r{tags: \["foo", "bar", "baz"\]}) }
-      end
+        let(:params) do
+          {
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
 
-      context 'with tags parameter with an empty tag' do
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags: \["foo", "bar", "baz"\]}) }
       end
 
       context 'with tags parameter empty values' do
         context 'mixed in with other tags' do
-          let(:params) {{
-            tags: [ 'foo', '', 'baz' ]
-          }}
+          let(:params) do
+            {
+              tags: ['foo', '', 'baz'],
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(%r{tags: \["foo", "baz"\]}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags: \["foo", "baz"\]}) }
         end
 
         context 'single element array of an empty string' do
-          let(:params) {{
-            tags: [''],
-          }}
+          let(:params) do
+            {
+              tags: [''],
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(%r{tags: \[\]}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags: \[\]}) }
         end
 
         context 'single value empty string' do
-          let(:params) {{
-            tags: '',
-          }}
+          let(:params) do
+            {
+              tags: '',
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(%r{tags: \[\]}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags: \[\]}) }
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -4,65 +4,71 @@ describe 'datadog_agent::integrations::elasticsearch' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/elastic.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/elastic.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/elastic.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
 
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{    - url: http://localhost:9200}) }
-        it { should contain_file(conf_file).with_content(%r{      cluster_stats: false}) }
-        it { should contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
-        it { should contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
-        it { should_not contain_file(conf_file).with_content(%r{      username}) }
-        it { should_not contain_file(conf_file).with_content(%r{      password}) }
-        it { should_not contain_file(conf_file).with_content(%r{      ssl_verify}) }
-        it { should_not contain_file(conf_file).with_content(%r{      ssl_cert}) }
-        it { should_not contain_file(conf_file).with_content(%r{      ssl_key}) }
-        it { should_not contain_file(conf_file).with_content(%r{      tags:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    - url: http://localhost:9200}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      cluster_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      username}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      password}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      ssl_verify}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      ssl_cert}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      ssl_key}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      tags:}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          password:           'password',
-          pending_task_stats: false,
-          url:                'https://foo:4242',
-          username:           'username',
-          ssl_cert:           '/etc/ssl/certs/client.pem',
-          ssl_key:            '/etc/ssl/private/client.key',
-          tags:               ['tag1:key1'],
-        }}
-        it { should contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
-        it { should contain_file(conf_file).with_content(%r{      pending_task_stats: false}) }
-        it { should contain_file(conf_file).with_content(%r{      username: username}) }
-        it { should contain_file(conf_file).with_content(%r{      password: password}) }
-        it { should contain_file(conf_file).with_content(%r{      ssl_verify: true}) }
-        it { should contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
-        it { should contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
-        it { should contain_file(conf_file).with_content(%r{      tags:}) }
-        it { should contain_file(conf_file).with_content(%r{        - tag1:key1}) }
+        let(:params) do
+          {
+            password:           'password',
+            pending_task_stats: false,
+            url:                'https://foo:4242',
+            username:           'username',
+            ssl_cert:           '/etc/ssl/certs/client.pem',
+            ssl_key:            '/etc/ssl/private/client.key',
+            tags:               ['tag1:key1'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      pending_task_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      username: username}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      password: password}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_verify: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tags:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{        - tag1:key1}) }
       end
 
       context 'with multiple instances set' do
-        let(:params) {
+        let(:params) do
           {
             instances: [
               {
                 'cluster_stats'      => true,
                 'password'           => 'password',
                 'pending_task_stats' => false,
-                'pshard_stats'       => false,
+                'pshard_stats'       => true,
                 'url'                => 'https://foo:4242',
                 'username'           => 'username',
                 'ssl_verify'         => true,
@@ -71,43 +77,38 @@ describe 'datadog_agent::integrations::elasticsearch' do
                 'tags'               => ['tag1:key1'],
               },
               {
-                'cluster_stats'      => true,
+                'cluster_stats'      => false,
                 'password'           => 'password_2',
                 'pending_task_stats' => true,
                 'pshard_stats'       => false,
                 'url'                => 'https://bar:2424',
                 'username'           => 'username_2',
                 'ssl_verify'         => false,
-                'ssl_cert'           => '/etc/ssl/certs/client.pem',
-                'ssl_key'            => '/etc/ssl/private/client.key',
                 'tags'               => ['tag2:key2'],
-              }
-            ]
+              },
+            ],
           }
-        }
-        it { should contain_file(conf_file).with_content(%r{instances:}) }
-        it { should contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
-        it { should contain_file(conf_file).with_content(%r{      cluster_stats: true}) }
-        it { should contain_file(conf_file).with_content(%r{      pending_task_stats: false}) }
-        it { should contain_file(conf_file).with_content(%r{      username: username}) }
-        it { should contain_file(conf_file).with_content(%r{      password: password}) }
-        it { should contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
-        it { should contain_file(conf_file).with_content(%r{      ssl_verify: true}) }
-        it { should contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
-        it { should contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
-        it { should contain_file(conf_file).with_content(%r{      tags:}) }
-        it { should contain_file(conf_file).with_content(%r{        - tag1:key1}) }
-        it { should contain_file(conf_file).with_content(%r{    - url: https://bar:2424}) }
-        it { should contain_file(conf_file).with_content(%r{      cluster_stats: true}) }
-        it { should contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
-        it { should contain_file(conf_file).with_content(%r{      username: username_2}) }
-        it { should contain_file(conf_file).with_content(%r{      password: password_2}) }
-        it { should contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
-        it { should contain_file(conf_file).with_content(%r{      ssl_verify: false}) }
-        it { should contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
-        it { should contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
-        it { should contain_file(conf_file).with_content(%r{      tags:}) }
-        it { should contain_file(conf_file).with_content(%r{        - tag2:key2}) }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{instances:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      cluster_stats: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      pending_task_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      username: username}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      password: password}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      pshard_stats: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_verify: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tags:\n        - tag1:key1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    - url: https://bar:2424}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      cluster_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      username: username_2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      password: password_2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_verify: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tags:\n        - tag2:key2}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_fluentd_spec.rb
+++ b/spec/classes/datadog_agent_integrations_fluentd_spec.rb
@@ -4,48 +4,58 @@ describe 'datadog_agent::integrations::fluentd' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/fluentd.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/fluentd.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/fluentd.d/conf.yaml" }
       end
 
       context 'with default parameters' do
-        it { should compile }
+        it { is_expected.to compile }
       end
 
       context 'with monitor_agent_url set' do
-        let(:params) {{
-          monitor_agent_url: 'foobar',
-        }}
+        let(:params) do
+          {
+            monitor_agent_url: 'foobar',
+          }
+        end
 
-        it { should compile.with_all_deps }
-        it { should contain_file(conf_file).with(
-          owner: DD_USER,
-          group: DD_GROUP,
-          mode: PERMISSIONS_PROTECTED_FILE,
-        )}
-        it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-        it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file(conf_file).with(
+            owner: DD_USER,
+            group: DD_GROUP,
+            mode: PERMISSIONS_PROTECTED_FILE,
+          )
+        }
+        it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
-        it { should contain_file(conf_file).with_content(%r{monitor_agent_url: foobar}) }
-        it { should contain_file(conf_file).without_content(%r{tags: }) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{monitor_agent_url: foobar}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags: }) }
 
         context 'with plugin_ids parameter array' do
-          let(:params) {{
-            monitor_agent_url: 'foobar',
-            plugin_ids: %w{ foo bar baz },
-          }}
-          it { should contain_file(conf_file).with_content(/plugin_ids:[^-]+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+          let(:params) do
+            {
+              monitor_agent_url: 'foobar',
+              plugin_ids: ['foo', 'bar', 'baz'],
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{plugin_ids:[^-]+- foo\s+- bar\s+- baz\s*?[^-]}m) }
         end
 
         context 'plugin_ids not array' do
-          let(:params) {{
-            monitor_agent_url: 'foobar',
-            plugin_ids: 'aoeu',
-          }}
+          let(:params) do
+            {
+              monitor_agent_url: 'foobar',
+              plugin_ids: 'aoeu',
+            }
+          end
 
-          it { should_not compile }
+          it { is_expected.not_to compile }
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_haproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_haproxy_spec.rb
@@ -4,100 +4,119 @@ describe 'datadog_agent::integrations::haproxy' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
-      let(:facts) {{
-        ipaddress: '1.2.3.4'
-      }}
+      let(:facts) do
+        {
+          ipaddress: '1.2.3.4',
+        }
+      end
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/haproxy.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/haproxy.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/haproxy.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{url: http://1.2.3.4:8080}) }
-        it { should contain_file(conf_file).without_content(%r{username: }) }
-        it { should contain_file(conf_file).without_content(%r{password: }) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://1.2.3.4:8080}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{username: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{password: }) }
       end
 
       context 'with url set' do
-        let(:params) {{
-          url: 'http://foo.bar:8421',
-        }}
-        it { should contain_file(conf_file).with_content(%r{url: http://foo.bar:8421}) }
+        let(:params) do
+          {
+            url: 'http://foo.bar:8421',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://foo.bar:8421}) }
       end
 
       context 'with creds set correctly' do
-        let(:params) {{
-          creds: {
-            'username' => 'foo',
-            'password' => 'bar',
-          },
-        }}
-        it { should contain_file(conf_file).with_content(%r{username: foo}) }
-        it { should contain_file(conf_file).with_content(%r{password: bar}) }
+        let(:params) do
+          {
+            creds: {
+              'username' => 'foo',
+              'password' => 'bar',
+            },
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{username: foo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: bar}) }
       end
 
       context 'with creds set incorrectly' do
-        let(:params) {{
-          'invalid' => 'is this real life',
-        }}
+        let(:params) do
+          {
+            'invalid' => 'is this real life',
+          }
+        end
 
         skip 'functionality not yet implemented' do
-          it { should contain_file(conf_file).without_content(/invalid: is this real life/) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{invalid: is this real life}) }
         end
       end
 
       context 'with options set' do
-        let(:params) {{
-          options: {
-            'optionk' => 'optionv',
-          },
-        }}
-        it { should contain_file(conf_file).with_content(%r{optionk: optionv}) }
+        let(:params) do
+          {
+            options: {
+              'optionk' => 'optionv',
+            },
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{optionk: optionv}) }
       end
 
       context 'with instances set' do
-        let(:params) {{
-          instances: [
-            {
-              'url'     => 'http://foo.bar:8421',
-              'creds'   => {
-                'username' => 'foo',
-                'password' => 'bar',
+        let(:params) do
+          {
+            instances: [
+              {
+                'url'     => 'http://foo.bar:8421',
+                'creds'   => {
+                  'username' => 'foo',
+                  'password' => 'bar',
+                },
+                'options' => {
+                  'optionk1' => 'optionv1',
+                },
               },
-              'options' => {
-                'optionk1' => 'optionv1',
+              {
+                'url'     => 'http://shoe.baz:1248',
+                'creds'   => {
+                  'username' => 'shoe',
+                  'password' => 'baz',
+                },
+                'options' => {
+                  'optionk2' => 'optionv2',
+                },
               },
-            },
-            {
-              'url'     => 'http://shoe.baz:1248',
-              'creds'   => {
-                'username' => 'shoe',
-                'password' => 'baz',
-              },
-              'options' => {
-                'optionk2' => 'optionv2',
-              },
-            },
-          ]
-        }}
-        it { should contain_file(conf_file).with_content(%r{url: http://foo.bar:8421}) }
-        it { should contain_file(conf_file).with_content(%r{username: foo}) }
-        it { should contain_file(conf_file).with_content(%r{password: bar}) }
-        it { should contain_file(conf_file).with_content(%r{optionk1: optionv1}) }
-        it { should contain_file(conf_file).with_content(%r{url: http://shoe.baz:1248}) }
-        it { should contain_file(conf_file).with_content(%r{username: shoe}) }
-        it { should contain_file(conf_file).with_content(%r{password: baz}) }
-        it { should contain_file(conf_file).with_content(%r{optionk2: optionv2}) }
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://foo.bar:8421}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{username: foo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{optionk1: optionv1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://shoe.baz:1248}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{username: shoe}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: baz}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{optionk2: optionv2}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -4,191 +4,218 @@ describe 'datadog_agent::integrations::http_check' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/http_check.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/http_check.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/http_check.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).without_content(%r{name: }) }
-        it { should contain_file(conf_file).without_content(%r{url: }) }
-        it { should contain_file(conf_file).without_content(%r{username: }) }
-        it { should contain_file(conf_file).without_content(%r{password: }) }
-        it { should contain_file(conf_file).without_content(%r{timeout: 1}) }
-        it { should contain_file(conf_file).without_content(%r{data: }) }
-        it { should contain_file(conf_file).without_content(%{threshold: }) }
-        it { should contain_file(conf_file).without_content(%r{window: }) }
-        it { should contain_file(conf_file).without_content(%r{content_match: }) }
-        it { should contain_file(conf_file).without_content(%r{reverse_content_match: true}) }
-        it { should contain_file(conf_file).without_content(%r{include_content: true}) }
-        it { should contain_file(conf_file).without_content(%r{collect_response_time: true}) }
-        it { should contain_file(conf_file).without_content(%r{http_response_status_code: }) }
-        it { should contain_file(conf_file).without_content(%r{disable_ssl_validation: false}) }
-        it { should contain_file(conf_file).without_content(%r{skip_event: }) }
-        it { should contain_file(conf_file).without_content(%r{no_proxy: }) }
-        it { should contain_file(conf_file).without_content(%r{check_certificate_expiration: }) }
-        it { should contain_file(conf_file).without_content(%r{days_warning: }) }
-        it { should contain_file(conf_file).without_content(%r{days_critical: }) }
-        it { should contain_file(conf_file).without_content(%r{headers: }) }
-        it { should contain_file(conf_file).without_content(%r{tags: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{name: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{url: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{username: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{password: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{timeout: 1}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{data: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%(threshold: )) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{window: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{content_match: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{reverse_content_match: true}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{include_content: true}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{collect_response_time: true}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{http_response_status_code: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{disable_ssl_validation: false}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{skip_event: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{no_proxy: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{check_certificate_expiration: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{days_warning: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{days_critical: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{headers: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags: }) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          sitename: 'foo.bar.baz',
-          url: 'http://foo.bar.baz:4096',
-          username: 'foouser',
-          password: 'barpassword',
-          timeout: 123,
-          method: 'post',
-          data: 'key=value',
-          threshold: 456,
-          window: 789,
-          content_match: 'foomatch',
-          reverse_content_match: true,
-          include_content: true,
-          collect_response_time: false,
-          disable_ssl_validation: true,
-          skip_event: true,
-          http_response_status_code: '503',
-          no_proxy: true,
-          check_certificate_expiration: true,
-          days_warning: 14,
-          days_critical: 7,
-          allow_redirects: true,
-          ca_certs: '/dev/null'
-        }}
+        let(:params) do
+          {
+            sitename: 'foo.bar.baz',
+            url: 'http://foo.bar.baz:4096',
+            username: 'foouser',
+            password: 'barpassword',
+            timeout: 123,
+            method: 'post',
+            data: 'key=value',
+            threshold: 456,
+            window: 789,
+            content_match: 'foomatch',
+            reverse_content_match: true,
+            include_content: true,
+            collect_response_time: false,
+            disable_ssl_validation: true,
+            skip_event: true,
+            http_response_status_code: '503',
+            no_proxy: true,
+            check_certificate_expiration: true,
+            days_warning: 14,
+            days_critical: 7,
+            allow_redirects: true,
+            ca_certs: '/dev/null',
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{name: foo.bar.baz}) }
-        it { should contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:4096}) }
-        it { should contain_file(conf_file).with_content(%r{username: foouser}) }
-        it { should contain_file(conf_file).with_content(%r{password: barpassword}) }
-        it { should contain_file(conf_file).with_content(%r{timeout: 123}) }
-        it { should contain_file(conf_file).with_content(%r{method: post}) }
-        it { should contain_file(conf_file).with_content(%r{data: key=value}) }
-        it { should contain_file(conf_file).with_content(%r{threshold: 456}) }
-        it { should contain_file(conf_file).with_content(%r{window: 789}) }
-        it { should contain_file(conf_file).with_content(%r{content_match: 'foomatch'}) }
-        it { should contain_file(conf_file).with_content(%r{reverse_content_match: true}) }
-        it { should contain_file(conf_file).with_content(%r{include_content: true}) }
-        it { should contain_file(conf_file).without_content(%r{collect_response_time: true}) }
-        it { should contain_file(conf_file).with_content(%r{disable_ssl_validation: true}) }
-        it { should contain_file(conf_file).with_content(%r{skip_event: true}) }
-        it { should contain_file(conf_file).with_content(%r{http_response_status_code: 503}) }
-        it { should contain_file(conf_file).with_content(%r{no_proxy: true}) }
-        it { should contain_file(conf_file).with_content(%r{check_certificate_expiration: true}) }
-        it { should contain_file(conf_file).with_content(%r{days_warning: 14}) }
-        it { should contain_file(conf_file).with_content(%r{days_critical: 7}) }
-        it { should contain_file(conf_file).with_content(%r{allow_redirects: true}) }
-        it { should contain_file(conf_file).with_content(%r{ca_certs: /dev/null}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{name: foo.bar.baz}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:4096}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{username: foouser}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: barpassword}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{timeout: 123}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{method: post}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{data: key=value}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{threshold: 456}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{window: 789}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{content_match: 'foomatch'}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{reverse_content_match: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{include_content: true}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{collect_response_time: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{disable_ssl_validation: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{skip_event: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{http_response_status_code: 503}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{no_proxy: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{check_certificate_expiration: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{days_warning: 14}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{days_critical: 7}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{allow_redirects: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ca_certs: /dev/null}) }
       end
 
       context 'with json post data' do
-        let(:params) {{
-          sitename: 'foo.bar.baz',
-          url: 'http://foo.bar.baz:4096',
-          method: 'post',
-          data: ['key: value'],
-          headers: ['Content-Type: application/json'],
-        }}
-        it { should contain_file(conf_file).with_content(%r{method: post}) }
-        it { should contain_file(conf_file).with_content(/data:\s+key:\s+value/) }
-        it { should contain_file(conf_file).with_content(/headers:\s+Content-Type:\s+application\/json/) }
+        let(:params) do
+          {
+            sitename: 'foo.bar.baz',
+            url: 'http://foo.bar.baz:4096',
+            method: 'post',
+            data: ['key: value'],
+            headers: ['Content-Type: application/json'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{method: post}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{data:\s+key:\s+value}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{headers:\s+Content-Type:\s+application/json}) }
       end
 
       context 'with headers parameter array' do
-        let(:params) {{
-          sitename: 'foo.bar.baz',
-          url: 'http://foo.bar.baz:4096',
-          headers: %w{ foo bar baz },
-        }}
-        it { should contain_file(conf_file).with_content(/headers:\s+foo\s+bar\s+baz\s*?[^-]/m) }
+        let(:params) do
+          {
+            sitename: 'foo.bar.baz',
+            url: 'http://foo.bar.baz:4096',
+            headers: ['foo', 'bar', 'baz'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{headers:\s+foo\s+bar\s+baz\s*?[^-]}m) }
       end
 
       context 'with headers parameter empty values' do
         context 'mixed in with other headers' do
-          let(:params) {{
-          sitename: 'foo.bar.baz',
-            url: 'http://foo.bar.baz:4096',
-            headers: [ 'foo', '', 'baz' ]
-          }}
+          let(:params) do
+            {
+              sitename: 'foo.bar.baz',
+              url: 'http://foo.bar.baz:4096',
+              headers: ['foo', '', 'baz'],
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(/headers:\s+foo\s+baz\s*?[^-]/m) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{headers:\s+foo\s+baz\s*?[^-]}m) }
         end
 
         context 'single element array of an empty string' do
-          let(:params) {{
-            headers: [''],
-          }}
+          let(:params) do
+            {
+              headers: [''],
+            }
+          end
 
-          skip("undefined behavior")
+          skip('undefined behavior')
         end
 
         context 'single value empty string' do
-          let(:params) {{
-            headers: '',
-          }}
+          let(:params) do
+            {
+              headers: '',
+            }
+          end
 
-          skip("doubly undefined behavior")
+          skip('doubly undefined behavior')
         end
       end
 
-
       context 'with tags parameter array' do
-        let(:params) {{
-          sitename: 'foo.bar.baz',
-          url: 'http://foo.bar.baz:4096',
-          tags: %w{ foo bar baz },
-        }}
-        it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+        let(:params) do
+          {
+            sitename: 'foo.bar.baz',
+            url: 'http://foo.bar.baz:4096',
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz\s*?[^-]}m) }
       end
 
       context 'with tags parameter empty values' do
         context 'mixed in with other tags' do
-          let(:params) {{
-            sitename: 'foo.bar.baz',
-            url: 'http://foo.bar.baz:4096',
-            tags: [ 'foo', '', 'baz' ]
-          }}
+          let(:params) do
+            {
+              sitename: 'foo.bar.baz',
+              url: 'http://foo.bar.baz:4096',
+              tags: ['foo', '', 'baz'],
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- baz\s*?[^-]}m) }
         end
 
         context 'single element array of an empty string' do
-          let(:params) {{
-            tags: [''],
-          }}
+          let(:params) do
+            {
+              tags: [''],
+            }
+          end
 
-          skip("undefined behavior")
+          skip('undefined behavior')
         end
 
         context 'single value empty string' do
-          let(:params) {{
-            tags: '',
-          }}
+          let(:params) do
+            {
+              tags: '',
+            }
+          end
 
-          skip("doubly undefined behavior")
+          skip('doubly undefined behavior')
         end
       end
 
       context 'with contact set' do
-        let(:params) {{
-          contact: %r{alice bob carlo}
-        }}
+        let(:params) do
+          {
+            contact: %r{alice bob carlo},
+          }
+        end
 
         # the parameter is '$contact' and the template uses '@contacts', so neither is used
-        skip "this functionality appears to not be functional" do
-          it { should contain_file(conf_file).with_content(%r{notify:\s+- alice\s+bob\s+carlo}) }
+        skip 'this functionality appears to not be functional' do
+          it { is_expected.to contain_file(conf_file).with_content(%r{notify:\s+- alice\s+bob\s+carlo}) }
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_jenkins_spec.rb
+++ b/spec/classes/datadog_agent_integrations_jenkins_spec.rb
@@ -4,30 +4,36 @@ describe 'datadog_agent::integrations::jenkins' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/jenkins.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/jenkins.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/jenkins.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{jenkins_home: /var/lib/jenkins}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{jenkins_home: /var/lib/jenkins}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          path: '/foo/bar/baz',
-        }}
-        it { should contain_file(conf_file).with_content(%r{jenkins_home: /foo/bar/baz}) }
+        let(:params) do
+          {
+            path: '/foo/bar/baz',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{jenkins_home: /foo/bar/baz}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_jmx_spec.rb
+++ b/spec/classes/datadog_agent_integrations_jmx_spec.rb
@@ -4,24 +4,27 @@ describe 'datadog_agent::integrations::jmx' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/jmx.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/jmx.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/jmx.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{init_config: \{\}}) }
-        it { should contain_file(conf_file).with_content(%r{instances: \[\]}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{init_config: \{\}}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{instances: \[\]}) }
       end
 
       context 'with parameters set' do
@@ -29,9 +32,9 @@ describe 'datadog_agent::integrations::jmx' do
           {
             'init_config' => {
               'custom_jar_paths' => [
-               '/path/to/custom/jarfile.jar',
-               '/path/to/another/custom/jarfile2.jar'
-              ]
+                '/path/to/custom/jarfile.jar',
+                '/path/to/another/custom/jarfile2.jar',
+              ],
             },
             'instances' => [{
               'host' => 'jmx1',
@@ -46,36 +49,37 @@ describe 'datadog_agent::integrations::jmx' do
               'trust_store_password' => 'hunter2',
               'tags' => {
                 'foo' => 'bar',
-                'baz' => 'bat'
+                'baz' => 'bat',
               },
               'conf' =>  [{
                 'include' => {
-                  'domain' => 'my_domain'
-                }
-              }]
-            }]
+                  'domain' => 'my_domain',
+                },
+              }],
+            }],
           }
         end
-        it { should contain_file(conf_file).with_content(%r{- ["']?/path/to/custom/jarfile.jar["']?}) }
-        it { should contain_file(conf_file).with_content(%r{- ["']?/path/to/another/custom/jarfile2.jar["']?}) }
-        it { should contain_file(conf_file).with_content(%r{host: jmx1}) }
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{- ["']?/path/to/custom/jarfile.jar["']?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{- ["']?/path/to/another/custom/jarfile2.jar["']?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: jmx1}) }
 
         # Stringification of integers.
         # Puppet treats everything as a string, and then there seems to be
         # quoting differences between YAML export deps for Puppet 3.x and Puppet 4.x.
         # YAML defaults to string representation, but supports other types, so ends
         # up quoting integers from Puppet to explicitly mark out they're strings.
-        it { should contain_file(conf_file).with_content(%r{port: ["']?867["']?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: ["']?867["']?}) }
 
-        it { should contain_file(conf_file).with_content(%r{jmx_url: ["']?service:jmx:rmi:///jndi/rmi://myhost.host:9999/custompath["']?}) }
-        it { should contain_file(conf_file).with_content(%r{user: userfoo}) }
-        it { should contain_file(conf_file).with_content(%r{password: passbar}) }
-        it { should contain_file(conf_file).with_content(%r{java_bin_path: ["']?/usr/java/jdk1.7.0_101/bin/java["']?}) }
-        it { should contain_file(conf_file).with_content(%r{java_options: ["']?-Xmx200m -Xms50m["']?}) }
-        it { should contain_file(conf_file).with_content(%r{trust_store_path: ["']?/var/lib/jmx/trust_store_path["']?}) }
-        it { should contain_file(conf_file).with_content(%r{trust_store_password: hunter2}) }
-        it { should contain_file(conf_file).with_content(%r{tags:\s+foo: bar\s+baz: bat}) }
-        it { should contain_file(conf_file).with_content(%r{domain: my_domain}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{jmx_url: ["']?service:jmx:rmi:///jndi/rmi://myhost.host:9999/custompath["']?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{user: userfoo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: passbar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{java_bin_path: ["']?/usr/java/jdk1.7.0_101/bin/java["']?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{java_options: ["']?-Xmx200m -Xms50m["']?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{trust_store_path: ["']?/var/lib/jmx/trust_store_path["']?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{trust_store_password: hunter2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+foo: bar\s+baz: bat}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{domain: my_domain}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_kafka_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kafka_spec.rb
@@ -4,81 +4,93 @@ describe 'datadog_agent::integrations::kafka' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/kafka.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/kafka.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/kafka.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{- host: localhost\s+port: 9999}) }
-        it { should contain_file(conf_file).without_content(%r{user:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{- host: localhost\s+port: 9999}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{user:}) }
       end
 
       context 'with one kafka broker' do
-        let(:params) {{
-          instances: [
-            {
-              'host' => 'localhost',
-              'port' => '9997',
-              'tags' => %w{ kafka:broker tag1:value1 },
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            instances: [
+              {
+                'host' => 'localhost',
+                'port' => '9997',
+                'tags' => ['kafka:broker', 'tag1:value1'],
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1}) }
       end
 
       context 'with two kafka brokers' do
-        let(:params) {{
-          instances: [
-            {
-              'host' => 'localhost',
-              'port' => '9997',
-              'tags' => %w{ kafka:broker tag1:value1 },
-            },
-            {
-              'host' => 'remotehost',
-              'port' => '9998',
-              'tags' => %w{ kafka:remote tag2:value2 },
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            instances: [
+              {
+                'host' => 'localhost',
+                'port' => '9997',
+                'tags' => ['kafka:broker', 'tag1:value1'],
+              },
+              {
+                'host' => 'remotehost',
+                'port' => '9998',
+                'tags' => ['kafka:remote', 'tag2:value2'],
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1}) }
-        it { should contain_file(conf_file).with_content(%r{host: remotehost\s+port: 9998\s+tags:\s+- kafka:remote\s+- tag2:value2}) }
-
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: remotehost\s+port: 9998\s+tags:\s+- kafka:remote\s+- tag2:value2}) }
       end
 
       context 'one kafka broker all options' do
-        let(:params) {{
-          instances: [
-            {
-              'host' => 'localhost',
-              'port' => '9997',
-              'tags' => %w{ kafka:broker tag1:value1 },
-              'username' => 'username',
-              'password' => 'password',
-              'process_name_regex' => 'regex',
-              'tools_jar_path' => 'tools.jar',
-              'name' => 'kafka_instance',
-              'java_bin_path' => '/path/to/java',
-              'trust_store_path' => '/path/to/trustStore.jks',
-              'trust_store_password' => 'password'
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            instances: [
+              {
+                'host' => 'localhost',
+                'port' => '9997',
+                'tags' => ['kafka:broker', 'tag1:value1'],
+                'username' => 'username',
+                'password' => 'password',
+                'process_name_regex' => 'regex',
+                'tools_jar_path' => 'tools.jar',
+                'name' => 'kafka_instance',
+                'java_bin_path' => '/path/to/java',
+                'trust_store_path' => '/path/to/trustStore.jks',
+                'trust_store_password' => 'password',
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1\s+user: username\s+password: password\s+process_name_regex: regex\s+tools_jar_path: tools.jar\s+name: kafka_instance\s+java_bin_path: /path/to/java\s+trust_store_path: /path/to/trustStore.jks\s+trust_store_password: password}) }
+        it {
+          is_expected.to contain_file(conf_file).with_content(%r{host: localhost\s+port: 9997\s+tags:\s+- kafka:broker\s+- tag1:value1
+\s+user: username\s+password: password\s+process_name_regex: regex\s+tools_jar_path: tools.jar\s+name: kafka_instance
+\s+java_bin_path: /path/to/java\s+trust_store_path: /path/to/trustStore.jks\s+trust_store_password: password})
+        }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_kong_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kong_spec.rb
@@ -4,37 +4,42 @@ describe 'datadog_agent::integrations::kong' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/kong.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/kong.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/kong.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{kong_status_url: http://localhost:8001/status/}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{kong_status_url: http://localhost:8001/status/}) }
       end
 
       context 'with params set' do
-        let(:params) {{
-          instances: [
-            {
-              'status_url' => 'http://foo.bar:8080/status/',
-              'tags' => ['baz']
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            instances: [
+              {
+                'status_url' => 'http://foo.bar:8080/status/',
+                'tags' => ['baz'],
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{tags:[\r\n]+.*- baz}) }
-        it { should contain_file(conf_file).with_content(%r{kong_status_url: http://foo.bar:8080/status/}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:[\r\n]+.*- baz}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{kong_status_url: http://foo.bar:8080/status/}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_kubernetes_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kubernetes_spec.rb
@@ -4,69 +4,81 @@ describe 'datadog_agent::integrations::kubernetes' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/kubernetes.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/kubernetes.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/kubernetes.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{api_server_url: Enter_Your_API_url}) }
-        it { should contain_file(conf_file).with_content(%r{apiserver_client_crt: /path/to/crt}) }
-        it { should contain_file(conf_file).with_content(%r{apiserver_client_key: /path/to/key}) }
-        it { should contain_file(conf_file).with_content(%r{kubelet_client_crt: /path/to/crt}) }
-        it { should contain_file(conf_file).with_content(%r{kubelet_client_key: /path/to/key}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{api_server_url: Enter_Your_API_url}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{apiserver_client_crt: /path/to/crt}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{apiserver_client_key: /path/to/key}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{kubelet_client_crt: /path/to/crt}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{kubelet_client_key: /path/to/key}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          api_server_url: 'unix://foo/bar/baz.sock',
-        }}
-        it { should contain_file(conf_file).with_content(%r{api_server_url: unix://foo/bar/baz.sock}) }
+        let(:params) do
+          {
+            api_server_url: 'unix://foo/bar/baz.sock',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{api_server_url: unix://foo/bar/baz.sock}) }
       end
 
       context 'with tags parameter array' do
-        let(:params) {{
-          tags: %w{ foo bar baz },
-        }}
-        it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
-      end
+        let(:params) do
+          {
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
 
-      context 'with tags parameter with an empty tag' do
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz\s*?[^-]}m) }
       end
 
       context 'with tags parameter empty values' do
         context 'mixed in with other tags' do
-          let(:params) {{
-            tags: [ 'foo', '', 'baz' ]
-          }}
+          let(:params) do
+            {
+              tags: ['foo', '', 'baz'],
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- baz\s*?[^-]}m) }
         end
 
         context 'single element array of an empty string' do
-          let(:params) {{
-            tags: [''],
-          }}
+          let(:params) do
+            {
+              tags: [''],
+            }
+          end
 
-          skip("undefined behavior")
+          skip('undefined behavior')
         end
 
         context 'single value empty string' do
-          let(:params) {{
-            tags: '',
-          }}
+          let(:params) do
+            {
+              tags: '',
+            }
+          end
 
-          skip("doubly undefined behavior")
+          skip('doubly undefined behavior')
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_kubernetes_state_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kubernetes_state_spec.rb
@@ -4,65 +4,77 @@ describe 'datadog_agent::integrations::kubernetes_state' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/kubernetes_state.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/kubernetes_state.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/kubernetes_state.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{kube_state_url: Enter_State_URL}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{kube_state_url: Enter_State_URL}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          url: 'Some_Other_State_URL',
-        }}
-        it { should contain_file(conf_file).with_content(%r{kube_state_url: Some_Other_State_URL}) }
+        let(:params) do
+          {
+            url: 'Some_Other_State_URL',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{kube_state_url: Some_Other_State_URL}) }
       end
 
       context 'with tags parameter array' do
-        let(:params) {{
-          tags: %w{ foo bar baz },
-        }}
-        it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
-      end
+        let(:params) do
+          {
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
 
-      context 'with tags parameter with an empty tag' do
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz\s*?[^-]}m) }
       end
 
       context 'with tags parameter empty values' do
         context 'mixed in with other tags' do
-          let(:params) {{
-            tags: [ 'foo', '', 'baz' ]
-          }}
+          let(:params) do
+            {
+              tags: ['foo', '', 'baz'],
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- baz\s*?[^-]}m) }
         end
 
         context 'single element array of an empty string' do
-          let(:params) {{
-            tags: [''],
-          }}
+          let(:params) do
+            {
+              tags: [''],
+            }
+          end
 
-          skip("undefined behavior")
+          skip('undefined behavior')
         end
 
         context 'single value empty string' do
-          let(:params) {{
-            tags: '',
-          }}
+          let(:params) do
+            {
+              tags: '',
+            }
+          end
 
-          skip("doubly undefined behavior")
+          skip('doubly undefined behavior')
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_logs_spec.rb
+++ b/spec/classes/datadog_agent_integrations_logs_spec.rb
@@ -6,25 +6,28 @@ describe 'datadog_agent::integrations::logs' do
     let(:conf_file) { "#{CONF_DIR}/logs.yaml" }
 
     context 'with default parameters' do
-      it { should compile }
+      it { is_expected.to compile }
     end
 
     context 'with parameters set' do
-      let(:params) {{
-        logs: [
-          {
-            'type' => 'file',
-            'path' => 'apath.log',
-          },
-          {
-            'type' => 'docker',
-          },
-        ],
-      }}
-      it { should contain_file(conf_file).with_content(%r{logs:}) }
-      it { should contain_file(conf_file).with_content(%r{- type: file}) }
-      it { should contain_file(conf_file).with_content(%r{path: apath.log}) }
-      it { should contain_file(conf_file).with_content(%r{- type: docker}) }
+      let(:params) do
+        {
+          logs: [
+            {
+              'type' => 'file',
+              'path' => 'apath.log',
+            },
+            {
+              'type' => 'docker',
+            },
+          ],
+        }
+      end
+
+      it { is_expected.to contain_file(conf_file).with_content(%r{logs:}) }
+      it { is_expected.to contain_file(conf_file).with_content(%r{- type: file}) }
+      it { is_expected.to contain_file(conf_file).with_content(%r{path: apath.log}) }
+      it { is_expected.to contain_file(conf_file).with_content(%r{- type: docker}) }
     end
   end
 end

--- a/spec/classes/datadog_agent_integrations_marathon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_marathon_spec.rb
@@ -4,34 +4,39 @@ describe 'datadog_agent::integrations::marathon' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/marathon.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/marathon.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/marathon.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{default_timeout: 5}) }
-        it { should contain_file(conf_file).with_content(%r{url: http://localhost:8080}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{default_timeout: 5}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://localhost:8080}) }
       end
 
       context 'with params set' do
-        let(:params) {{
-          marathon_timeout: 867,
-          url: 'http://foo.bar.baz:5309',
-        }}
+        let(:params) do
+          {
+            marathon_timeout: 867,
+            url: 'http://foo.bar.baz:5309',
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{default_timeout: 867}) }
-        it { should contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:5309}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{default_timeout: 867}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:5309}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_mesos_master_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mesos_master_spec.rb
@@ -4,33 +4,39 @@ describe 'datadog_agent::integrations::mesos_master' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/mesos_master.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/mesos_master.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/mesos_master.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{default_timeout: 10}) }
-        it { should contain_file(conf_file).with_content(%r{url: http://localhost:5050}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{default_timeout: 10}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://localhost:5050}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          mesos_timeout: 867,
-          url: 'http://foo.bar.baz:5309',
-        }}
-        it { should contain_file(conf_file).with_content(%r{default_timeout: 867}) }
-        it { should contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:5309}) }
+        let(:params) do
+          {
+            mesos_timeout: 867,
+            url: 'http://foo.bar.baz:5309',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{default_timeout: 867}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:5309}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_mongo_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mongo_spec.rb
@@ -4,136 +4,155 @@ describe 'datadog_agent::integrations::mongo' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/mongo.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/mongo.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/mongo.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{- server: mongodb://localhost:27017}) }
-        it { should contain_file(conf_file).without_content(%r{tags:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{- server: mongodb://localhost:27017}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags:}) }
       end
 
       context 'with one mongo' do
-        let(:params) {{
-          servers: [
-            {
-              'host' => '127.0.0.1',
-              'port' => '12345',
-              'tags' => %w{ foo bar baz },
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            servers: [
+              {
+                'host' => '127.0.0.1',
+                'port' => '12345',
+                'tags' => ['foo', 'bar', 'baz'],
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz}) }
       end
 
       context 'with multiple mongos' do
-        let(:params) {{
-          servers: [
-            {
-              'host' => '127.0.0.1',
-              'port' => '34567',
-              'tags' => %w{foo bar},
-            },
-            {
-              'host' => '127.0.0.2',
-              'port' => '45678',
-              'tags' => %w{baz bat},
-            }
-          ]
-        }}
-        it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:34567/\s+tags:\s+- foo\s+- bar}) }
-        it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.2:45678/\s+tags:\s+- baz\s+- bat}) }
-        it { should contain_file(conf_file).with_content(%r{server:.*127.0.0.1.*server:.*127.0.0.2}m) }
+        let(:params) do
+          {
+            servers: [
+              {
+                'host' => '127.0.0.1',
+                'port' => '34567',
+                'tags' => ['foo', 'bar'],
+              },
+              {
+                'host' => '127.0.0.2',
+                'port' => '45678',
+                'tags' => ['baz', 'bat'],
+              },
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:34567/\s+tags:\s+- foo\s+- bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.2:45678/\s+tags:\s+- baz\s+- bat}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{server:.*127.0.0.1.*server:.*127.0.0.2}m) }
       end
 
       context 'with custom collections one mongos' do
-        let(:params) {{
-          servers: [
-            {
-              'host' => '127.0.0.1',
-              'port' => '12345',
-              'tags' => %w{ foo bar baz },
-              'collections' => %w{ collection_1 collection_2 },
-            },
-            {
-              'host' => '127.0.0.2',
-              'port' => '45678',
-              'tags' => %w{baz bat},
-              'collections' => %w{ collection_1 collection_2 },
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            servers: [
+              {
+                'host' => '127.0.0.1',
+                'port' => '12345',
+                'tags' => ['foo', 'bar', 'baz'],
+                'collections' => ['collection_1', 'collection_2'],
+              },
+              {
+                'host' => '127.0.0.2',
+                'port' => '45678',
+                'tags' => ['baz', 'bat'],
+                'collections' => ['collection_1', 'collection_2'],
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz\s+collections:\s+- collection_1\s+- collection_2}) }
-        it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.2:45678/\s+tags:\s+- baz\s+- bat\s+collections:\s+- collection_1\s+- collection_2}) }
-
+        it { is_expected.to contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz\s+collections:\s+- collection_1\s+- collection_2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.2:45678/\s+tags:\s+- baz\s+- bat\s+collections:\s+- collection_1\s+- collection_2}) }
       end
 
       context 'with custom collections multiple mongo' do
-        let(:params) {{
-          servers: [
-            {
-              'host' => '127.0.0.1',
-              'port' => '12345',
-              'tags' => %w{ foo bar baz },
-              'collections' => %w{ collection_1 collection_2 },
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            servers: [
+              {
+                'host' => '127.0.0.1',
+                'port' => '12345',
+                'tags' => ['foo', 'bar', 'baz'],
+                'collections' => ['collection_1', 'collection_2'],
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz\s+collections:\s+- collection_1\s+- collection_2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz\s+collections:\s+- collection_1\s+- collection_2}) }
       end
 
       context 'with additional metrics' do
-        let(:params) {{
-          servers: [
-            {
-              'host' => '127.0.0.1',
-              'port' => '12345',
-              'tags' => %w{ foo bar baz },
-              'additional_metrics' => %w{ top },
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            servers: [
+              {
+                'host' => '127.0.0.1',
+                'port' => '12345',
+                'tags' => ['foo', 'bar', 'baz'],
+                'additional_metrics' => ['top'],
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz\s+additional_metrics:\s+- top}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{server: mongodb://127.0.0.1:12345/\s+tags:\s+- foo\s+- bar\s+- baz\s+additional_metrics:\s+- top}) }
       end
 
       context 'without tags' do
-        let(:params) {{
-          servers: [
-            {
-              'host' => '127.0.0.1',
-              'port' => '12345',
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            servers: [
+              {
+                'host' => '127.0.0.1',
+                'port' => '12345',
+              },
+            ],
+          }
+        end
 
+        it { is_expected.to compile }
       end
 
       context 'weird tags' do
-        let(:params) {{
-          servers: [
-            {
-              'host' => '127.0.0.1',
-              'port' => '56789',
-              'tags' => 'word'
-            }
-          ]
-        }}
-        it { should_not compile }
+        let(:params) do
+          {
+            servers: [
+              {
+                'host' => '127.0.0.1',
+                'port' => '56789',
+                'tags' => 'word',
+              },
+            ],
+          }
+        end
+
+        it { is_expected.not_to compile }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_mysql_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mysql_spec.rb
@@ -4,96 +4,110 @@ describe 'datadog_agent::integrations::mysql' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/mysql.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/mysql.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/mysql.d/conf.yaml" }
       end
 
       context 'with default parameters' do
-        it { should compile }
+        it { is_expected.to compile }
       end
 
       context 'with password set' do
-        let(:params) {{
-          password: 'foobar',
-        }}
+        let(:params) do
+          {
+            password: 'foobar',
+          }
+        end
 
-        it { should compile.with_all_deps }
-        it { should contain_file(conf_file).with(
-          owner: DD_USER,
-          group: DD_GROUP,
-          mode: PERMISSIONS_PROTECTED_FILE,
-        )}
-        it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-        it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file(conf_file).with(
+            owner: DD_USER,
+            group: DD_GROUP,
+            mode: PERMISSIONS_PROTECTED_FILE,
+          )
+        }
+        it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
-        it { should contain_file(conf_file).with_content(%r{pass: foobar}) }
-        it { should contain_file(conf_file).without_content(%r{tags: }) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{pass: foobar}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags: }) }
 
         context 'with defaults' do
-          it { should contain_file(conf_file).with_content(%r{server: localhost}) }
-          it { should contain_file(conf_file).with_content(%r{user: datadog}) }
-          it { should contain_file(conf_file).without_content(%r{sock: }) }
-          it { should contain_file(conf_file).with_content(%r{replication: 0}) }
-          it { should contain_file(conf_file).with_content(%r{galera_cluster: 0}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{server: localhost}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{user: datadog}) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{sock: }) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{replication: 0}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{galera_cluster: 0}) }
         end
 
         context 'with parameters set' do
-          let(:params) {{
-            password: 'foobar',
-            host: 'mysql1',
-            user: 'baz',
-            sock: '/tmp/mysql.foo.sock',
-            replication: '1',
-            galera_cluster: '1',
-          }}
+          let(:params) do
+            {
+              password: 'foobar',
+              host: 'mysql1',
+              user: 'baz',
+              sock: '/tmp/mysql.foo.sock',
+              replication: '1',
+              galera_cluster: '1',
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(%r{pass: foobar}) }
-          it { should contain_file(conf_file).with_content(%r{server: mysql1}) }
-          it { should contain_file(conf_file).with_content(%r{user: baz}) }
-          it { should contain_file(conf_file).with_content(%r{sock: /tmp/mysql.foo.sock}) }
-          it { should contain_file(conf_file).with_content(%r{replication: 1}) }
-          it { should contain_file(conf_file).with_content(%r{galera_cluster: 1}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{pass: foobar}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{server: mysql1}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{user: baz}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{sock: /tmp/mysql.foo.sock}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{replication: 1}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{galera_cluster: 1}) }
         end
 
         context 'with tags parameter array' do
-          let(:params) {{
-            password: 'foobar',
-            tags: %w{ foo bar baz },
-          }}
-          it { should contain_file(conf_file).with_content(/tags:[^-]+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+          let(:params) do
+            {
+              password: 'foobar',
+              tags: ['foo', 'bar', 'baz'],
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:[^-]+- foo\s+- bar\s+- baz\s*?[^-]}m) }
         end
 
         context 'tags not array' do
-          let(:params) {{
-            password: 'foobar',
-            tags: 'aoeu',
-          }}
+          let(:params) do
+            {
+              password: 'foobar',
+              tags: 'aoeu',
+            }
+          end
 
-          it { should_not compile }
+          it { is_expected.not_to compile }
         end
       end
     end
 
     context 'with queries parameter set' do
-      let(:params) {{
-        password: 'foobar',
-        queries: [
-          {
-            'query'  => 'SELECT TIMESTAMPDIFF(second,MAX(create_time),NOW()) as last_accessed FROM requests',
-            'metric' => 'app.seconds_since_last_request',
-            'type'   => 'gauge',
-            'field'  => 'last_accessed'
-          }
-        ]
-      }}
+      let(:params) do
+        {
+          password: 'foobar',
+          queries: [
+            {
+              'query'  => 'SELECT TIMESTAMPDIFF(second,MAX(create_time),NOW()) as last_accessed FROM requests',
+              'metric' => 'app.seconds_since_last_request',
+              'type'   => 'gauge',
+              'field'  => 'last_accessed',
+            },
+          ],
+        }
+      end
 
-      it { should contain_file(conf_file).with_content(/- query/) }
-      it { should contain_file(conf_file).with_content(%r{query: SELECT TIMESTAMPDIFF\(second,MAX\(create_time\),NOW\(\)\) as last_accessed FROM requests}) }
-      it { should contain_file(conf_file).with_content(%r{metric: app.seconds_since_last_request}) }
-      it { should contain_file(conf_file).with_content(%r{type: gauge}) }
-      it { should contain_file(conf_file).with_content(%r{field: last_accessed}) }
+      it { is_expected.to contain_file(conf_file).with_content(%r{- query}) }
+      it { is_expected.to contain_file(conf_file).with_content(%r{query: SELECT TIMESTAMPDIFF\(second,MAX\(create_time\),NOW\(\)\) as last_accessed FROM requests}) }
+      it { is_expected.to contain_file(conf_file).with_content(%r{metric: app.seconds_since_last_request}) }
+      it { is_expected.to contain_file(conf_file).with_content(%r{type: gauge}) }
+      it { is_expected.to contain_file(conf_file).with_content(%r{field: last_accessed}) }
     end
   end
 end

--- a/spec/classes/datadog_agent_integrations_network_spec.rb
+++ b/spec/classes/datadog_agent_integrations_network_spec.rb
@@ -4,38 +4,46 @@ describe 'datadog_agent::integrations::network' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/network.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/network.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/network.d/conf.yaml" }
       end
 
       context 'with default parameters' do
-        it { should compile }
+        it { is_expected.to compile }
       end
 
       context 'with collect_connection_state set' do
-        let(:params) {{
-          collect_connection_state: true,
-        }}
+        let(:params) do
+          {
+            collect_connection_state: true,
+          }
+        end
 
-        it { should compile.with_all_deps }
-        it { should contain_file(conf_file).with(
-          owner: DD_USER,
-          group: DD_GROUP,
-          mode: PERMISSIONS_PROTECTED_FILE,
-        )}
-        it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-        it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file(conf_file).with(
+            owner: DD_USER,
+            group: DD_GROUP,
+            mode: PERMISSIONS_PROTECTED_FILE,
+          )
+        }
+        it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
-        it { should contain_file(conf_file).with_content(%r{collect_connection_state: true}) }
-        it { should contain_file(conf_file).without_content(%r{tags: }) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{collect_connection_state: true}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags: }) }
 
         context 'with excluded_interfaces parameter array' do
-          let(:params) {{
-            excluded_interfaces: %w{ lo lo0 eth0 },
-          }}
-          it { should contain_file(conf_file).with_content(/excluded_interfaces:[^-]+- lo\s+- lo0\s+- eth0\s*?[^-]/m) }
+          let(:params) do
+            {
+              excluded_interfaces: ['lo', 'lo0', 'eth0'],
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{excluded_interfaces:[^-]+- lo\s+- lo0\s+- eth0\s*?[^-]}m) }
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_nginx_spec.rb
+++ b/spec/classes/datadog_agent_integrations_nginx_spec.rb
@@ -4,59 +4,64 @@ describe 'datadog_agent::integrations::nginx' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/nginx.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/nginx.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/nginx.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'default parameters' do
-        it { should contain_file(conf_file).without_content(/^[^#]*nginx_status_url/) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{^[^#]*nginx_status_url}) }
       end
 
       context 'parameters set' do
-        let(:params) {{
-          instances: [
-            {
-              'nginx_status_url' => 'http://foo.bar:1941/check',
-              'tags' => %w{foo bar baz}
-            }
-          ],
-          logs: [
-            {
-              'type' => 'file',
-              'path' => '/var/log/nginx/access.log',
-              'service' => 'nginx',
-              'source' => 'nginx',
-              'sourcecategory' => 'http_web_access'
-            },
-            {
-              'type' => 'file',
-              'path' => '/var/log/nginx/error.log',
-              'service' => 'nginx',
-              'source' => 'nginx',
-              'sourcecategory' => 'http_web_access'
-            }
-          ]
-        }}
+        let(:params) do
+          {
+            instances: [
+              {
+                'nginx_status_url' => 'http://foo.bar:1941/check',
+                'tags' => ['foo', 'bar', 'baz'],
+              },
+            ],
+            logs: [
+              {
+                'type' => 'file',
+                'path' => '/var/log/nginx/access.log',
+                'service' => 'nginx',
+                'source' => 'nginx',
+                'sourcecategory' => 'http_web_access',
+              },
+              {
+                'type' => 'file',
+                'path' => '/var/log/nginx/error.log',
+                'service' => 'nginx',
+                'source' => 'nginx',
+                'sourcecategory' => 'http_web_access',
+              },
+            ],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{nginx_status_url:.*http://foo.bar:1941/check}m) }
-        it { should contain_file(conf_file).with_content(%r{tags:.*foo.*bar.*baz}m) }
-        it { should contain_file(conf_file).with_content(%r{type:.*file}m) }
-        it { should contain_file(conf_file).with_content(%r{path:.*/var/log/nginx/access.log}m) }
-        it { should contain_file(conf_file).with_content(%r{service:.*nginx}m) }
-        it { should contain_file(conf_file).with_content(%r{source:.*nginx}m) }
-        it { should contain_file(conf_file).with_content(%r{sourcecategory:.*http_web_access}m) }
-        it { should contain_file(conf_file).with_content(%r{path:.*/var/log/nginx/error.log}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{nginx_status_url:.*http://foo.bar:1941/check}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:.*foo.*bar.*baz}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{type:.*file}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{path:.*/var/log/nginx/access.log}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{service:.*nginx}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{source:.*nginx}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{sourcecategory:.*http_web_access}m) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{path:.*/var/log/nginx/error.log}m) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_ntp_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ntp_spec.rb
@@ -4,30 +4,36 @@ describe 'datadog_agent::integrations::ntp' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/ntp.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/ntp.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/ntp.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(/offset_threshold: 60/) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{offset_threshold: 60}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          offset_threshold: 42,
-        }}
-        it { should contain_file(conf_file).with_content(/offset_threshold: 42/) }
+        let(:params) do
+          {
+            offset_threshold: 42,
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{offset_threshold: 42}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_pgbouncer_spec.rb
+++ b/spec/classes/datadog_agent_integrations_pgbouncer_spec.rb
@@ -4,71 +4,83 @@ describe 'datadog_agent::integrations::pgbouncer' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/pgbouncer.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/pgbouncer.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/pgbouncer.d/conf.yaml" }
       end
 
       context 'with default parameters' do
-        let(:params) {{
-          password: 'foobar',
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-        it { should contain_file(conf_file).with_content(%r{port: 6432}) }
-        it { should contain_file(conf_file).with_content(%r{password: foobar}) }
+        let(:params) do
+          {
+            password: 'foobar',
+          }
+        end
 
-        it { should compile.with_all_deps }
-        it { should contain_file(conf_file).with(
-          owner: DD_USER,
-          group: DD_GROUP,
-          mode: PERMISSIONS_PROTECTED_FILE,
-        )}
-        it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-        it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 6432}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: foobar}) }
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file(conf_file).with(
+            owner: DD_USER,
+            group: DD_GROUP,
+            mode: PERMISSIONS_PROTECTED_FILE,
+          )
+        }
+        it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
       end
 
       context 'with one pgbouncer config parameters' do
-        let(:params) {{
-          host: 'localhost',
-          username:  'foo',
-          port: '1234',
-          password: 'bar',
-          tags: ['foo:bar'],
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-        it { should contain_file(conf_file).with_content(%r{username: foo}) }
-        it { should contain_file(conf_file).with_content(%r{port: ("|')?1234("|')?}) }
-        it { should contain_file(conf_file).with_content(%r{password: bar}) }
-        it { should contain_file(conf_file).with_content(%r{- ("|')?foo:bar("|')?}) }
+        let(:params) do
+          {
+            host: 'localhost',
+            username:  'foo',
+            port: '1234',
+            password: 'bar',
+            tags: ['foo:bar'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{username: foo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: ("|')?1234("|')?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{- ("|')?foo:bar("|')?}) }
       end
 
       context 'with multiple pgbouncers configured' do
-        let(:params) {{
-          pgbouncers: [
-            {
-              'host'      => 'localhost',
-              'username'  => 'datadog',
-              'port'      => '6432',
-              'password'  => 'some_pass',
-              'tags'      => ['instance:one'],
-            },
-            {
-              'host'      => 'localhost',
-              'username'  => 'datadog2',
-              'port'      => '6433',
-              'password'  => 'some_pass2',
-              'tags'      => ['instance:two'],
-            }
-          ]
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-        it { should contain_file(conf_file).with_content(%r{port: ("|')?6432("|')?}) }
-        it { should contain_file(conf_file).with_content(%r{password: some_pass}) }
-        it { should contain_file(conf_file).with_content(%r{- ("|')?instance:one("|')?}) }
-        it { should contain_file(conf_file).with_content(%r{port: ("|')?6433("|')?}) }
-        it { should contain_file(conf_file).with_content(%r{password: some_pass2}) }
-        it { should contain_file(conf_file).with_content(%r{- ("|')?instance:two("|')?}) }
+        let(:params) do
+          {
+            pgbouncers: [
+              {
+                'host'      => 'localhost',
+                'username'  => 'datadog',
+                'port'      => '6432',
+                'password'  => 'some_pass',
+                'tags'      => ['instance:one'],
+              },
+              {
+                'host'      => 'localhost',
+                'username'  => 'datadog2',
+                'port'      => '6433',
+                'password'  => 'some_pass2',
+                'tags'      => ['instance:two'],
+              },
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: ("|')?6432("|')?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: some_pass}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{- ("|')?instance:one("|')?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: ("|')?6433("|')?}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: some_pass2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{- ("|')?instance:two("|')?}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
+++ b/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
@@ -4,71 +4,83 @@ describe 'datadog_agent::integrations::php_fpm' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/php_fpm.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/php_fpm.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/php_fpm.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/status/) }
-        it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/ping/) }
-        it { should contain_file(conf_file).with_content(/ping_reply: pong/) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{status_url: http://localhost/status}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_url: http://localhost/ping}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_reply: pong}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          status_url: 'http://localhost/fpm_status',
-          ping_url: 'http://localhost/fpm_ping',
-          ping_reply: 'success',
-        }}
-        it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/fpm_status/) }
-        it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/fpm_ping/) }
-        it { should contain_file(conf_file).with_content(/ping_reply: success/) }
+        let(:params) do
+          {
+            status_url: 'http://localhost/fpm_status',
+            ping_url: 'http://localhost/fpm_ping',
+            ping_reply: 'success',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{status_url: http://localhost/fpm_status}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_url: http://localhost/fpm_ping}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_reply: success}) }
       end
 
       context 'with http_host set' do
-        let(:params) {{
-          status_url: 'http://localhost/fpm_status',
-          ping_url: 'http://localhost/fpm_ping',
-          ping_reply: 'success',
-          http_host: 'php_fpm_server',
-        }}
-        it { should contain_file(conf_file).with_content(/http_host: php_fpm_server/) }
-        it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/fpm_status/) }
-        it { should contain_file(conf_file).with_content(/ping_reply: success/) }
-        it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/fpm_ping/) }
+        let(:params) do
+          {
+            status_url: 'http://localhost/fpm_status',
+            ping_url: 'http://localhost/fpm_ping',
+            ping_reply: 'success',
+            http_host: 'php_fpm_server',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{http_host: php_fpm_server}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{status_url: http://localhost/fpm_status}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_reply: success}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_url: http://localhost/fpm_ping}) }
       end
 
       context 'with instances set' do
-        let(:params) {{
-          instances: [
-            {
-              'status_url'   => 'http://localhost/a/fpm_status',
-              'ping_url'   => 'http://localhost/a/fpm_ping',
-            },
-            {
-              'status_url'   => 'http://localhost/b/fpm_status',
-              'ping_url'   => 'http://localhost/b/fpm_ping',
-              'ping_reply' => 'success',
-            },
-          ]
-        }}
-        it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/a\/fpm_status/) }
-        it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/a\/fpm_ping/) }
-        it { should contain_file(conf_file).with_content(/ping_reply: pong/) }
-        it { should contain_file(conf_file).with_content(/status_url: http:\/\/localhost\/b\/fpm_status/) }
-        it { should contain_file(conf_file).with_content(/ping_url: http:\/\/localhost\/b\/fpm_ping/) }
-        it { should contain_file(conf_file).with_content(/ping_reply: success/) }
+        let(:params) do
+          {
+            instances: [
+              {
+                'status_url' => 'http://localhost/a/fpm_status',
+                'ping_url' => 'http://localhost/a/fpm_ping',
+              },
+              {
+                'status_url' => 'http://localhost/b/fpm_status',
+                'ping_url'   => 'http://localhost/b/fpm_ping',
+                'ping_reply' => 'success',
+              },
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{status_url: http://localhost/a/fpm_status}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_url: http://localhost/a/fpm_ping}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_reply: pong}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{status_url: http://localhost/b/fpm_status}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_url: http://localhost/b/fpm_ping}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ping_reply: success}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_postfix_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postfix_spec.rb
@@ -4,45 +4,51 @@ describe 'datadog_agent::integrations::postfix' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/postfix.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/postfix.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/postfix.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
 
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{  - directory: /var/spool/postfix}) }
-        it { should contain_file(conf_file).with_content(%r{    queues:}) }
-        it { should contain_file(conf_file).with_content(%r{      - active}) }
-        it { should contain_file(conf_file).with_content(%r{      - deferred}) }
-        it { should contain_file(conf_file).with_content(%r{      - incoming}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{  - directory: /var/spool/postfix}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    queues:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      - active}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      - deferred}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      - incoming}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          directory: '/var/spool/foobaz',
-          queues:    ['foobar'],
-          tags:      ['tag1:value1'],
-        }}
-        it { should contain_file(conf_file).with_content(%r{  - directory: /var/spool/foobaz}) }
-        it { should contain_file(conf_file).with_content(%r{    queues:}) }
-        it { should contain_file(conf_file).with_content(%r{      - foobar}) }
-        it { should contain_file(conf_file).with_content(%r{    tags:}) }
-        it { should contain_file(conf_file).with_content(%r{      - tag1:value1}) }
+        let(:params) do
+          {
+            directory: '/var/spool/foobaz',
+            queues:    ['foobar'],
+            tags:      ['tag1:value1'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{  - directory: /var/spool/foobaz}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    queues:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      - foobar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    tags:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      - tag1:value1}) }
       end
 
       context 'with multiple instances set' do
-        let(:params) {
+        let(:params) do
           {
             instances: [
               {
@@ -56,20 +62,17 @@ describe 'datadog_agent::integrations::postfix' do
                 'tags'      => ['tag3:value3'],
               },
 
-            ]
+            ],
           }
-        }
-        it { should contain_file(conf_file).with_content(%r{instances:}) }
-        it { should contain_file(conf_file).with_content(%r{  - directory: /var/spool/postfix-2}) }
-        it { should contain_file(conf_file).with_content(%r{    queues:}) }
-        it { should contain_file(conf_file).with_content(%r{      - active}) }
-        it { should contain_file(conf_file).with_content(%r{    tags:}) }
-        it { should contain_file(conf_file).with_content(%r{      - tag2:value2}) }
-        it { should contain_file(conf_file).with_content(%r{  - directory: /var/spool/postfix-3}) }
-        it { should contain_file(conf_file).with_content(%r{    queues:}) }
-        it { should contain_file(conf_file).with_content(%r{      - incoming}) }
-        it { should contain_file(conf_file).with_content(%r{    tags:}) }
-        it { should contain_file(conf_file).with_content(%r{      - tag3:value3}) }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{instances:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{  - directory: /var/spool/postfix-2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    queues:\n      - active}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    tags:\n      - tag2:value2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{  - directory: /var/spool/postfix-3}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    queues:\n      - incoming}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    tags:\n      - tag3:value3}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_postgres_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postgres_spec.rb
@@ -4,57 +4,65 @@ describe 'datadog_agent::integrations::postgres' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/postgres.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/postgres.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/postgres.d/conf.yaml" }
       end
 
       context 'with default parameters' do
-        it { should compile }
+        it { is_expected.to compile }
       end
 
       context 'with password set' do
-        let(:params) {{
-          password: 'abc123',
-        }}
+        let(:params) do
+          {
+            password: 'abc123',
+          }
+        end
 
-        it { should compile.with_all_deps }
-        it { should contain_file(conf_file).with(
-          owner: DD_USER,
-          group: DD_GROUP,
-          mode: PERMISSIONS_PROTECTED_FILE,
-        )}
-        it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-        it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
-        it { should contain_file(conf_file).with_content(/password: abc123/) }
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file(conf_file).with(
+            owner: DD_USER,
+            group: DD_GROUP,
+            mode: PERMISSIONS_PROTECTED_FILE,
+          )
+        }
+        it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: abc123}) }
 
         context 'with default parameters' do
-          it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-          it { should contain_file(conf_file).with_content(%r{dbname: postgres}) }
-          it { should contain_file(conf_file).with_content(%r{port: 5432}) }
-          it { should contain_file(conf_file).with_content(%r{username: datadog}) }
-          it { should contain_file(conf_file).without_content(%r{^\s*use_psycopg2: }) }
-          it { should contain_file(conf_file).with_content(%r{collect_function_metrics: false}) }
-          it { should contain_file(conf_file).with_content(%r{collect_count_metrics: false}) }
-          it { should contain_file(conf_file).with_content(%r{collect_activity_metrics: false}) }
-          it { should contain_file(conf_file).with_content(%r{collect_database_size_metrics: false}) }
-          it { should contain_file(conf_file).with_content(%r{collect_default_database: false}) }
-          it { should contain_file(conf_file).without_content(%r{tags: })}
-          it { should contain_file(conf_file).without_content(%r{^[^#]*relations: }) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{dbname: postgres}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{port: 5432}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{username: datadog}) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{^\s*use_psycopg2: }) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{collect_function_metrics: false}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{collect_count_metrics: false}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{collect_activity_metrics: false}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{collect_database_size_metrics: false}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{collect_default_database: false}) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{tags: }) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{^[^#]*relations: }) }
         end
 
         context 'with extra metrics collection' do
-          let(:params) {{
-            password: 'abc123',
-            collect_function_metrics: true,
-            collect_count_metrics: true,
-            collect_activity_metrics: true,
-            collect_database_size_metrics: true,
-            collect_default_database: true,
-          }}
+          let(:params) do
+            {
+              password: 'abc123',
+              collect_function_metrics: true,
+              collect_count_metrics: true,
+              collect_activity_metrics: true,
+              collect_database_size_metrics: true,
+              collect_default_database: true,
+            }
+          end
+
           it {
-            should contain_file(conf_file)
+            is_expected.to contain_file(conf_file)
               .with_content(%r{collect_function_metrics: true})
               .with_content(%r{collect_count_metrics: true})
               .with_content(%r{collect_activity_metrics: true})
@@ -64,75 +72,87 @@ describe 'datadog_agent::integrations::postgres' do
         end
 
         context 'with use_psycopg2' do
-          let(:params) {{
-            use_psycopg2: true,
-            password: 'abc123',
-          }}
-          it { should contain_file(conf_file).with_content(%r{use_psycopg2: true}) }
+          let(:params) do
+            {
+              use_psycopg2: true,
+              password: 'abc123',
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{use_psycopg2: true}) }
         end
 
         context 'with parameters set' do
-          let(:params) {{
-            host: 'postgres1',
-            dbname: 'cats',
-            port: 4142,
-            username: 'monitoring',
-            password: 'abc123',
-            tags: %w{foo bar baz},
-            tables: %w{furry fuzzy funky}
-          }}
-          it { should contain_file(conf_file).with_content(%r{host: postgres1}) }
-          it { should contain_file(conf_file).with_content(%r{dbname: cats}) }
-          it { should contain_file(conf_file).with_content(%r{port: 4142}) }
-          it { should contain_file(conf_file).with_content(%r{username: monitoring}) }
-          it { should contain_file(conf_file).with_content(%r{^[^#]*tags:\s+- foo\s+- bar\s+- baz}) }
-          it { should contain_file(conf_file).with_content(%r{^[^#]*relations:\s+- furry\s+- fuzzy\s+- funky}) }
-
-          context 'with custom metric query missing %s' do
-            let(:params) {{
+          let(:params) do
+            {
               host: 'postgres1',
               dbname: 'cats',
               port: 4142,
               username: 'monitoring',
               password: 'abc123',
-              custom_metrics: {
-                'query_is_missing_%s' => {
-                  'query' => 'select * from fuzz',
-                  'metrics' => { },
-                }
+              tags: ['foo', 'bar', 'baz'],
+              tables: ['furry', 'fuzzy', 'funky'],
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{host: postgres1}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{dbname: cats}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{port: 4142}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{username: monitoring}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*tags:\s+- foo\s+- bar\s+- baz}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*relations:\s+- furry\s+- fuzzy\s+- funky}) }
+
+          context 'with custom metric query missing %s' do
+            let(:params) do
+              {
+                host: 'postgres1',
+                dbname: 'cats',
+                port: 4142,
+                username: 'monitoring',
+                password: 'abc123',
+                custom_metrics: {
+                  'query_is_missing_%s' => {
+                    'query' => 'select * from fuzz',
+                    'metrics' => {},
+                  },
+                },
               }
-            }}
+            end
+
             it do
               expect {
                 is_expected.to compile
-              }.to raise_error(/custom_metrics require %s for metric substitution/)
+              }.to raise_error(%r{custom_metrics require %s for metric substitution})
             end
           end
 
           context 'with custom metric query' do
-            let(:params) {{
-              host: 'postgres1',
-              dbname: 'cats',
-              port: 4142,
-              username: 'monitoring',
-              password: 'abc123',
-              custom_metrics: {
-                'foo_gooo_bar_query' => {
-                  'query' => 'select foo, %s from bar',
-                  'metrics' => {
-                    "gooo" => ["custom_metric.tag.gooo", "GAUGE"]
+            let(:params) do
+              {
+                host: 'postgres1',
+                dbname: 'cats',
+                port: 4142,
+                username: 'monitoring',
+                password: 'abc123',
+                custom_metrics: {
+                  'foo_gooo_bar_query' => {
+                    'query' => 'select foo, %s from bar',
+                    'metrics' => {
+                      'gooo' => ['custom_metric.tag.gooo', 'GAUGE'],
+                    },
+                    'descriptors' => [['foo', 'custom_metric.tag.foo']],
                   },
-                  'descriptors' => [["foo", "custom_metric.tag.foo"]]
-                }
+                },
               }
-            }}
+            end
+
             it { is_expected.to compile }
-            it { should contain_file(conf_file).with_content(%r{^[^#]*custom_metrics:}) }
-            it { should contain_file(conf_file).with_content(%r{\s+query:\s*['"]?select foo, %s from bar['"]?}) }
-            it { should contain_file(conf_file).with_content(%r{\s+metrics:}) }
-            it { should contain_file(conf_file).with_content(%r{\s+"gooo":\s+\[custom_metric.tag.gooo, GAUGE\]}) }
-            it { should contain_file(conf_file).with_content(%r{\s+query.*[\r\n]+\s+relation:\s*false}) }
-            it { should contain_file(conf_file).with_content(%r{\s+descriptors.*[\r\n]+\s+-\s+\[foo, custom_metric.tag.foo\]}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*custom_metrics:}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+query:\s*['"]?select foo, %s from bar['"]?}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+metrics:}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+"gooo":\s+\[custom_metric.tag.gooo, GAUGE\]}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+query.*[\r\n]+\s+relation:\s*false}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+descriptors.*[\r\n]+\s+-\s+\[foo, custom_metric.tag.foo\]}) }
           end
         end
       end

--- a/spec/classes/datadog_agent_integrations_process_spec.rb
+++ b/spec/classes/datadog_agent_integrations_process_spec.rb
@@ -4,38 +4,44 @@ describe 'datadog_agent::integrations::process' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/process.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/process.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/process.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).without_content(%r{^[^#]*name:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{^[^#]*name:}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          processes: [
-            {
-              'name' => 'foo',
-              'search_string' => 'bar',
-              'exact_match' => true
-            }
-          ]
-        }}
-        it { should contain_file(conf_file).with_content(%r{name: foo}) }
-        it { should contain_file(conf_file).with_content(%r{search_string: bar}) }
-        it { should contain_file(conf_file).with_content(%r{exact_match: true}) }
+        let(:params) do
+          {
+            processes: [
+              {
+                'name' => 'foo',
+                'search_string' => 'bar',
+                'exact_match' => true,
+              },
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{name: foo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{search_string: bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{exact_match: true}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
+++ b/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
@@ -4,63 +4,69 @@ describe 'datadog_agent::integrations::rabbitmq' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/rabbitmq.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/rabbitmq.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/rabbitmq.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url:}) }
-        it { should contain_file(conf_file).with_content(%r{rabbitmq_user: guest}) }
-        it { should contain_file(conf_file).with_content(%r{rabbitmq_pass: guest}) }
-        it { should contain_file(conf_file).with_content(%r{ssl_verify: true}) }
-        it { should contain_file(conf_file).with_content(%r{tag_families: false}) }
-        it { should contain_file(conf_file).without_content(%r{nodes:}) }
-        it { should contain_file(conf_file).without_content(%r{nodes_regexes:}) }
-        it { should contain_file(conf_file).without_content(%r{queues:}) }
-        it { should contain_file(conf_file).without_content(%r{queues_regexes:}) }
-        it { should contain_file(conf_file).without_content(%r{vhosts:}) }
-        it { should contain_file(conf_file).without_content(%r{exchanges:}) }
-        it { should contain_file(conf_file).without_content(%r{exchanges_regexes:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{rabbitmq_api_url:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{rabbitmq_user: guest}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{rabbitmq_pass: guest}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ssl_verify: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tag_families: false}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{nodes:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{nodes_regexes:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{queues:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{queues_regexes:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{vhosts:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{exchanges:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{exchanges_regexes:}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          url: 'http://rabbit1:15672/',
-          username: 'foo',
-          password: 'bar',
-          ssl_verify: false,
-          tag_families: true,
-          nodes: %w{ node1 node2 node3 },
-          nodes_regexes: %w{ ^regex1 regex2$ regex3* },
-          queues: %w{ queue1 queue2 queue3 },
-          queues_regexes: %w{ ^regex4 regex5$ regex6* },
-          vhosts: %w{ vhost1 vhost2 vhost3 },
-          exchanges: %w{ exchange1 exchange2 exchange3 },
-          exchanges_regexes: %w{ ^regex7 regex8$ regex9* },
-        }}
-        it { should contain_file(conf_file).with_content(%r{rabbitmq_api_url: http://rabbit1:15672/}) }
-        it { should contain_file(conf_file).with_content(%r{rabbitmq_user: foo}) }
-        it { should contain_file(conf_file).with_content(%r{rabbitmq_pass: bar}) }
-        it { should contain_file(conf_file).with_content(%r{ssl_verify: false}) }
-        it { should contain_file(conf_file).with_content(%r{tag_families: true}) }
-        it { should contain_file(conf_file).with_content(%r{nodes:\s+- node1\s+- node2\s+- node3}) }
-        it { should contain_file(conf_file).with_content(%r{nodes_regexes:\s+- \^regex1\s+- regex2\$\s+- regex3\*}) }
-        it { should contain_file(conf_file).with_content(%r{queues:\s+- queue1\s+- queue2\s+- queue3}) }
-        it { should contain_file(conf_file).with_content(%r{queues_regexes:\s+- \^regex4\s+- regex5\$\s+- regex6\*}) }
-        it { should contain_file(conf_file).with_content(%r{vhosts:\s+- vhost1\s+- vhost2\s+- vhost3}) }
-        it { should contain_file(conf_file).with_content(%r{exchanges:\s+- exchange1\s+- exchange2\s+- exchange3}) }
-        it { should contain_file(conf_file).with_content(%r{exchanges_regexes:\s+- \^regex7\s+- regex8\$\s+- regex9\*}) }
+        let(:params) do
+          {
+            url: 'http://rabbit1:15672/',
+            username: 'foo',
+            password: 'bar',
+            ssl_verify: false,
+            tag_families: true,
+            nodes: ['node1', 'node2', 'node3'],
+            nodes_regexes: ['^regex1', 'regex2$', 'regex3*'],
+            queues: ['queue1', 'queue2', 'queue3'],
+            queues_regexes: ['^regex4', 'regex5$', 'regex6*'],
+            vhosts: ['vhost1', 'vhost2', 'vhost3'],
+            exchanges: ['exchange1', 'exchange2', 'exchange3'],
+            exchanges_regexes: ['^regex7', 'regex8$', 'regex9*'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{rabbitmq_api_url: http://rabbit1:15672/}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{rabbitmq_user: foo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{rabbitmq_pass: bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{ssl_verify: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tag_families: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{nodes:\s+- node1\s+- node2\s+- node3}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{nodes_regexes:\s+- \^regex1\s+- regex2\$\s+- regex3\*}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{queues:\s+- queue1\s+- queue2\s+- queue3}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{queues_regexes:\s+- \^regex4\s+- regex5\$\s+- regex6\*}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{vhosts:\s+- vhost1\s+- vhost2\s+- vhost3}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{exchanges:\s+- exchange1\s+- exchange2\s+- exchange3}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{exchanges_regexes:\s+- \^regex7\s+- regex8\$\s+- regex9\*}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -4,161 +4,182 @@ describe 'datadog_agent::integrations::redis' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/redisdb.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/redisdb.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/redisdb.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-        it { should contain_file(conf_file).with_content(%r{port: 6379}) }
-        it { should contain_file(conf_file).without_content(%r{^[^#]*password: }) }
-        it { should contain_file(conf_file).without_content(%r{^[^#]*slowlog-max-len: }) }
-        it { should contain_file(conf_file).without_content(%r{tags:}) }
-        it { should contain_file(conf_file).without_content(%r{\bkeys:}) }
-        it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: true}) }
-        it { should contain_file(conf_file).with_content(%r{command_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 6379}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{^[^#]*password: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{^[^#]*slowlog-max-len: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{\bkeys:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{warn_on_missing_keys: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{command_stats: false}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          host: 'redis1',
-          password: 'hunter2',
-          port: 867,
-          slowlog_max_len: 5309,
-          tags: %w{foo bar},
-          keys: %w{baz bat},
-          warn_on_missing_keys: false,
-          command_stats: true,
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: redis1}) }
-        it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
-        it { should contain_file(conf_file).with_content(%r{port: 867}) }
-        it { should contain_file(conf_file).with_content(%r{^[^#]*slowlog-max-len: 5309}) }
-        it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
-        it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
-        it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
-        it { should contain_file(conf_file).with_content(%r{command_stats: true}) }
+        let(:params) do
+          {
+            host: 'redis1',
+            password: 'hunter2',
+            port: 867,
+            slowlog_max_len: 5309,
+            tags: ['foo', 'bar'],
+            keys: ['baz', 'bat'],
+            warn_on_missing_keys: false,
+            command_stats: true,
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: redis1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 867}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*slowlog-max-len: 5309}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{command_stats: true}) }
       end
 
       context 'with ports parameters set' do
-        let(:params) {{
-          host: 'redis1',
-          password: 'hunter2',
-          ports: %w(2379 2380 2381),
-          slowlog_max_len: 5309,
-          tags: %w{foo bar},
-          keys: %w{baz bat},
-          warn_on_missing_keys: false,
-          command_stats: true,
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: redis1}) }
-        it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
-        it { should contain_file(conf_file).with_content(%r{^[^#]*slowlog-max-len: 5309}) }
-        it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
-        it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
-        it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
-        it { should contain_file(conf_file).with_content(%r{command_stats: true}) }
-        it { should contain_file(conf_file).with_content(%r{port: 2379}) }
-        it { should contain_file(conf_file).with_content(%r{port: 2380}) }
-        it { should contain_file(conf_file).with_content(%r{port: 2381}) }
+        let(:params) do
+          {
+            host: 'redis1',
+            password: 'hunter2',
+            ports: ['2379', '2380', '2381'],
+            slowlog_max_len: 5309,
+            tags: ['foo', 'bar'],
+            keys: ['baz', 'bat'],
+            warn_on_missing_keys: false,
+            command_stats: true,
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: redis1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*slowlog-max-len: 5309}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{command_stats: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 2379}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 2380}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 2381}) }
       end
 
       context 'with strings instead of ints' do
-        let(:params) {{
-          host: 'redis1',
-          password: 'hunter2',
-          port: '867',
-          slowlog_max_len: '5309',
-          tags: %w{foo bar},
-          keys: %w{baz bat},
-          warn_on_missing_keys: false,
-          command_stats: true,
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: redis1}) }
-        it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
-        it { should contain_file(conf_file).with_content(%r{port: 867}) }
-        it { should contain_file(conf_file).with_content(%r{^[^#]*slowlog-max-len: 5309}) }
-        it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
-        it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
-        it { should contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
-        it { should contain_file(conf_file).with_content(%r{command_stats: true}) }
+        let(:params) do
+          {
+            host: 'redis1',
+            password: 'hunter2',
+            port: '867',
+            slowlog_max_len: '5309',
+            tags: ['foo', 'bar'],
+            keys: ['baz', 'bat'],
+            warn_on_missing_keys: false,
+            command_stats: true,
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: redis1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 867}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*slowlog-max-len: 5309}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{warn_on_missing_keys: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{command_stats: true}) }
       end
 
       context 'with instances set' do
-        let(:params) {{
-          instances: [
+        let(:params) do
+          {
+            instances: [
               {
-                  'host'     => 'redis1',
-                  'password' => 'hunter2',
-                  'port'     => 2379,
-                  'tags'     => %w(foo bar),
-                  'keys'     => %w(baz bat),
+                'host' => 'redis1',
+                'password' => 'hunter2',
+                'port'     => 2379,
+                'tags'     => ['foo', 'bar'],
+                'keys'     => ['baz', 'bat'],
               },
               {
-                  'host'     => 'redis1',
-                  'password' => 'hunter2',
-                  'port'     => 2380,
-                  'tags'     => %w(foo bar),
-                  'keys'     => %w(baz bat),
+                'host'     => 'redis1',
+                'password' => 'hunter2',
+                'port'     => 2380,
+                'tags'     => ['foo', 'bar'],
+                'keys'     => ['baz', 'bat'],
               },
-          ],
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: redis1}) }
-        it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
-        it { should contain_file(conf_file).with_content(%r{port: 2379}) }
-        it { should contain_file(conf_file).with_content(%r{port: 2380}) }
-        it { should contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
-        it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
-        it { should contain_file(conf_file).without_content(%r{^[^#]*slowlog-max-len: 5309}) }
-        it { should contain_file(conf_file).without_content(%r{warn_on_missing_keys: false}) }
-        it { should contain_file(conf_file).without_content(%r{command_stats: true}) }
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: redis1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 2379}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 2380}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:.*\s+- foo\s+- bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{^[^#]*slowlog-max-len: 5309}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{warn_on_missing_keys: false}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{command_stats: true}) }
       end
 
       context 'with only keys' do
-        let(:params) {{
-          instances: [
+        let(:params) do
+          {
+            instances: [
               {
-                  'host'     => 'redis1',
-                  'password' => 'hunter2',
-                  'port'     => 2379,
-                  'tags'     => %w(),
-                  'keys'     => %w(baz bat),
+                'host'     => 'redis1',
+                'password' => 'hunter2',
+                'port'     => 2379,
+                'tags'     => [],
+                'keys'     => ['baz', 'bat'],
               },
-          ],
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: redis1}) }
-        it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
-        it { should contain_file(conf_file).with_content(%r{port: 2379}) }
-        it { should contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: redis1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 2379}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{keys:.*\s+- baz\s+- bat}) }
       end
 
       context 'with only tags' do
-        let(:params) {{
-          instances: [
+        let(:params) do
+          {
+            instances: [
               {
-                  'host'     => 'redis1',
-                  'password' => 'hunter2',
-                  'port'     => 2379,
-                  'tags'     => %w(baz bat),
-                  'keys'     => %w(),
+                'host'     => 'redis1',
+                'password' => 'hunter2',
+                'port'     => 2379,
+                'tags'     => ['baz', 'bat'],
+                'keys'     => [],
               },
-          ],
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: redis1}) }
-        it { should contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
-        it { should contain_file(conf_file).with_content(%r{port: 2379}) }
-        it { should contain_file(conf_file).with_content(%r{tags:.*\s+- baz\s+- bat}) }
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: redis1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*password: hunter2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 2379}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:.*\s+- baz\s+- bat}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_riak_spec.rb
+++ b/spec/classes/datadog_agent_integrations_riak_spec.rb
@@ -4,72 +4,91 @@ describe 'datadog_agent::integrations::riak' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/riak.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/riak.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/riak.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{url: http://localhost:8098/stats}) }
-        it { should contain_file(conf_file).without_content(%r{tags: }) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://localhost:8098/stats}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags: }) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          url: 'http://foo.bar.baz:8098/stats',
-          tags: %w{ foo bar baz },
-        }}
-        it { should contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:8098/stats}) }
-        it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+        let(:params) do
+          {
+            url: 'http://foo.bar.baz:8098/stats',
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{url: http://foo.bar.baz:8098/stats}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz\s*?[^-]}m) }
       end
       context 'with tags parameter single value' do
-        let(:params) {{
-          tags: 'foo',
-        }}
-        it { should_not compile }
+        let(:params) do
+          {
+            tags: 'foo',
+          }
+        end
 
-        skip "this is currently unimplemented behavior" do
-          it { should contain_file(conf_file).with_content(/tags:\s+- foo\s*?[^-]/m) }
+        it { is_expected.not_to compile }
+
+        skip 'this is currently unimplemented behavior' do
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s*?[^-]}m) }
         end
       end
       context 'with tags parameter array' do
-        let(:params) {{
-          tags: %w{ foo bar baz },
-        }}
-        it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+        let(:params) do
+          {
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz\s*?[^-]}m) }
       end
       context 'with tags parameter empty values' do
         context 'mixed in with other tags' do
-          let(:params) {{
-            tags: [ 'foo', '', 'baz' ]
-          }}
-          it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+          let(:params) do
+            {
+              tags: ['foo', '', 'baz'],
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- baz\s*?[^-]}m) }
         end
 
         context 'single element array of an empty string' do
-          let(:params) {{
-            tags: [''],
-          }}
+          let(:params) do
+            {
+              tags: [''],
+            }
+          end
 
-          skip("undefined behavior")
+          skip('undefined behavior')
         end
 
         context 'single value empty string' do
-          let(:params) {{
-            tags: '',
-          }}
+          let(:params) do
+            {
+              tags: '',
+            }
+          end
 
-          skip("doubly undefined behavior")
+          skip('doubly undefined behavior')
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_snmp_spec.rb
+++ b/spec/classes/datadog_agent_integrations_snmp_spec.rb
@@ -4,30 +4,36 @@ describe 'datadog_agent::integrations::snmp' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/snmp.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/snmp.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/snmp.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it {should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).without_content(/ignore_nonincreasing_oid/) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{ignore_nonincreasing_oid}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
+        let(:params) do
+          {
             ignore_nonincreasing_oid: true,
-        }}
-        it { should contain_file(conf_file).with_content(/ignore_nonincreasing_oid: true/) }
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{ignore_nonincreasing_oid: true}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_solr_spec.rb
+++ b/spec/classes/datadog_agent_integrations_solr_spec.rb
@@ -4,53 +4,59 @@ describe 'datadog_agent::integrations::solr' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/solr.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/solr.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/solr.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-        it { should contain_file(conf_file).with_content(%r{port: 7199}) }
-        it { should contain_file(conf_file).without_content(%r{user:}) }
-        it { should contain_file(conf_file).without_content(%r{password:}) }
-        it { should contain_file(conf_file).without_content(%r{java_bin_path:}) }
-        it { should contain_file(conf_file).without_content(%r{trust_store_path:}) }
-        it { should contain_file(conf_file).without_content(%r{trust_store_password:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 7199}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{user:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{password:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{java_bin_path:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{trust_store_path:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{trust_store_password:}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          hostname: 'solr1',
-          port: 867,
-          username: 'userfoo',
-          password: 'passbar',
-          java_bin_path: '/opt/java/bin',
-          trust_store_path: '/var/lib/solr/trust_store',
-          trust_store_password: 'hunter2',
-          tags: {
-            'foo' => 'bar',
-            'baz' => 'bat',
+        let(:params) do
+          {
+            hostname: 'solr1',
+            port: 867,
+            username: 'userfoo',
+            password: 'passbar',
+            java_bin_path: '/opt/java/bin',
+            trust_store_path: '/var/lib/solr/trust_store',
+            trust_store_password: 'hunter2',
+            tags: {
+              'foo' => 'bar',
+              'baz' => 'bat',
+            },
           }
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: solr1}) }
-        it { should contain_file(conf_file).with_content(%r{port: 867}) }
-        it { should contain_file(conf_file).with_content(%r{user: userfoo}) }
-        it { should contain_file(conf_file).with_content(%r{password: passbar}) }
-        it { should contain_file(conf_file).with_content(%r{java_bin_path: /opt/java/bin}) }
-        it { should contain_file(conf_file).with_content(%r{trust_store_path: /var/lib/solr/trust_store}) }
-        it { should contain_file(conf_file).with_content(%r{trust_store_password: hunter2}) }
-        it { should contain_file(conf_file).with_content(%r{tags:\s+foo: bar\s+baz: bat}) }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: solr1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 867}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{user: userfoo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: passbar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{java_bin_path: /opt/java/bin}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{trust_store_path: /var/lib/solr/trust_store}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{trust_store_password: hunter2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+foo: bar\s+baz: bat}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_ssh_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ssh_spec.rb
@@ -4,29 +4,33 @@ describe 'datadog_agent::integrations::ssh' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/ssh.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/ssh.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/ssh_check.d/conf.yaml" }
       end
 
       context 'with default parameters' do
-        it { should compile }
+        it { is_expected.to compile }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          host: 'localhost',
-          port:  222,
-          username: 'foo',
-          password: 'bar',
-          sftp_check: false,
-        }}
-        it { should contain_file(conf_file).with_content(/host: localhost/) }
-        it { should contain_file(conf_file).with_content(/port: 222/) }
-        it { should contain_file(conf_file).with_content(/username: foo/) }
-        it { should contain_file(conf_file).with_content(/password: bar/) }
-        it { should contain_file(conf_file).without_content(/private_key_file:/) }
+        let(:params) do
+          {
+            host: 'localhost',
+            port:  222,
+            username: 'foo',
+            password: 'bar',
+            sftp_check: false,
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 222}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{username: foo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: bar}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{private_key_file:}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_supervisrd_spec.rb
+++ b/spec/classes/datadog_agent_integrations_supervisrd_spec.rb
@@ -4,87 +4,102 @@ describe 'datadog_agent::integrations::supervisord' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/supervisord.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/supervisord.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/supervisord.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{name: server0\s+host: localhost\s+port: 9001}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{name: server0\s+host: localhost\s+port: 9001}) }
       end
 
       context 'with one supervisord' do
         context 'without processes' do
-          let(:params) {{
-            instances: [
-              {
-                'servername' => 'server0',
-                'socket'     => 'unix://var/run/supervisor.sock',
-              },
-            ]
-          }}
-          it { should contain_file(conf_file).with_content(%r{name: server0\s+socket: unix://var/run/supervisor.sock}) }
+          let(:params) do
+            {
+              instances: [
+                {
+                  'servername' => 'server0',
+                  'socket'     => 'unix://var/run/supervisor.sock',
+                },
+              ],
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{name: server0\s+socket: unix://var/run/supervisor.sock}) }
         end
         context 'with processes' do
-          let(:params) {{
-            instances: [
-              {
-                'servername' => 'server0',
-                'socket'     => 'unix://var/run/supervisor.sock',
-                'proc_names' => %w{ java apache2 },
-              },
-            ]
-          }}
-          it { should contain_file(conf_file).with_content(%r{name: server0\s+socket: unix://var/run/supervisor.sock\s+proc_names:\s+- java\s+- apache2}) }
+          let(:params) do
+            {
+              instances: [
+                {
+                  'servername' => 'server0',
+                  'socket'     => 'unix://var/run/supervisor.sock',
+                  'proc_names' => ['java', 'apache2'],
+                },
+              ],
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{name: server0\s+socket: unix://var/run/supervisor.sock\s+proc_names:\s+- java\s+- apache2}) }
         end
       end
 
       context 'with multiple supervisord' do
         context 'without processes parameter array' do
-          let(:params) {{
-            instances: [
-              {
-                'servername' => 'server0',
-                'socket'   => 'unix://var/run/supervisor.sock',
-              },
-              {
-                'servername' => 'server1',
-                'hostname'   => 'localhost',
-                'port'       => '9001',
-              },
-            ]
-          }}
-          it { should contain_file(conf_file).with_content(%r{name: server0\s+socket: unix://var/run/supervisor.sock}) }
-          it { should contain_file(conf_file).with_content(%r{name: server1\s+host: localhost\s+port: 9001}) }
+          let(:params) do
+            {
+              instances: [
+                {
+                  'servername' => 'server0',
+                  'socket' => 'unix://var/run/supervisor.sock',
+                },
+                {
+                  'servername' => 'server1',
+                  'hostname'   => 'localhost',
+                  'port'       => '9001',
+                },
+              ],
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{name: server0\s+socket: unix://var/run/supervisor.sock}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{name: server1\s+host: localhost\s+port: 9001}) }
         end
         context 'with processes parameter array' do
-          let(:params) {{
-            instances: [
-              {
-                'servername' => 'server0',
-                'socket'     => 'unix://var/run/supervisor.sock',
-                'proc_names' => %w{ webapp nginx },
-              },
-              {
-                'servername' => 'server1',
-                'hostname'   => 'localhost',
-                'port'       => '9001',
-                'proc_names' => %w{ java apache2 },
-              },
-            ]
-          }}
-          it { should contain_file(conf_file).with_content(%r{name: server0\s+socket: unix://var/run/supervisor.sock\s+proc_names:\s+- webapp\s+- nginx}) }
-          it { should contain_file(conf_file).with_content(%r{name: server1\s+host: localhost\s+port: 9001\s+proc_names:\s+- java\s+- apache2}) }
+          let(:params) do
+            {
+              instances: [
+                {
+                  'servername' => 'server0',
+                  'socket'     => 'unix://var/run/supervisor.sock',
+                  'proc_names' => ['webapp', 'nginx'],
+                },
+                {
+                  'servername' => 'server1',
+                  'hostname'   => 'localhost',
+                  'port'       => '9001',
+                  'proc_names' => ['java', 'apache2'],
+                },
+              ],
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{name: server0\s+socket: unix://var/run/supervisor.sock\s+proc_names:\s+- webapp\s+- nginx}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{name: server1\s+host: localhost\s+port: 9001\s+proc_names:\s+- java\s+- apache2}) }
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_system_core_spec.rb
+++ b/spec/classes/datadog_agent_integrations_system_core_spec.rb
@@ -4,24 +4,27 @@ describe 'datadog_agent::integrations::system_core' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/system_core.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/system_core.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/system_core.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{instances:}) }
-        it { should contain_file(conf_file).with_content(%r{  - foo: bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{instances:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{  - foo: bar}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
@@ -4,91 +4,105 @@ describe 'datadog_agent::integrations::tcp_check' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/tcp_check.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/tcp_check.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/tcp_check.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).without_content(%r{name: }) }
-        it { should contain_file(conf_file).without_content(%r{host: }) }
-        it { should contain_file(conf_file).without_content(%r{port: }) }
-        it { should contain_file(conf_file).without_content(%r{timeout: 1}) }
-        it { should contain_file(conf_file).without_content(%{threshold: }) }
-        it { should contain_file(conf_file).without_content(%r{window: }) }
-        it { should contain_file(conf_file).without_content(%r{collect_response_time: }) }
-        it { should contain_file(conf_file).without_content(%r{skip_event: }) }
-        it { should contain_file(conf_file).without_content(%r{tags: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{name: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{host: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{port: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{timeout: 1}) }
+        it { is_expected.to contain_file(conf_file).without_content(%(threshold: )) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{window: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{collect_response_time: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{skip_event: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags: }) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          check_name: 'foo.bar.baz',
-          host: 'foo.bar.baz',
-          port: '80',
-          timeout: 123,
-          threshold: 456,
-          window: 789,
-          collect_response_time: true,
-          skip_event: true,
-        }}
+        let(:params) do
+          {
+            check_name: 'foo.bar.baz',
+            host: 'foo.bar.baz',
+            port: '80',
+            timeout: 123,
+            threshold: 456,
+            window: 789,
+            collect_response_time: true,
+            skip_event: true,
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{name: foo.bar.baz}) }
-        it { should contain_file(conf_file).with_content(%r{host: foo.bar.baz}) }
-        it { should contain_file(conf_file).with_content(%r{port: 80}) }
-        it { should contain_file(conf_file).with_content(%r{timeout: 123}) }
-        it { should contain_file(conf_file).with_content(%r{threshold: 456}) }
-        it { should contain_file(conf_file).with_content(%r{window: 789}) }
-        it { should contain_file(conf_file).with_content(%r{collect_response_time: true}) }
-        it { should contain_file(conf_file).with_content(%r{skip_event: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{name: foo.bar.baz}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: foo.bar.baz}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 80}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{timeout: 123}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{threshold: 456}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{window: 789}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{collect_response_time: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{skip_event: true}) }
       end
 
       context 'with tags parameter array' do
-        let(:params) {{
-          check_name: 'foo.bar.baz',
-          host: 'foo.bar.baz',
-          port: '80',
-          tags: [ 'foo', 'bar', 'baz' ],
-        }}
-        it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- bar\s+- baz\s*?[^-]/m) }
+        let(:params) do
+          {
+            check_name: 'foo.bar.baz',
+            host: 'foo.bar.baz',
+            port: '80',
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz\s*?[^-]}m) }
       end
 
       context 'with tags parameter empty values' do
         context 'mixed in with other tags' do
-          let(:params) {{
-            check_name: 'foo.bar.baz',
-            host: 'foo.bar.baz',
-            port: '80',
-            tags: [ 'foo', '', 'baz' ]
-          }}
+          let(:params) do
+            {
+              check_name: 'foo.bar.baz',
+              host: 'foo.bar.baz',
+              port: '80',
+              tags: ['foo', '', 'baz'],
+            }
+          end
 
-          it { should contain_file(conf_file).with_content(/tags:\s+- foo\s+- baz\s*?[^-]/m) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- baz\s*?[^-]}m) }
         end
 
         context 'single element array of an empty string' do
-          let(:params) {{
-            tags: [''],
-          }}
+          let(:params) do
+            {
+              tags: [''],
+            }
+          end
 
-          skip("undefined behavior")
+          skip('undefined behavior')
         end
 
         context 'single value empty string' do
-          let(:params) {{
-            tags: '',
-          }}
+          let(:params) do
+            {
+              tags: '',
+            }
+          end
 
-          skip("doubly undefined behavior")
+          skip('doubly undefined behavior')
         end
       end
     end

--- a/spec/classes/datadog_agent_integrations_tomcat_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tomcat_spec.rb
@@ -4,67 +4,76 @@ describe 'datadog_agent::integrations::tomcat' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/tomcat.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/tomcat.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/tomcat.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-        it { should contain_file(conf_file).with_content(%r{port: 7199}) }
-        it { should contain_file(conf_file).without_content(%r{user: }) }
-        it { should contain_file(conf_file).without_content(%r{password: }) }
-        it { should contain_file(conf_file).without_content(%r{java_bin_path:}) }
-        it { should contain_file(conf_file).without_content(%r{trust_store_path:}) }
-        it { should contain_file(conf_file).without_content(%r{trust_store_password}) }
-        it { should contain_file(conf_file).without_content(%r{tags:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 7199}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{user: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{password: }) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{java_bin_path:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{trust_store_path:}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{trust_store_password}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags:}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          hostname: 'tomcat1',
-          port: 867,
-          username: 'userfoo',
-          password: 'passbar',
-          java_bin_path: '/opt/bin/java',
-          trust_store_path: '/var/lib/tomcat/trust_store_path',
-          trust_store_password: 'hunter2',
-          tags: {
-            'foo' => 'bar',
-            'baz' => 'bat',
+        let(:params) do
+          {
+            hostname: 'tomcat1',
+            port: 867,
+            username: 'userfoo',
+            password: 'passbar',
+            java_bin_path: '/opt/bin/java',
+            trust_store_path: '/var/lib/tomcat/trust_store_path',
+            trust_store_password: 'hunter2',
+            tags: {
+              'foo' => 'bar',
+              'baz' => 'bat',
+            },
           }
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: tomcat1}) }
-        it { should contain_file(conf_file).with_content(%r{port: 867}) }
-        it { should contain_file(conf_file).with_content(%r{user: userfoo}) }
-        it { should contain_file(conf_file).with_content(%r{password: passbar}) }
-        it { should contain_file(conf_file).with_content(%r{java_bin_path: /opt/bin/java}) }
-        it { should contain_file(conf_file).with_content(%r{trust_store_path: /var/lib/tomcat/trust_store_path}) }
-        it { should contain_file(conf_file).with_content(%r{trust_store_password: hunter2}) }
-        it { should contain_file(conf_file).with_content(%r{tags:\s+foo: bar\s+baz: bat}) }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: tomcat1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 867}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{user: userfoo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: passbar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{java_bin_path: /opt/bin/java}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{trust_store_path: /var/lib/tomcat/trust_store_path}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{trust_store_password: hunter2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+foo: bar\s+baz: bat}) }
       end
 
       context 'with jmx_url parameter set' do
-        let(:params) {{
-          hostname: 'tomcat1',
-          jmx_url: 'service:jmx:rmi:///jndi/rmi://tomcat.foo:9999/custompath',
-          username: 'userfoo',
-          password: 'passbar',
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: tomcat1}) }
-        it { should contain_file(conf_file).with_content(%r{jmx_url: "service:jmx:rmi:///jndi/rmi://tomcat.foo:9999/custompath"}) }
-        it { should contain_file(conf_file).with_content(%r{user: userfoo}) }
-        it { should contain_file(conf_file).with_content(%r{password: passbar}) }
+        let(:params) do
+          {
+            hostname: 'tomcat1',
+            jmx_url: 'service:jmx:rmi:///jndi/rmi://tomcat.foo:9999/custompath',
+            username: 'userfoo',
+            password: 'passbar',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: tomcat1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{jmx_url: "service:jmx:rmi:///jndi/rmi://tomcat.foo:9999/custompath"}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{user: userfoo}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: passbar}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_twemproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_twemproxy_spec.rb
@@ -4,43 +4,49 @@ describe 'datadog_agent::integrations::twemproxy' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/twemproxy.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/twemproxy.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/twemproxy.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-        it { should contain_file(conf_file).with_content(%r{port: 22222}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 22222}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          instances: [
-            {
-              'host' => 'twemproxy1',
-              'port' => '1234',
-            },
-            {
-              'host' => 'twemproxy2',
-              'port' => '4567',
-            }
-          ]
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: twemproxy1}) }
-        it { should contain_file(conf_file).with_content(%r{port: 1234}) }
-        it { should contain_file(conf_file).with_content(%r{host: twemproxy2}) }
-        it { should contain_file(conf_file).with_content(%r{port: 4567}) }
+        let(:params) do
+          {
+            instances: [
+              {
+                'host' => 'twemproxy1',
+                'port' => '1234',
+              },
+              {
+                'host' => 'twemproxy2',
+                'port' => '4567',
+              },
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: twemproxy1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 1234}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: twemproxy2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 4567}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_varnish_spec.rb
+++ b/spec/classes/datadog_agent_integrations_varnish_spec.rb
@@ -4,35 +4,39 @@ describe 'datadog_agent::integrations::varnish' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/varnish.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/varnish.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/varnish.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
-
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{varnishstat: /usr/bin/varnishstat}) }
-        it { should contain_file(conf_file).without_content(%r{tags: }) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{varnishstat: /usr/bin/varnishstat}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags: }) }
       end
 
       context 'with parameters set' do
-        let(:params){{
-          varnishstat: '/opt/bin/varnishstat',
-          tags: %w{ foo bar baz },
-        }}
+        let(:params) do
+          {
+            varnishstat: '/opt/bin/varnishstat',
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
 
-        it { should contain_file(conf_file).with_content(%r{varnishstat: /opt/bin/varnishstat}) }
-        it { should contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{varnishstat: /opt/bin/varnishstat}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_zk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_zk_spec.rb
@@ -4,50 +4,56 @@ describe 'datadog_agent::integrations::zk' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+
       if agent_major_version == 5
-        let(:conf_file) { "/etc/dd-agent/conf.d/zk.yaml" }
+        let(:conf_file) { '/etc/dd-agent/conf.d/zk.yaml' }
       else
         let(:conf_file) { "#{CONF_DIR}/zk.d/conf.yaml" }
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_file(conf_file).with(
-        owner: DD_USER,
-        group: DD_GROUP,
-        mode: PERMISSIONS_PROTECTED_FILE,
-      )}
-      it { should contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
-      it { should contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_file(conf_file).with(
+          owner: DD_USER,
+          group: DD_GROUP,
+          mode: PERMISSIONS_PROTECTED_FILE,
+        )
+      }
+      it { is_expected.to contain_file(conf_file).that_requires("Package[#{PACKAGE_NAME}]") }
+      it { is_expected.to contain_file(conf_file).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with default parameters' do
-        it { should contain_file(conf_file).with_content(%r{host: localhost}) }
-        it { should contain_file(conf_file).with_content(%r{port: 2181}) }
-        it { should contain_file(conf_file).with_content(%r{timeout: 3}) }
-        it { should contain_file(conf_file).without_content(%r{tags:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: localhost}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 2181}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{timeout: 3}) }
+        it { is_expected.to contain_file(conf_file).without_content(%r{tags:}) }
       end
 
       context 'with parameters set' do
-        let(:params) {{
-          servers: [
-            {
-              'host' => 'zookeeper1',
-              'port' => '1234',
-              'tags' => %w{foo bar},
-            },
-            {
-              'host' => 'zookeeper2',
-              'port' => '4567',
-              'tags' => %w{baz bat},
-            }
-          ]
-        }}
-        it { should contain_file(conf_file).with_content(%r{host: zookeeper1}) }
-        it { should contain_file(conf_file).with_content(%r{port: 1234}) }
-        it { should contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar}) }
-        it { should contain_file(conf_file).with_content(%r{host: zookeeper2}) }
-        it { should contain_file(conf_file).with_content(%r{port: 4567}) }
-        it { should contain_file(conf_file).with_content(%r{tags:\s+- baz\s+- bat}) }
-        it { should contain_file(conf_file).with_content(%r{host: zookeeper1.+host: zookeeper2}m) }
+        let(:params) do
+          {
+            servers: [
+              {
+                'host' => 'zookeeper1',
+                'port' => '1234',
+                'tags' => ['foo', 'bar'],
+              },
+              {
+                'host' => 'zookeeper2',
+                'port' => '4567',
+                'tags' => ['baz', 'bat'],
+              },
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: zookeeper1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 1234}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: zookeeper2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{port: 4567}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- baz\s+- bat}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{host: zookeeper1.+host: zookeeper2}m) }
       end
     end
   end

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -16,7 +16,12 @@ describe 'datadog_agent::redhat' do
 
     # it should install the mirror
     context 'with manage_repo => true' do
-      let(:params) { { manage_repo: true, agent_major_version: 5 } }
+      let(:params) do
+        {
+          manage_repo: true,
+          agent_major_version: 5,
+        }
+      end
 
       it do
         is_expected.to contain_yumrepo('datadog')
@@ -27,7 +32,11 @@ describe 'datadog_agent::redhat' do
       end
     end
     context 'with manage_repo => false' do
-      let(:params) { { manage_repo: false, agent_major_version: 5 } }
+      let(:params) do
+        {
+          manage_repo: false, agent_major_version: 5
+        }
+      end
 
       it do
         is_expected.not_to contain_yumrepo('datadog')
@@ -79,7 +88,11 @@ describe 'datadog_agent::redhat' do
 
     # it should install the mirror
     context 'with manage_repo => true' do
-      let(:params) { { manage_repo: true, agent_major_version: 6 } }
+      let(:params) do
+        {
+          manage_repo: true, agent_major_version: 6
+        }
+      end
 
       it do
         is_expected.to contain_yumrepo('datadog')
@@ -90,7 +103,11 @@ describe 'datadog_agent::redhat' do
       end
     end
     context 'with manage_repo => false' do
-      let(:params) { { manage_repo: false, agent_major_version: 6 } }
+      let(:params) do
+        {
+          manage_repo: false, agent_major_version: 6
+        }
+      end
 
       it do
         is_expected.not_to contain_yumrepo('datadog')
@@ -142,7 +159,11 @@ describe 'datadog_agent::redhat' do
 
     # it should install the mirror
     context 'with manage_repo => true' do
-      let(:params) { { manage_repo: true, agent_major_version: 7 } }
+      let(:params) do
+        {
+          manage_repo: true, agent_major_version: 7
+        }
+      end
 
       it do
         is_expected.to contain_yumrepo('datadog')
@@ -153,7 +174,12 @@ describe 'datadog_agent::redhat' do
       end
     end
     context 'with manage_repo => false' do
-      let(:params) { { manage_repo: false, agent_major_version: 7 } }
+      let(:params) do
+        {
+          manage_repo: false,
+          agent_major_version: 7,
+        }
+      end
 
       it do
         is_expected.not_to contain_yumrepo('datadog')

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'datadog_agent::redhat' do
-
   context 'agent 5' do
     if RSpec::Support::OS.windows?
       return
@@ -11,40 +10,45 @@ describe 'datadog_agent::redhat' do
       {
         osfamily: 'redhat',
         operatingsystem: 'Fedora',
-        architecture: 'x86_64'
+        architecture: 'x86_64',
       }
     end
 
     # it should install the mirror
     context 'with manage_repo => true' do
-      let(:params){ {:manage_repo => true, :agent_major_version => 5} }
+      let(:params) { { manage_repo: true, agent_major_version: 5 } }
+
       it do
-        should contain_yumrepo('datadog')
+        is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-            .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
           .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
       end
     end
     context 'with manage_repo => false' do
-      let(:params){ {:manage_repo => false, :agent_major_version => 5} }
+      let(:params) { { manage_repo: false, agent_major_version: 5 } }
+
       it do
-        should_not contain_yumrepo('datadog')
-        should_not contain_yumrepo('datadog5')
-        should_not contain_yumrepo('datadog6')
+        is_expected.not_to contain_yumrepo('datadog')
+        is_expected.not_to contain_yumrepo('datadog5')
+        is_expected.not_to contain_yumrepo('datadog6')
       end
     end
     context 'overriding provider' do
-      let(:params) {{
-        service_provider: 'upstart',
-        agent_major_version: 5
-      }}
+      let(:params) do
+        {
+          service_provider: 'upstart',
+          agent_major_version: 5,
+        }
+      end
+
       it do
-        should contain_service('datadog-agent')\
+        is_expected.to contain_service('datadog-agent')\
           .that_requires('package[datadog-agent]')
       end
       it do
-        should contain_service('datadog-agent').with(
+        is_expected.to contain_service('datadog-agent').with(
           'provider' => 'upstart',
           'ensure' => 'running',
         )
@@ -53,13 +57,13 @@ describe 'datadog_agent::redhat' do
 
     # it should install the packages
     it do
-      should contain_package('datadog-agent')\
+      is_expected.to contain_package('datadog-agent')\
         .with_ensure('latest')
     end
 
     # it should be able to start the service and enable the service by default
     it do
-      should contain_service('datadog-agent')\
+      is_expected.to contain_service('datadog-agent')\
         .that_requires('Package[datadog-agent]')
     end
   end
@@ -69,40 +73,45 @@ describe 'datadog_agent::redhat' do
       {
         osfamily: 'redhat',
         operatingsystem: 'Fedora',
-        architecture: 'x86_64'
+        architecture: 'x86_64',
       }
     end
 
     # it should install the mirror
     context 'with manage_repo => true' do
-      let(:params){ {:manage_repo => true, :agent_major_version => 6} }
+      let(:params) { { manage_repo: true, agent_major_version: 6 } }
+
       it do
-        should contain_yumrepo('datadog')
+        is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-            .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/6/x86_64/')
       end
     end
     context 'with manage_repo => false' do
-      let(:params){ {:manage_repo => false, :agent_major_version => 6} }
+      let(:params) { { manage_repo: false, agent_major_version: 6 } }
+
       it do
-        should_not contain_yumrepo('datadog')
-        should_not contain_yumrepo('datadog5')
-        should_not contain_yumrepo('datadog6')
+        is_expected.not_to contain_yumrepo('datadog')
+        is_expected.not_to contain_yumrepo('datadog5')
+        is_expected.not_to contain_yumrepo('datadog6')
       end
     end
     context 'overriding provider' do
-      let(:params) {{
-        service_provider: 'upstart',
-        agent_major_version: 6
-      }}
+      let(:params) do
+        {
+          service_provider: 'upstart',
+          agent_major_version: 6,
+        }
+      end
+
       it do
-        should contain_service('datadog-agent')\
+        is_expected.to contain_service('datadog-agent')\
           .that_requires('package[datadog-agent]')
       end
       it do
-        should contain_service('datadog-agent').with(
+        is_expected.to contain_service('datadog-agent').with(
           'provider' => 'upstart',
           'ensure' => 'running',
         )
@@ -111,13 +120,13 @@ describe 'datadog_agent::redhat' do
 
     # it should install the packages
     it do
-      should contain_package('datadog-agent')\
+      is_expected.to contain_package('datadog-agent')\
         .with_ensure('latest')
     end
 
     # it should be able to start the service and enable the service by default
     it do
-      should contain_service('datadog-agent')\
+      is_expected.to contain_service('datadog-agent')\
         .that_requires('Package[datadog-agent]')
     end
   end
@@ -127,40 +136,45 @@ describe 'datadog_agent::redhat' do
       {
         osfamily: 'redhat',
         operatingsystem: 'Fedora',
-        architecture: 'x86_64'
+        architecture: 'x86_64',
       }
     end
 
     # it should install the mirror
     context 'with manage_repo => true' do
-      let(:params){ {:manage_repo => true, :agent_major_version => 7} }
+      let(:params) { { manage_repo: true, agent_major_version: 7 } }
+
       it do
-        should contain_yumrepo('datadog')
+        is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-            .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')
       end
     end
     context 'with manage_repo => false' do
-      let(:params){ {:manage_repo => false, :agent_major_version => 7} }
+      let(:params) { { manage_repo: false, agent_major_version: 7 } }
+
       it do
-        should_not contain_yumrepo('datadog')
-        should_not contain_yumrepo('datadog5')
-        should_not contain_yumrepo('datadog6')
+        is_expected.not_to contain_yumrepo('datadog')
+        is_expected.not_to contain_yumrepo('datadog5')
+        is_expected.not_to contain_yumrepo('datadog6')
       end
     end
     context 'overriding provider' do
-      let(:params) {{
-        service_provider: 'upstart',
-        agent_major_version: 7
-      }}
+      let(:params) do
+        {
+          service_provider: 'upstart',
+          agent_major_version: 7,
+        }
+      end
+
       it do
-        should contain_service('datadog-agent')\
+        is_expected.to contain_service('datadog-agent')\
           .that_requires('package[datadog-agent]')
       end
       it do
-        should contain_service('datadog-agent').with(
+        is_expected.to contain_service('datadog-agent').with(
           'provider' => 'upstart',
           'ensure' => 'running',
         )
@@ -169,13 +183,13 @@ describe 'datadog_agent::redhat' do
 
     # it should install the packages
     it do
-      should contain_package('datadog-agent')\
+      is_expected.to contain_package('datadog-agent')\
         .with_ensure('latest')
     end
 
     # it should be able to start the service and enable the service by default
     it do
-      should contain_service('datadog-agent')\
+      is_expected.to contain_service('datadog-agent')\
         .that_requires('Package[datadog-agent]')
     end
   end

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'datadog_agent::reports' do
-
   if RSpec::Support::OS.windows?
     return
   end
@@ -15,6 +14,7 @@ describe 'datadog_agent::reports' do
       }
     end
     let(:conf_file) { '/etc/datadog-agent/datadog-reports.yaml' }
+
     ALL_OS.each do |operatingsystem|
       describe "datadog_agent class common actions on #{operatingsystem}" do
         let(:facts) do
@@ -26,42 +26,42 @@ describe 'datadog_agent::reports' do
         end
 
         if WINDOWS_OS.include?(operatingsystem)
-          it "should raise on Windows" do
-            should raise_error(Puppet::Error)
+          it 'raises on Windows' do
+            is_expected.to raise_error(Puppet::Error)
           end
         else
-          it { should contain_class('ruby').with_rubygems_update(false) }
-          it { should contain_class('ruby::params') }
-          it { should contain_package('ruby').with_ensure('installed') }
-          it { should contain_package('rubygems').with_ensure('installed') }
+          it { is_expected.to contain_class('ruby').with_rubygems_update(false) }
+          it { is_expected.to contain_class('ruby::params') }
+          it { is_expected.to contain_package('ruby').with_ensure('installed') }
+          it { is_expected.to contain_package('rubygems').with_ensure('installed') }
 
           if DEBIAN_OS.include?(operatingsystem)
             it do
-              should contain_package('ruby-dev')\
+              is_expected.to contain_package('ruby-dev')\
                 .with_ensure('installed')\
                 .that_comes_before('Package[dogapi]')
             end
           elsif REDHAT_OS.include?(operatingsystem)
             it do
-              should contain_package('ruby-devel')\
+              is_expected.to contain_package('ruby-devel')\
                 .with_ensure('installed')\
                 .that_comes_before('Package[dogapi]')
             end
           end
 
           it do
-            should contain_package('dogapi')\
+            is_expected.to contain_package('dogapi')\
               .with_ensure('installed')
               .with_provider('puppetserver_gem')
           end
 
           it do
-            should contain_file(conf_file)\
+            is_expected.to contain_file(conf_file)\
               .with_owner('puppet')\
               .with_group('root')
           end
 
-          it { should contain_file(conf_file).without_content(/hostname_extraction_regex:/) }
+          it { is_expected.to contain_file(conf_file).without_content(%r{hostname_extraction_regex:}) }
 
         end
       end
@@ -72,38 +72,38 @@ describe 'datadog_agent::reports' do
       {
         api_key: 'notanapikey',
         puppetmaster_user: 'puppet',
-        dogapi_version: '1.2.2'
+        dogapi_version: '1.2.2',
       }
     end
     let(:conf_file) { '/etc/datadog-agent/datadog-reports.yaml' }
 
-    describe "datadog_agent class dogapi version override" do
+    describe 'datadog_agent class dogapi version override' do
       let(:facts) do
         {
           operatingsystem: 'Debian',
-          osfamily: 'debian'
+          osfamily: 'debian',
         }
       end
 
-      it { should contain_class('ruby').with_rubygems_update(false) }
-      it { should contain_class('ruby::params') }
-      it { should contain_package('ruby').with_ensure('installed') }
-      it { should contain_package('rubygems').with_ensure('installed') }
+      it { is_expected.to contain_class('ruby').with_rubygems_update(false) }
+      it { is_expected.to contain_class('ruby::params') }
+      it { is_expected.to contain_package('ruby').with_ensure('installed') }
+      it { is_expected.to contain_package('rubygems').with_ensure('installed') }
 
       it do
-        should contain_package('ruby-dev')\
+        is_expected.to contain_package('ruby-dev')\
           .with_ensure('installed')\
           .that_comes_before('Package[dogapi]')
       end
 
       it do
-        should contain_package('dogapi')\
+        is_expected.to contain_package('dogapi')\
           .with_ensure('1.2.2')
           .with_provider('puppetserver_gem')
       end
 
       it do
-        should contain_file(conf_file)\
+        is_expected.to contain_file(conf_file)\
           .with_owner('puppet')\
           .with_group('root')
       end
@@ -122,27 +122,27 @@ describe 'datadog_agent::reports' do
     end
     let(:conf_file) { '/etc/datadog-agent/datadog-reports.yaml' }
 
-    describe "datadog_agent class puppet gem provider override" do
+    describe 'datadog_agent class puppet gem provider override' do
       let(:facts) do
         {
           operatingsystem: 'Debian',
-          osfamily: 'debian'
+          osfamily: 'debian',
         }
       end
 
-      it { should contain_class('ruby').with_rubygems_update(false) }
-      it { should contain_class('ruby::params') }
-      it { should contain_package('ruby').with_ensure('installed') }
-      it { should contain_package('rubygems').with_ensure('installed') }
+      it { is_expected.to contain_class('ruby').with_rubygems_update(false) }
+      it { is_expected.to contain_class('ruby::params') }
+      it { is_expected.to contain_package('ruby').with_ensure('installed') }
+      it { is_expected.to contain_package('rubygems').with_ensure('installed') }
 
       it do
-        should contain_package('ruby-dev')\
+        is_expected.to contain_package('ruby-dev')\
           .with_ensure('installed')\
           .that_comes_before('Package[dogapi]')
       end
 
       it do
-        should contain_package('dogapi')\
+        is_expected.to contain_package('dogapi')\
           .with_ensure('1.2.2')
           .with_provider('gem')
       end
@@ -160,32 +160,32 @@ describe 'datadog_agent::reports' do
     end
     let(:conf_file) { '/etc/datadog-agent/datadog-reports.yaml' }
 
-    describe "datadog_agent class dogapi version override" do
+    describe 'datadog_agent class dogapi version override' do
       let(:facts) do
         {
           operatingsystem: 'Debian',
-          osfamily: 'debian'
+          osfamily: 'debian',
         }
       end
 
-      it { should contain_class('ruby').with_rubygems_update(false) }
-      it { should contain_class('ruby::params') }
-      it { should contain_package('ruby').with_ensure('installed') }
-      it { should contain_package('rubygems').with_ensure('installed') }
+      it { is_expected.to contain_class('ruby').with_rubygems_update(false) }
+      it { is_expected.to contain_class('ruby::params') }
+      it { is_expected.to contain_package('ruby').with_ensure('installed') }
+      it { is_expected.to contain_package('rubygems').with_ensure('installed') }
 
       it do
-        should contain_package('ruby-dev')\
+        is_expected.to contain_package('ruby-dev')\
           .with_ensure('installed')\
           .that_comes_before('Package[dogapi]')
       end
 
       it do
-        should contain_file(conf_file)\
+        is_expected.to contain_file(conf_file)\
           .with_owner('puppet')\
           .with_group('root')\
-          .with_content(/:api_url: https:\/\/api.datadoghq.eu/)
+          .with_content(%r{:api_url: https://api.datadoghq.eu})
       end
-      it { should contain_file(conf_file).without_content(/hostname_extraction_regex:/)  }
+      it { is_expected.to contain_file(conf_file).without_content(%r{hostname_extraction_regex:}) }
     end
   end
 end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -20,8 +20,17 @@ describe 'datadog_agent' do
     end
 
     context 'autodetect major version agent 5' do
-      let(:params) { { agent_version: '5.15.1' } }
-      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+      let(:params) do
+        {
+          agent_version: '5.15.1',
+        }
+      end
+      let(:facts) do
+        {
+          osfamily: 'debian',
+          operatingsystem: 'Ubuntu',
+        }
+      end
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
@@ -30,8 +39,17 @@ describe 'datadog_agent' do
     end
 
     context 'autodetect major version agent 6' do
-      let(:params) { { agent_version: '6.15.1' } }
-      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+      let(:params) do
+        {
+          agent_version: '6.15.1',
+        }
+      end
+      let(:facts) do
+        {
+          osfamily: 'debian',
+          operatingsystem: 'Ubuntu',
+        }
+      end
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
@@ -40,8 +58,17 @@ describe 'datadog_agent' do
     end
 
     context 'autodetect major version agent 7' do
-      let(:params) { { agent_version: '7.15.1' } }
-      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+      let(:params) do
+        {
+          agent_version: '7.15.1',
+        }
+      end
+      let(:facts) do
+        {
+          osfamily: 'debian',
+          operatingsystem: 'Ubuntu',
+        }
+      end
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
@@ -50,8 +77,17 @@ describe 'datadog_agent' do
     end
 
     context 'autodetect major version agent with suffix and release' do
-      let(:params) { { agent_version: '1:6.15.1~rc.1-1' } }
-      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+      let(:params) do
+        {
+          agent_version: '1:6.15.1~rc.1-1',
+        }
+      end
+      let(:facts) do
+        {
+          osfamily: 'debian',
+          operatingsystem: 'Ubuntu',
+        }
+      end
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
@@ -60,8 +96,17 @@ describe 'datadog_agent' do
     end
 
     context 'autodetect major version agent with windows suffix and release' do
-      let(:params) { { agent_version: '1:6.15.1-rc.1-1' } }
-      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+      let(:params) do
+        {
+          agent_version: '1:6.15.1-rc.1-1',
+        }
+      end
+      let(:facts) do
+        {
+          osfamily: 'debian',
+          operatingsystem: 'Ubuntu',
+        }
+      end
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
@@ -70,8 +115,17 @@ describe 'datadog_agent' do
     end
 
     context 'autodetect major version agent with release' do
-      let(:params) { { agent_version: '1:6.15.1-1' } }
-      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+      let(:params) do
+        {
+          agent_version: '1:6.15.1-1',
+        }
+      end
+      let(:facts) do
+        {
+          osfamily: 'debian',
+          operatingsystem: 'Ubuntu',
+        }
+      end
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
@@ -1474,7 +1528,11 @@ describe 'datadog_agent' do
       end
 
       describe "datadog_agent 6 class with reports on #{operatingsystem}" do
-        let(:params) { { puppet_run_reports: true } }
+        let(:params) do
+          {
+            puppet_run_reports: true,
+          }
+        end
         let(:facts) do
           {
             operatingsystem: operatingsystem,
@@ -1496,7 +1554,11 @@ describe 'datadog_agent' do
       end
 
       describe "datadog_agent 6 class common actions on #{operatingsystem}" do
-        let(:params) { { puppet_run_reports: false } }
+        let(:params) do
+          {
+            puppet_run_reports: false,
+          }
+        end
         let(:facts) do
           {
             operatingsystem: operatingsystem,

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -1,78 +1,82 @@
 require 'spec_helper'
 
 describe 'datadog_agent' do
-
-  if !RSpec::Support::OS.windows?
+  unless RSpec::Support::OS.windows?
     context 'unsupported operating system' do
       describe 'datadog_agent class without any parameters on Solaris/Nexenta' do
         let(:facts) do
           {
             osfamily:         'Solaris',
-            operatingsystem:  'Nexenta'
+            operatingsystem:  'Nexenta',
           }
         end
 
         it do
           expect {
-            should contain_package('module')
-          }.to raise_error(Puppet::Error, /Unsupported operatingsystem: Nexenta/)
+            is_expected.to contain_package('module')
+          }.to raise_error(Puppet::Error, %r{Unsupported operatingsystem: Nexenta})
         end
       end
     end
 
     context 'autodetect major version agent 5' do
-        let(:params){ {:agent_version => '5.15.1'} }
-        let(:facts){ { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
-        it do
-        should contain_file('/etc/apt/sources.list.d/datadog.list')\
-            .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+main})
-        end
+      let(:params) { { agent_version: '5.15.1' } }
+      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+
+      it do
+        is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
+          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+main})
+      end
     end
 
     context 'autodetect major version agent 6' do
-        let(:params){ {:agent_version => '6.15.1'} }
-        let(:facts){ { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
-        it do
-        should contain_file('/etc/apt/sources.list.d/datadog.list')\
-            .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
-        end
+      let(:params) { { agent_version: '6.15.1' } }
+      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+
+      it do
+        is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
+          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
+      end
     end
 
     context 'autodetect major version agent 7' do
-        let(:params){ {:agent_version => '7.15.1'} }
-        let(:facts){ { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
-        it do
-        should contain_file('/etc/apt/sources.list.d/datadog.list')\
-            .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+7})
-        end
+      let(:params) { { agent_version: '7.15.1' } }
+      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+
+      it do
+        is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
+          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+7})
+      end
     end
 
-
     context 'autodetect major version agent with suffix and release' do
-        let(:params){ {:agent_version => '1:6.15.1~rc.1-1'} }
-        let(:facts){ { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
-        it do
-        should contain_file('/etc/apt/sources.list.d/datadog.list')\
-            .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
-        end
+      let(:params) { { agent_version: '1:6.15.1~rc.1-1' } }
+      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+
+      it do
+        is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
+          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
+      end
     end
 
     context 'autodetect major version agent with windows suffix and release' do
-        let(:params){ {:agent_version => '1:6.15.1-rc.1-1'} }
-        let(:facts){ { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
-        it do
-        should contain_file('/etc/apt/sources.list.d/datadog.list')\
-            .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
-        end
+      let(:params) { { agent_version: '1:6.15.1-rc.1-1' } }
+      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+
+      it do
+        is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
+          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
+      end
     end
 
     context 'autodetect major version agent with release' do
-        let(:params){ {:agent_version => '1:6.15.1-1'} }
-        let(:facts){ { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
-        it do
-        should contain_file('/etc/apt/sources.list.d/datadog.list')\
-            .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
-        end
+      let(:params) { { agent_version: '1:6.15.1-1' } }
+      let(:facts) { { osfamily: 'debian', operatingsystem: 'Ubuntu' } }
+
+      it do
+        is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
+          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
+      end
     end
   end
 
@@ -80,9 +84,10 @@ describe 'datadog_agent' do
   context 'all supported operating systems' do
     ALL_OS.each do |operatingsystem|
       describe "datadog_agent 5 class common actions on #{operatingsystem}" do
-        let(:params) { { puppet_run_reports: true,
-                         agent_major_version: 5,
-        } }
+        let(:params) do
+          { puppet_run_reports: true,
+            agent_major_version: 5 }
+        end
         let(:facts) do
           {
             operatingsystem: operatingsystem,
@@ -91,848 +96,1255 @@ describe 'datadog_agent' do
         end
 
         if WINDOWS_OS.include?(operatingsystem)
-          it "agent 5 should raise on Windows" do
-            should raise_error(Puppet::Error, /Installation of agent 5 with puppet is not supported on Windows/)
+          it 'agent 5 should raise on Windows' do
+            is_expected.to raise_error(Puppet::Error, %r{Installation of agent 5 with puppet is not supported on Windows})
           end
         else
-          it { should compile.with_all_deps }
+          it { is_expected.to compile.with_all_deps }
 
-          it { should contain_class('datadog_agent') }
+          it { is_expected.to contain_class('datadog_agent') }
 
           describe 'datadog_agent imports the default params' do
-            it { should contain_class('datadog_agent::params') }
+            it { is_expected.to contain_class('datadog_agent::params') }
           end
 
-          it { should contain_file('/etc/datadog-agent') }
-          it { should contain_file('/etc/dd-agent') }
-          it { should contain_concat('/etc/dd-agent/datadog.conf') }
-          it { should contain_file('/etc/dd-agent/conf.d').with_ensure('directory') }
+          it { is_expected.to contain_file('/etc/datadog-agent') }
+          it { is_expected.to contain_file('/etc/dd-agent') }
+          it { is_expected.to contain_concat('/etc/dd-agent/datadog.conf') }
+          it { is_expected.to contain_file('/etc/dd-agent/conf.d').with_ensure('directory') }
 
-          it { should contain_class('datadog_agent::reports') }
+          it { is_expected.to contain_class('datadog_agent::reports') }
 
           describe 'parameter check' do
-              context 'with defaults' do
-                  context 'for proxy' do
-                      it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^dd_url: https:\/\/app.datadoghq.com\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^# proxy_host:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^# proxy_port:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^# proxy_user:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^# proxy_password:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^# skip_ssl_validation: no\n/,
-                      )}
-                  end
-
-                  context 'for general' do
-                      it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^api_key: your_API_key\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^# hostname:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^non_local_traffic: false\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^collect_ec2_tags: false\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^collect_instance_metadata: true\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /# recent_point_threshold: 30\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# listen_port: 17123\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# graphite_listen_port: 17124\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# additional_checksd: \/etc\/dd-agent\/checks.d\/\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^use_curl_http_client: false\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# device_blacklist_re: .*\\\/dev\\\/mapper\\\/lxc-box.*\n/,
-                      )}
-                  end
-
-                  context 'for pup' do
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^use_pup: no\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# pup_port: 17125\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# pup_interface: localhost\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# pup_url: http:\/\/localhost:17125\n/,
-                      )}
-                  end
-
-                  context 'for dogstatsd' do
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# bind_host: localhost\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^use_dogstatsd: yes\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstatsd_port: 8125\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# dogstatsd_target: http:\/\/localhost:17123\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# dogstatsd_interval: 10\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstatsd_normalize: yes\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# statsd_forward_host: address_of_own_statsd_server\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# statsd_forward_port: 8125\n/,
-                      )}
-                  end
-
-                  context 'for ganglia' do
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# ganglia_host: localhost\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# ganglia_port: 8651\n/,
-                      )}
-                  end
-
-                  context 'for logging' do
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^log_level: INFO\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^log_to_syslog: yes\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# collector_log_file: \/var\/log\/datadog\/collector.log\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# forwarder_log_file: \/var\/log\/datadog\/forwarder.log\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# dogstatsd_log_file: \/var\/log\/datadog\/dogstatsd.log\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      #'content' => /^# pup_log_file:        \/var\/log\/datadog\/pup.log\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# syslog_host:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^# syslog_port:\n/,
-                      )}
-                  end
-
-                  context 'for service_discovery' do
-                      it { should contain_concat__fragment('datadog footer').without(
-                      'content' => /^service_discovery_backend:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').without(
-                      'content' => /^sd_config_backend:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').without(
-                      'content' => /^sd_backend_host:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').without(
-                      'content' => /^sd_backend_port:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').without(
-                      'content' => /^sd_template_dir:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').without(
-                      'content' => /^consul_token:\n/,
-                      )}
-                      it { should contain_concat__fragment('datadog footer').without(
-                      'content' => /^# sd_jmx_enable:\n/,
-                      )}
-                  end
-
-                  context 'for APM' do
-                      it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^apm_enabled: false\n/,
-                      )}
-                  end
-
+            context 'with defaults' do
+              context 'for proxy' do
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{dd_url: https://app.datadoghq.com\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^# proxy_host:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^# proxy_port:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^# proxy_user:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^# proxy_password:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^# skip_ssl_validation: no\n},
+                  )
+                }
               end
 
-              context 'with user provided paramaters' do
+              context 'for general' do
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^api_key: your_API_key\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^# hostname:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^non_local_traffic: false\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^collect_ec2_tags: false\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^collect_instance_metadata: true\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{# recent_point_threshold: 30\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# listen_port: 17123\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# graphite_listen_port: 17124\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{# additional_checksd: /etc/dd-agent/checks.d/\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^use_curl_http_client: false\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# device_blacklist_re: .*\\/dev\\/mapper\\/lxc-box.*\n},
+                  )
+                }
+              end
+
+              context 'for pup' do
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^use_pup: no\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# pup_port: 17125\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# pup_interface: localhost\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{# pup_url: http://localhost:17125\n},
+                  )
+                }
+              end
+
+              context 'for dogstatsd' do
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# bind_host: localhost\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^use_dogstatsd: yes\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^dogstatsd_port: 8125\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{# dogstatsd_target: http://localhost:17123\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# dogstatsd_interval: 10\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^dogstatsd_normalize: yes\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# statsd_forward_host: address_of_own_statsd_server\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# statsd_forward_port: 8125\n},
+                  )
+                }
+              end
+
+              context 'for ganglia' do
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# ganglia_host: localhost\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# ganglia_port: 8651\n},
+                  )
+                }
+              end
+
+              context 'for logging' do
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^log_level: INFO\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^log_to_syslog: yes\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{# collector_log_file: /var/log/datadog/collector.log\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{# forwarder_log_file: /var/log/datadog/forwarder.log\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{# dogstatsd_log_file: /var/log/datadog/dogstatsd.log\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with
+                  # 'content' => %r{# pup_log_file:        /var/log/datadog/pup.log\n},
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# syslog_host:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^# syslog_port:\n},
+                  )
+                }
+              end
+
+              context 'for service_discovery' do
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').without(
+                    'content' => %r{^service_discovery_backend:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').without(
+                    'content' => %r{^sd_config_backend:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').without(
+                    'content' => %r{^sd_backend_host:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').without(
+                    'content' => %r{^sd_backend_port:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').without(
+                    'content' => %r{^sd_template_dir:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').without(
+                    'content' => %r{^consul_token:\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').without(
+                    'content' => %r{^# sd_jmx_enable:\n},
+                  )
+                }
+              end
+
+              context 'for APM' do
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^apm_enabled: false\n},
+                  )
+                }
+              end
+            end
+
+            context 'with user provided paramaters' do
               context 'with a custom dd_url' do
-                  let(:params) {{ :dd_url => 'https://notaurl.datadoghq.com',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^dd_url: https:\/\/notaurl.datadoghq.com\n/,
-                  )}
+                let(:params) do
+                  { dd_url: 'https://notaurl.datadoghq.com',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{dd_url: https://notaurl.datadoghq.com\n},
+                  )
+                }
               end
               context 'with a custom proxy_host' do
-                  let(:params) {{ :proxy_host => 'localhost',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^proxy_host: localhost\n/,
-                  )}
+                let(:params) do
+                  { proxy_host: 'localhost',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^proxy_host: localhost\n},
+                  )
+                }
               end
               context 'with a custom proxy_port' do
-                  let(:params) {{ :proxy_port => '1234',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^proxy_port: 1234\n/,
-                  )}
+                let(:params) do
+                  { proxy_port: '1234',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^proxy_port: 1234\n},
+                  )
+                }
               end
               context 'with a custom proxy_port, specified as an integer' do
-                  let(:params) {{ :proxy_port => 1234,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^proxy_port: 1234\n/,
-                  )}
+                let(:params) do
+                  { proxy_port: 1234,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^proxy_port: 1234\n},
+                  )
+                }
               end
               context 'with a custom proxy_user' do
-                  let(:params) {{ :proxy_user => 'notauser',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^proxy_user: notauser\n/,
-                  )}
+                let(:params) do
+                  { proxy_user: 'notauser',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^proxy_user: notauser\n},
+                  )
+                }
               end
               context 'with a custom api_key' do
-                  let(:params) {{ :api_key => 'notakey',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^api_key: notakey\n/,
-                  )}
+                let(:params) do
+                  { api_key: 'notakey',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^api_key: notakey\n},
+                  )
+                }
               end
               context 'with a custom hostname' do
-                  let(:params) {{ :host => 'notahost',
-                                  :agent_major_version => 5,
-                  }}
+                let(:params) do
+                  { host: 'notahost',
+                    agent_major_version: 5 }
+                end
 
-                  it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^hostname: notahost\n/,
-                  )}
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^hostname: notahost\n},
+                  )
+                }
               end
               context 'with non_local_traffic set to true' do
-                  let(:params) {{ :non_local_traffic => true,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^non_local_traffic: true\n/,
-                  )}
+                let(:params) do
+                  { non_local_traffic: true,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^non_local_traffic: true\n},
+                  )
+                }
               end
-              #Should expand testing to cover changes to the case upcase
+              # Should expand testing to cover changes to the case upcase
               context 'with log level set to critical' do
-                  let(:params) {{ :log_level => 'critical',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^log_level: CRITICAL\n/,
-                  )}
+                let(:params) do
+                  { log_level: 'critical',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^log_level: CRITICAL\n},
+                  )
+                }
               end
               context 'with a custom hostname' do
-                  let(:params) {{ :host => 'notahost',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^hostname: notahost\n/,
-                  )}
+                let(:params) do
+                  { host: 'notahost',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^hostname: notahost\n},
+                  )
+                }
               end
               context 'with log_to_syslog set to false' do
-                  let(:params) {{ :log_to_syslog => false,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^log_to_syslog: no\n/,
-                  )}
+                let(:params) do
+                  { log_to_syslog: false,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^log_to_syslog: no\n},
+                  )
+                }
               end
               context 'with skip_ssl_validation set to true' do
-                  let(:params) {{ :skip_ssl_validation => true,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog header').with(
-                      'content' => /^skip_ssl_validation: true\n/,
-                  )}
+                let(:params) do
+                  { skip_ssl_validation: true,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog header').with(
+                    'content' => %r{^skip_ssl_validation: true\n},
+                  )
+                }
               end
               context 'with collect_ec2_tags set to yes' do
-                  let(:params) {{ :collect_ec2_tags => true,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^collect_ec2_tags: true\n/,
-                  )}
+                let(:params) do
+                  { collect_ec2_tags: true,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^collect_ec2_tags: true\n},
+                  )
+                }
               end
               context 'with collect_instance_metadata set to no' do
-                  let(:params) {{ :collect_instance_metadata => false,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^collect_instance_metadata: false\n/,
-                  )}
+                let(:params) do
+                  { collect_instance_metadata: false,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^collect_instance_metadata: false\n},
+                  )
+                }
               end
               context 'with recent_point_threshold set to 60' do
-                  let(:params) {{ :recent_point_threshold => '60',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^recent_point_threshold: 60\n/,
-                  )}
+                let(:params) do
+                  { recent_point_threshold: '60',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^recent_point_threshold: 60\n},
+                  )
+                }
               end
               context 'with a custom port set to 17125' do
-                  let(:params) {{ :listen_port => '17125',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^listen_port: 17125\n/,
-                  )}
+                let(:params) do
+                  { listen_port: '17125',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^listen_port: 17125\n},
+                  )
+                }
               end
               context 'with a custom port set to 17125, specified as an integer' do
-                  let(:params) {{ :listen_port => 17125,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^listen_port: 17125\n/,
-                  )}
+                let(:params) do
+                  { listen_port: 17_125,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^listen_port: 17125\n},
+                  )
+                }
               end
               context 'listening for graphite data on port 17124' do
-                  let(:params) {{ :graphite_listen_port => '17124',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^graphite_listen_port: 17124\n/,
-                  )}
+                let(:params) do
+                  { graphite_listen_port: '17124',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^graphite_listen_port: 17124\n},
+                  )
+                }
               end
               context 'listening for graphite data on port 17124, port specified as an integer' do
-                  let(:params) {{ :graphite_listen_port => 17124,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^graphite_listen_port: 17124\n/,
-                  )}
+                let(:params) do
+                  { graphite_listen_port: 17_124,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^graphite_listen_port: 17124\n},
+                  )
+                }
               end
               context 'with configuration for a custom checks.d' do
-                  let(:params) {{ :additional_checksd => '/etc/dd-agent/checks_custom.d',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^additional_checksd: \/etc\/dd-agent\/checks_custom.d\n/,
-                  )}
+                let(:params) do
+                  { additional_checksd: '/etc/dd-agent/checks_custom.d',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{additional_checksd: /etc/dd-agent/checks_custom.d\n},
+                  )
+                }
               end
               context 'with configuration for a custom checks.d' do
-                  let(:params) {{ :additional_checksd => '/etc/dd-agent/checks_custom.d',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^additional_checksd: \/etc\/dd-agent\/checks_custom.d\n/,
-                  )}
+                let(:params) do
+                  { additional_checksd: '/etc/dd-agent/checks_custom.d',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{additional_checksd: /etc/dd-agent/checks_custom.d\n},
+                  )
+                }
               end
               context 'with configuration for a custom checks.d' do
-                  let(:params) {{ :additional_checksd => '/etc/dd-agent/checks_custom.d',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^additional_checksd: \/etc\/dd-agent\/checks_custom.d\n/,
-                  )}
+                let(:params) do
+                  { additional_checksd: '/etc/dd-agent/checks_custom.d',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{additional_checksd: /etc/dd-agent/checks_custom.d\n},
+                  )
+                }
               end
               context 'with using the Tornado HTTP client' do
-                  let(:params) {{ :use_curl_http_client => true,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^use_curl_http_client: true\n/,
-                  )}
+                let(:params) do
+                  { use_curl_http_client: true,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^use_curl_http_client: true\n},
+                  )
+                }
               end
               context 'with a custom bind_host' do
-                  let(:params) {{ :bind_host => 'test',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^bind_host: test\n/,
-                  )}
+                let(:params) do
+                  { bind_host: 'test',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^bind_host: test\n},
+                  )
+                }
               end
               context 'with pup enabled' do
-                  let(:params) {{ :use_pup => true,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^use_pup: yes\n/,
-                  )}
+                let(:params) do
+                  { use_pup: true,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^use_pup: yes\n},
+                  )
+                }
               end
               context 'with a custom pup_port' do
-                  let(:params) {{ :pup_port => '17126',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^pup_port: 17126\n/,
-                  )}
+                let(:params) do
+                  { pup_port: '17126',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^pup_port: 17126\n},
+                  )
+                }
               end
               context 'with a custom pup_port, specified as an integer' do
-                  let(:params) {{ :pup_port => 17126,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^pup_port: 17126\n/,
-                  )}
+                let(:params) do
+                  { pup_port: 17_126,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^pup_port: 17126\n},
+                  )
+                }
               end
               context 'with a custom pup_interface' do
-                  let(:params) {{ :pup_interface => 'notalocalhost',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^pup_interface: notalocalhost\n/,
-                  )}
+                let(:params) do
+                  { pup_interface: 'notalocalhost',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^pup_interface: notalocalhost\n},
+                  )
+                }
               end
               context 'with a custom pup_url' do
-                  let(:params) {{ :pup_url => 'http://localhost:17126',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^pup_url: http:\/\/localhost:17126\n/,
-                  )}
+                let(:params) do
+                  { pup_url: 'http://localhost:17126',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{pup_url: http://localhost:17126\n},
+                  )
+                }
               end
               context 'with use_dogstatsd set to no' do
-                  let(:params) {{ :use_dogstatsd => false,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^use_dogstatsd: no\n/,
-                  )}
+                let(:params) do
+                  { use_dogstatsd: false,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^use_dogstatsd: no\n},
+                  )
+                }
               end
               context 'with use_dogstatsd set to yes' do
-                  let(:params) {{ :use_dogstatsd => true,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^use_dogstatsd: yes\n/,
-                  )}
+                let(:params) do
+                  { use_dogstatsd: true,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^use_dogstatsd: yes\n},
+                  )
+                }
               end
               context 'with dogstatsd_port set to 8126 - must be specified as an integer!' do
-                  let(:params) {{ :dogstatsd_port => 8126,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstatsd_port: 8126\n/,
-                  )}
+                let(:params) do
+                  { dogstatsd_port: 8126,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^dogstatsd_port: 8126\n},
+                  )
+                }
               end
               context 'with dogstatsd_port set to 8126' do
-                  let(:params) {{ :dogstatsd_port  => 8126,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstatsd_port: 8126\n/,
-                  )}
+                let(:params) do
+                  { dogstatsd_port: 8126,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^dogstatsd_port: 8126\n},
+                  )
+                }
               end
               context 'with dogstatsd_target set to localhost:17124' do
-                  let(:params) {{ :dogstatsd_target  => 'http://localhost:17124',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstatsd_target: http:\/\/localhost:17124\n/,
-                  )}
+                let(:params) do
+                  { dogstatsd_target: 'http://localhost:17124',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{dogstatsd_target: http://localhost:17124\n},
+                  )
+                }
               end
               context 'with dogstatsd_interval set to 5' do
-                  let(:params) {{ :dogstatsd_interval  => '5',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstatsd_interval: 5\n/,
-                  )}
+                let(:params) do
+                  { dogstatsd_interval: '5',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^dogstatsd_interval: 5\n},
+                  )
+                }
               end
               context 'with dogstatsd_interval set to 5' do
-                  let(:params) {{ :dogstatsd_interval  => '5',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstatsd_interval: 5\n/,
-                  )}
+                let(:params) do
+                  { dogstatsd_interval: '5',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^dogstatsd_interval: 5\n},
+                  )
+                }
               end
               context 'with dogstatsd_normalize set to false' do
-                  let(:params) {{ :dogstatsd_normalize  => false,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstatsd_normalize: no\n/,
-                  )}
+                let(:params) do
+                  { dogstatsd_normalize: false,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^dogstatsd_normalize: no\n},
+                  )
+                }
               end
               context 'with statsd_forward_host set to localhost:3958' do
-                  let(:params) {{ :statsd_forward_host  => 'localhost:3958',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^statsd_forward_host: localhost:3958\n/,
-                  )}
+                let(:params) do
+                  { statsd_forward_host: 'localhost:3958',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^statsd_forward_host: localhost:3958\n},
+                  )
+                }
               end
               context 'with statsd_forward_port set to 8126' do
-                  let(:params) {{ :statsd_forward_port => '8126',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^statsd_forward_port: 8126\n/,
-                  )}
+                let(:params) do
+                  { statsd_forward_port: '8126',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^statsd_forward_port: 8126\n},
+                  )
+                }
               end
               context 'with statsd_forward_port set to 8126, specified as an integer' do
-                  let(:params) {{ :statsd_forward_port => 8126,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^statsd_forward_port: 8126\n/,
-                  )}
+                let(:params) do
+                  { statsd_forward_port: 8126,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^statsd_forward_port: 8126\n},
+                  )
+                }
               end
               context 'with device_blacklist_re set to test' do
-                  let(:params) {{ :device_blacklist_re  => 'test',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^device_blacklist_re: test\n/,
-                  )}
+                let(:params) do
+                  { device_blacklist_re: 'test',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^device_blacklist_re: test\n},
+                  )
+                }
               end
               context 'with device_blacklist_re set to test' do
-                  let(:params) {{ :device_blacklist_re  => 'test',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^device_blacklist_re: test\n/,
-                  )}
+                let(:params) do
+                  { device_blacklist_re: 'test',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^device_blacklist_re: test\n},
+                  )
+                }
               end
               context 'with ganglia_host set to localhost and ganglia_port set to 12345' do
-                  let(:params) {{ :ganglia_host => 'testhost',
-                                  :ganglia_port => '12345',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^ganglia_port: 12345\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^ganglia_host: testhost\n/,
-                  )}
+                let(:params) do
+                  { ganglia_host: 'testhost',
+                    ganglia_port: '12345',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^ganglia_port: 12345\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^ganglia_host: testhost\n},
+                  )
+                }
               end
               context 'with ganglia_host set to localhost and ganglia_port set to 12345, port specified as an integer' do
-                  let(:params) {{ :ganglia_host => 'testhost',
-                                  :ganglia_port => 12345,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^ganglia_port: 12345\n/,
-                  )}
+                let(:params) do
+                  { ganglia_host: 'testhost',
+                    ganglia_port: 12_345,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^ganglia_port: 12345\n},
+                  )
+                }
               end
               context 'with dogstreams set to /path/to/log1:/path/to/parser' do
-                  let(:params) {{ :dogstreams  => ['/path/to/log1:/path/to/parser'],
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstreams: \/path\/to\/log1:\/path\/to\/parser\n/,
-                  )}
+                let(:params) do
+                  { dogstreams: ['/path/to/log1:/path/to/parser'],
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{dogstreams: /path/to/log1:/path/to/parser\n},
+                  )
+                }
               end
               context 'with custom_emitters set to /test/emitter' do
-                  let(:params) {{ :custom_emitters  => '/test/emitter/',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^custom_emitters: \/test\/emitter\/\n/,
-                  )}
+                let(:params) do
+                  { custom_emitters: '/test/emitter/',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{custom_emitters: /test/emitter/\n},
+                  )
+                }
               end
               context 'with custom_emitters set to /test/emitter' do
-                  let(:params) {{ :custom_emitters  => '/test/emitter/',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^custom_emitters: \/test\/emitter\/\n/,
-                  )}
+                let(:params) do
+                  { custom_emitters: '/test/emitter/',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{custom_emitters: /test/emitter/\n},
+                  )
+                }
               end
               context 'with collector_log_file set to /test/log' do
-                  let(:params) {{ :collector_log_file  => '/test/log',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^collector_log_file: \/test\/log\n/,
-                  )}
+                let(:params) do
+                  { collector_log_file: '/test/log',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{collector_log_file: /test/log\n},
+                  )
+                }
               end
               context 'with forwarder_log_file set to /test/log' do
-                  let(:params) {{ :forwarder_log_file  => '/test/log',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^forwarder_log_file: \/test\/log\n/,
-                  )}
+                let(:params) do
+                  { forwarder_log_file: '/test/log',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{forwarder_log_file: /test/log\n},
+                  )
+                }
               end
               context 'with forwarder_log_file set to /test/log' do
-                  let(:params) {{ :forwarder_log_file  => '/test/log',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^forwarder_log_file: \/test\/log\n/,
-                  )}
+                let(:params) do
+                  { forwarder_log_file: '/test/log',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{forwarder_log_file: /test/log\n},
+                  )
+                }
               end
               context 'with dogstatsd_log_file set to /test/log' do
-                  let(:params) {{ :dogstatsd_log_file  => '/test/log',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^dogstatsd_log_file: \/test\/log\n/,
-                  )}
+                let(:params) do
+                  { dogstatsd_log_file: '/test/log',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{dogstatsd_log_file: /test/log\n},
+                  )
+                }
               end
               context 'with pup_log_file set to /test/log' do
-                  let(:params) {{ :pup_log_file  => '/test/log',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^pup_log_file: \/test\/log\n/,
-                  )}
+                let(:params) do
+                  { pup_log_file: '/test/log',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^pup_log_file: /test/log\n},
+                  )
+                }
               end
               context 'with syslog location set to localhost' do
-                  let(:params) {{ :syslog_host  => 'localhost',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^syslog_host: localhost\n/,
-                  )}
+                let(:params) do
+                  { syslog_host: 'localhost',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^syslog_host: localhost\n},
+                  )
+                }
               end
               context 'with syslog port set to 8080' do
-                  let(:params) {{ :syslog_port => '8080',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^syslog_port: 8080\n/,
-                  )}
+                let(:params) do
+                  { syslog_port: '8080',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^syslog_port: 8080\n},
+                  )
+                }
               end
               context 'with syslog port set to 8080, specified as an integer' do
-                  let(:params) {{ :syslog_port => 8080,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^syslog_port: 8080\n/,
-                  )}
+                let(:params) do
+                  { syslog_port: 8080,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^syslog_port: 8080\n},
+                  )
+                }
               end
               context 'with apm_enabled set to true' do
-                  let(:params) {{ :apm_enabled  => true,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^apm_enabled: true\n/,
-                  )}
+                let(:params) do
+                  { apm_enabled: true,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^apm_enabled: true\n},
+                  )
+                }
               end
               context 'with apm_enabled set to true and env specified' do
-                  let(:params) {{ :apm_enabled  => true,
-                                  :apm_env => 'foo',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^apm_enabled: true\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog apm footer').with(
-                      'content' => /^\[trace.agent\]\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog apm footer').with(
-                      'content' => /^env: foo\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog apm footer').with(
-                      'order' => '07',
-                  )}
+                let(:params) do
+                  { apm_enabled: true,
+                    apm_env: 'foo',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^apm_enabled: true\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog apm footer').with(
+                    'content' => %r{^\[trace.agent\]\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog apm footer').with(
+                    'content' => %r{^env: foo\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog apm footer').with(
+                    'order' => '07',
+                  )
+                }
               end
               context 'with apm_enabled and apm_analyzed_spans set' do
-                  let(:params) {{ :apm_enabled  => true,
-                                  :agent_major_version => 5,
-                                  :apm_analyzed_spans => {
-                                      'foo|bar' => 0.5,
-                                      'haz|qux' => 0.1
-                                  },
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                      'content' => /^apm_enabled: true\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog apm footer').with(
-                      'content' => /^\[trace.analyzed_spans\]\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog apm footer').with(
-                      'content' => /^\[trace.analyzed_spans\]\nfoo|bar: 0.5\nhaz|qux: 0.1/,
-                  )}
-                  it { should contain_concat__fragment('datadog apm footer').with(
-                      'order' => '07',
-                  )}
+                let(:params) do
+                  { apm_enabled: true,
+                    agent_major_version: 5,
+                    apm_analyzed_spans: {
+                      'foo|bar' => 0.5,
+                      'haz|qux' => 0.1,
+                    } }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^apm_enabled: true\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog apm footer').with(
+                    'content' => %r{^\[trace.analyzed_spans\]\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog apm footer').with(
+                    'content' => %r{^\[trace.analyzed_spans\]\nfoo|bar: 0.5\nhaz|qux: 0.1},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog apm footer').with(
+                    'order' => '07',
+                  )
+                }
               end
               context 'with service_discovery enabled' do
-                  let(:params) {{ :service_discovery_backend  => 'docker',
-                                  :sd_config_backend          => 'etcd',
-                                  :sd_backend_host            => 'localhost',
-                                  :sd_backend_port            => 8080,
-                                  :sd_jmx_enable              =>  true,
-                                  :agent_major_version        => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                  'content' => /^service_discovery_backend: docker\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog footer').with(
-                  'content' => /^sd_config_backend: etcd\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog footer').with(
-                  'content' => /^sd_backend_host: localhost\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog footer').with(
-                  'content' => /^sd_backend_port: 8080\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog footer').with(
-                  'content' => /^sd_jmx_enable: true\n/,
-                  )}
+                let(:params) do
+                  { service_discovery_backend: 'docker',
+                    sd_config_backend: 'etcd',
+                    sd_backend_host: 'localhost',
+                    sd_backend_port: 8080,
+                    sd_jmx_enable: true,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^service_discovery_backend: docker\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^sd_config_backend: etcd\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^sd_backend_host: localhost\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^sd_backend_port: 8080\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^sd_jmx_enable: true\n},
+                  )
+                }
               end
               context 'with extra_template enabled' do
-                  let(:params) {{ :extra_template => 'custom_datadog/extra_template_test.erb',
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog extra_template footer').with(
-                  'order' => '06',
-                  )}
-                  it { should contain_concat__fragment('datadog extra_template footer').with(
-                  'content' => /^# extra template is here\n/,
-                  )}
-                  it { should_not contain_concat__fragment('datadog apm footer').with(
-                  'order' => '07',
-                  )}
+                let(:params) do
+                  { extra_template: 'custom_datadog/extra_template_test.erb',
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog extra_template footer').with(
+                    'order' => '06',
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog extra_template footer').with(
+                    'content' => %r{^# extra template is here\n},
+                  )
+                }
+                it {
+                  is_expected.not_to contain_concat__fragment('datadog apm footer').with(
+                    'order' => '07',
+                  )
+                }
               end
               context 'with APM enabled' do
-                  let(:params) {{
-                      :apm_enabled => true,
-                      :apm_env => 'foo',
-                      :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog apm footer').with(
-                  'order' => '07',
-                  )}
+                let(:params) do
+                  {
+                    apm_enabled: true,
+                    apm_env: 'foo',
+                    agent_major_version: 5,
+                  }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog apm footer').with(
+                    'order' => '07',
+                  )
+                }
               end
               context 'with APM enabled but no APM env' do
-                  let(:params) {{
-                      :apm_enabled => true,
-                      :agent_major_version => 5,
-                  }}
-                  it { should_not contain_concat__fragment('datadog apm footer').with(
-                  'order' => '07',
-                  )}
+                let(:params) do
+                  {
+                    apm_enabled: true,
+                    agent_major_version: 5,
+                  }
+                end
+
+                it {
+                  is_expected.not_to contain_concat__fragment('datadog apm footer').with(
+                    'order' => '07',
+                  )
+                }
               end
               context 'with extra_template and APM enabled' do
-                  let(:params) {{
-                      :extra_template => 'custom_datadog/extra_template_test.erb',
-                      :apm_enabled => true,
-                      :apm_env => 'foo',
-                      :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog extra_template footer').with(
-                  'order' => '06',
-                  )}
-                  it { should contain_concat__fragment('datadog extra_template footer').with(
-                  'content' => /^# extra template is here\n/,
-                  )}
-                  it { should contain_concat__fragment('datadog apm footer').with(
-                  'order' => '07',
-                  )}
+                let(:params) do
+                  {
+                    extra_template: 'custom_datadog/extra_template_test.erb',
+                    apm_enabled: true,
+                    apm_env: 'foo',
+                    agent_major_version: 5,
+                  }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog extra_template footer').with(
+                    'order' => '06',
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog extra_template footer').with(
+                    'content' => %r{^# extra template is here\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog apm footer').with(
+                    'order' => '07',
+                  )
+                }
               end
               context 'with process_agent enabled' do
-                  let(:params) {{ :process_enabled => true,
-                                  :agent_major_version => 5,
-                  }}
-                  it { should contain_concat__fragment('datadog footer').with(
-                  'content' => /^process_agent_enabled: true\n/,
-                  )}
+                let(:params) do
+                  { process_enabled: true,
+                    agent_major_version: 5 }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^process_agent_enabled: true\n},
+                  )
+                }
               end
 
               context 'with data scrubbing disabled' do
-                let(:params) {{
-                    :process_enabled => true,
-                    :agent_major_version => 5,
-                    :scrub_args => false
-                }}
-                it { should contain_concat__fragment('datadog footer').with(
-                  'content' => /^process_agent_enabled: true\n/,
-                )}
-                it { should contain_concat__fragment('datadog process agent footer').with(
-                  'content' => /^\[process.config\]\n/,
-                )}
-                it { should contain_concat__fragment('datadog process agent footer').with(
-                  'content' => /^scrub_args: false\n/,
-                )}
-                it { should contain_concat__fragment('datadog process agent footer').with(
-                  'content' => /^custom_sensitive_words: \n/,
-                )}
+                let(:params) do
+                  {
+                    process_enabled: true,
+                    agent_major_version: 5,
+                    scrub_args: false,
+                  }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^process_agent_enabled: true\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog process agent footer').with(
+                    'content' => %r{^\[process.config\]\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog process agent footer').with(
+                    'content' => %r{^scrub_args: false\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog process agent footer').with(
+                    'content' => %r{^custom_sensitive_words: \n},
+                  )
+                }
               end
 
               context 'with data scrubbing enabled with custom sensitive_words' do
-                let(:params) {{
-                    :process_enabled => true,
-                    :agent_major_version => 5,
-                    :custom_sensitive_words => ['consul_token','dd_key']
-                }}
-                it { should contain_concat__fragment('datadog footer').with(
-                  'content' => /^process_agent_enabled: true\n/,
-                )}
-                it { should contain_concat__fragment('datadog process agent footer').with(
-                  'content' => /^\[process.config\]\n/,
-                )}
-                it { should contain_concat__fragment('datadog process agent footer').with(
-                  'content' => /^scrub_args: true\n/,
-                )}
-                it { should contain_concat__fragment('datadog process agent footer').with(
-                  'content' => /^custom_sensitive_words: consul_token,dd_key\n/,
-                )}
+                let(:params) do
+                  {
+                    process_enabled: true,
+                    agent_major_version: 5,
+                    custom_sensitive_words: ['consul_token', 'dd_key'],
+                  }
+                end
+
+                it {
+                  is_expected.to contain_concat__fragment('datadog footer').with(
+                    'content' => %r{^process_agent_enabled: true\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog process agent footer').with(
+                    'content' => %r{^\[process.config\]\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog process agent footer').with(
+                    'content' => %r{^scrub_args: true\n},
+                  )
+                }
+                it {
+                  is_expected.to contain_concat__fragment('datadog process agent footer').with(
+                    'content' => %r{^custom_sensitive_words: consul_token,dd_key\n},
+                  )
+                }
               end
 
               context 'with service provider override' do
-                let(:params) {{
-                    :service_provider => 'upstart',
-                }}
+                let(:params) do
+                  {
+                    service_provider: 'upstart',
+                  }
+                end
+
                 it do
-                  should contain_service('datadog-agent')\
+                  is_expected.to contain_service('datadog-agent')\
                     .that_requires('package[datadog-agent]')
                 end
                 it do
-                  should contain_service('datadog-agent').with(
+                  is_expected.to contain_service('datadog-agent').with(
                     'provider' => 'upstart',
                     'ensure' => 'running',
                   )
                 end
               end
-
             end
           end
 
           if DEBIAN_OS.include?(operatingsystem)
             it do
-              should contain_class('datadog_agent::ubuntu')\
-                  .with_apt_keyserver('hkp://keyserver.ubuntu.com:80')
+              is_expected.to contain_class('datadog_agent::ubuntu')\
+                .with_apt_keyserver('hkp://keyserver.ubuntu.com:80')
             end
             context 'use backup keyserver' do
-              let(:params) {{
-                  :use_apt_backup_keyserver => true,
-                  :agent_major_version => 5,
-              }}
+              let(:params) do
+                {
+                  use_apt_backup_keyserver: true,
+                  agent_major_version: 5,
+                }
+              end
+
               it do
-                  should contain_class('datadog_agent::ubuntu')\
-                      .with_apt_keyserver('hkp://pool.sks-keyservers.net:80')
+                is_expected.to contain_class('datadog_agent::ubuntu')\
+                  .with_apt_keyserver('hkp://pool.sks-keyservers.net:80')
               end
             end
           elsif REDHAT_OS.include?(operatingsystem)
-            it { should contain_class('datadog_agent::redhat') }
+            it { is_expected.to contain_class('datadog_agent::redhat') }
           end
         end
       end
@@ -942,22 +1354,21 @@ describe 'datadog_agent' do
         let(:facts) do
           {
             operatingsystem: operatingsystem,
-            osfamily: getosfamily(operatingsystem)
+            osfamily: getosfamily(operatingsystem),
           }
         end
 
         if WINDOWS_OS.include?(operatingsystem)
-          it "reports should raise on Windows" do
-            should raise_error(Puppet::Error, /Reporting is not yet supported from a Windows host/)
+          it 'reports should raise on Windows' do
+            is_expected.to raise_error(Puppet::Error, %r{Reporting is not yet supported from a Windows host})
           end
         else
-          it { should compile.with_all_deps }
+          it { is_expected.to compile.with_all_deps }
 
-          it { should contain_class('datadog_agent') }
+          it { is_expected.to contain_class('datadog_agent') }
 
-          it { should contain_class('datadog_agent::reports') }
+          it { is_expected.to contain_class('datadog_agent::reports') }
         end
-
       end
 
       describe "datadog_agent 6 class common actions on #{operatingsystem}" do
@@ -965,387 +1376,588 @@ describe 'datadog_agent' do
         let(:facts) do
           {
             operatingsystem: operatingsystem,
-            osfamily: getosfamily(operatingsystem)
+            osfamily: getosfamily(operatingsystem),
           }
         end
 
-        it { should compile.with_all_deps }
+        it { is_expected.to compile.with_all_deps }
 
-        it { should contain_class('datadog_agent') }
+        it { is_expected.to contain_class('datadog_agent') }
 
         describe 'datadog_agent imports the default params' do
-          it { should contain_class('datadog_agent::params') }
+          it { is_expected.to contain_class('datadog_agent::params') }
         end
 
-        config_dir = WINDOWS_OS.include?(operatingsystem) ? 'C:/ProgramData/Datadog' : "/etc/datadog-agent"
-        config_yaml_file = config_dir + "/datadog.yaml"
+        config_dir = WINDOWS_OS.include?(operatingsystem) ? 'C:/ProgramData/Datadog' : '/etc/datadog-agent'
+        config_yaml_file = config_dir + '/datadog.yaml'
         log_file = WINDOWS_OS.include?(operatingsystem) ? 'C:/ProgramData/Datadog/logs/agent.log' : '\/var\/log\/datadog\/agent.log'
 
-        it { should contain_file(config_dir) }
-        it { should contain_file(config_yaml_file) }
-        it { should contain_file(config_dir + '/conf.d').with_ensure('directory') }
+        it { is_expected.to contain_file(config_dir) }
+        it { is_expected.to contain_file(config_yaml_file) }
+        it { is_expected.to contain_file(config_dir + '/conf.d').with_ensure('directory') }
 
         # Agent 5 files
-        it { should_not contain_file('/etc/dd-agent') }
-        it { should_not contain_concat('/etc/dd-agent/datadog.conf') }
-        it { should_not contain_file('/etc/dd-agent/conf.d').with_ensure('directory') }
+        it { is_expected.not_to contain_file('/etc/dd-agent') }
+        it { is_expected.not_to contain_concat('/etc/dd-agent/datadog.conf') }
+        it { is_expected.not_to contain_file('/etc/dd-agent/conf.d').with_ensure('directory') }
 
         describe 'agent6 parameter check' do
           context 'with defaults' do
             context 'for basic beta settings' do
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^api_key: your_API_key\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => Regexp.new('^confd_path: \"{0,1}' + config_dir + '/conf.d' + '"{0,1}\n'),
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^cmd_port: \"{0,1}5001\"{0,1}\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^collect_ec2_tags: false\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^dd_url: ''\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^site: datadoghq.com\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^enable_metadata_collection: true\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^dogstatsd_port: \"{0,1}8125\"{0,1}\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => Regexp.new('^log_file: \"{0,1}' + log_file + '"{0,1}\n'),
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^log_level: info\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n\ \ enabled: false\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ apm_non_local_traffic: false\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n\ \ enabled: disabled\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ scrub_args: true\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ custom_sensitive_words: \[\]\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^logs_enabled: false\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^logs_config:\n\ \ container_collect_all: false\n/,
-              )}
-              it { should contain_file(config_yaml_file).without(
-              'content' => /^hostname: .*\n/,
-              )}
-              it { should contain_file(config_yaml_file).without(
-              'content' => /^statsd_forward_host: .*\n/,
-              )}
-              it { should contain_file(config_yaml_file).without(
-              'content' => /^statsd_forward_port: ,*\n/,
-              )}
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^api_key: your_API_key\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => Regexp.new('^confd_path: \"{0,1}' + config_dir + '/conf.d' + '"{0,1}\n'),
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^cmd_port: \"{0,1}5001\"{0,1}\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^collect_ec2_tags: false\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^dd_url: ''\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^site: datadoghq.com\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^enable_metadata_collection: true\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^dogstatsd_port: \"{0,1}8125\"{0,1}\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => Regexp.new('^log_file: \"{0,1}' + log_file + '"{0,1}\n'),
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^log_level: info\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n\ \ enabled: false\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ apm_non_local_traffic: false\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n\ \ enabled: disabled\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ scrub_args: true\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ custom_sensitive_words: \[\]\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^logs_enabled: false\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^logs_config:\n\ \ container_collect_all: false\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).without(
+                  'content' => %r{^hostname: .*\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).without(
+                  'content' => %r{^statsd_forward_host: .*\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).without(
+                  'content' => %r{^statsd_forward_port: ,*\n},
+                )
+              }
             end
           end
 
           context 'with modified defaults' do
             context 'hostname override' do
-              let(:params) {{
-                  :host => 'my_custom_hostname',
-                  :collect_ec2_tags => true,
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^hostname: my_custom_hostname\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^collect_ec2_tags: true\n/,
-              )}
+              let(:params) do
+                {
+                  host: 'my_custom_hostname',
+                  collect_ec2_tags: true,
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^hostname: my_custom_hostname\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^collect_ec2_tags: true\n},
+                )
+              }
             end
             context 'datadog EU' do
-              let(:params) {{
-                  :datadog_site => 'datadoghq.eu',
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^site: datadoghq.eu\n/,
-              )}
+              let(:params) do
+                {
+                  datadog_site: 'datadoghq.eu',
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^site: datadoghq.eu\n},
+                )
+              }
             end
             context 'forward statsd settings set' do
-              let(:params) {{
-                  :statsd_forward_host => 'foo',
-                  :statsd_forward_port => 1234,
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^statsd_forward_host: foo\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^statsd_forward_port: 1234\n/,
-              )}
+              let(:params) do
+                {
+                  statsd_forward_host: 'foo',
+                  statsd_forward_port: 1234,
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^statsd_forward_host: foo\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^statsd_forward_port: 1234\n},
+                )
+              }
             end
             context 'deprecated proxy settings' do
-              let(:params) {{
-                  :proxy_host => 'foo',
-                  :proxy_port => 1234,
-                  :proxy_user => 'bar',
-                  :proxy_password => 'abcd1234',
-              }}
-              it { is_expected.to contain_notify(
-                  'Setting proxy_host is only used with Agent 5. Please use agent_extra_options to set your proxy')
+              let(:params) do
+                {
+                  proxy_host: 'foo',
+                  proxy_port: 1234,
+                  proxy_user: 'bar',
+                  proxy_password: 'abcd1234',
+                }
+              end
+
+              it {
+                is_expected.to contain_notify(
+                  'Setting proxy_host is only used with Agent 5. Please use agent_extra_options to set your proxy',
+                )
               }
-              it { is_expected.to contain_notify(
-                  'Setting proxy_port is only used with Agent 5. Please use agent_extra_options to set your proxy')
+              it {
+                is_expected.to contain_notify(
+                  'Setting proxy_port is only used with Agent 5. Please use agent_extra_options to set your proxy',
+                )
               }
-              it { is_expected.to contain_notify(
-                  'Setting proxy_user is only used with Agent 5. Please use agent_extra_options to set your proxy')
+              it {
+                is_expected.to contain_notify(
+                  'Setting proxy_user is only used with Agent 5. Please use agent_extra_options to set your proxy',
+                )
               }
-              it { is_expected.to contain_notify(
-                  'Setting proxy_password is only used with Agent 5. Please use agent_extra_options to set your proxy')
+              it {
+                is_expected.to contain_notify(
+                  'Setting proxy_password is only used with Agent 5. Please use agent_extra_options to set your proxy',
+                )
               }
             end
             context 'deprecated proxy settings with default values' do
-              let(:params) {{
-                  :proxy_host => '',
-                  :proxy_port => '',
-                  :proxy_user => '',
-                  :proxy_password => '',
-              }}
-              it { is_expected.not_to contain_notify(
-                  'Setting proxy_host is only used with Agent 5. Please use agent_extra_options to set your proxy')
+              let(:params) do
+                {
+                  proxy_host: '',
+                  proxy_port: '',
+                  proxy_user: '',
+                  proxy_password: '',
+                }
+              end
+
+              it {
+                is_expected.not_to contain_notify(
+                  'Setting proxy_host is only used with Agent 5. Please use agent_extra_options to set your proxy',
+                )
               }
-              it { is_expected.not_to contain_notify(
-                  'Setting proxy_port is only used with Agent 5. Please use agent_extra_options to set your proxy')
+              it {
+                is_expected.not_to contain_notify(
+                  'Setting proxy_port is only used with Agent 5. Please use agent_extra_options to set your proxy',
+                )
               }
-              it { is_expected.not_to contain_notify(
-                  'Setting proxy_user is only used with Agent 5. Please use agent_extra_options to set your proxy')
+              it {
+                is_expected.not_to contain_notify(
+                  'Setting proxy_user is only used with Agent 5. Please use agent_extra_options to set your proxy',
+                )
               }
-              it { is_expected.not_to contain_notify(
-                  'Setting proxy_password is only used with Agent 5. Please use agent_extra_options to set your proxy')
+              it {
+                is_expected.not_to contain_notify(
+                  'Setting proxy_password is only used with Agent 5. Please use agent_extra_options to set your proxy',
+                )
               }
             end
           end
 
           context 'with additional agents config' do
             context 'with extra_options and APM enabled' do
-              let(:params) {{
-                  :apm_enabled => true,
-                  :apm_env => 'foo',
-                  :agent_extra_options => {
-                      'apm_config' => {
-                          'foo' => 'bar',
-                          'bar' => 'haz',
-                      }
-                  }
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n\ \ enabled: true\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ foo: bar\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ bar: haz\n/,
-              )}
+              let(:params) do
+                {
+                  apm_enabled: true,
+                  apm_env: 'foo',
+                  agent_extra_options: {
+                    'apm_config' => {
+                      'foo' => 'bar',
+                      'bar' => 'haz',
+                    },
+                  },
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n\ \ enabled: true\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ foo: bar\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ bar: haz\n},
+                )
+              }
             end
 
             context 'with APM non local traffic enabled' do
-              let(:params) {{
-                  :apm_enabled => true,
-                  :apm_env => 'foo',
-                  :apm_non_local_traffic => true,
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n\ \ enabled: true\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ apm_non_local_traffic: true\n/,
-              )}
+              let(:params) do
+                {
+                  apm_enabled: true,
+                  apm_env: 'foo',
+                  apm_non_local_traffic: true,
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n\ \ enabled: true\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ apm_non_local_traffic: true\n},
+                )
+              }
             end
 
             context 'with apm_enabled set to true and apm_analyzed_spans specified' do
-              let(:params) {{
-                  :apm_enabled  => true,
-                  :apm_analyzed_spans => {
-                      'foo|bar' => 0.5,
-                      'haz|qux' => 0.1
+              let(:params) do
+                {
+                  apm_enabled: true,
+                  apm_analyzed_spans: {
+                    'foo|bar' => 0.5,
+                    'haz|qux' => 0.1,
                   },
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n\ \ enabled: true\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ analyzed_spans:\n\ \ \ \ foo|bar: 0.5\n\ \ \ \ haz|qux: 0.1\n/,
-              )}
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n\ \ enabled: true\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ analyzed_spans:\n\ \ \ \ foo|bar: 0.5\n\ \ \ \ haz|qux: 0.1\n},
+                )
+              }
             end
             context 'with extra_options and Process enabled' do
-              let(:params) {{
-                  :apm_enabled => false,
-                  :process_enabled => true,
-                  :agent_extra_options => {
-                      'process_config' => {
-                          'foo' => 'bar',
-                          'bar' => 'haz',
-                      }
-                  }
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^apm_config:\n\ \ enabled: false\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n\ \ enabled: 'true'\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ foo: bar\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ bar: haz\n/,
-              )}
+              let(:params) do
+                {
+                  apm_enabled: false,
+                  process_enabled: true,
+                  agent_extra_options: {
+                    'process_config' => {
+                      'foo' => 'bar',
+                      'bar' => 'haz',
+                    },
+                  },
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^apm_config:\n\ \ enabled: false\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n\ \ enabled: 'true'\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ foo: bar\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ bar: haz\n},
+                )
+              }
             end
             context 'with extra_options and process options overriden' do
-              let(:params) {{
-                  :process_enabled => true,
-                  :agent_extra_options => {
-                      'process_config' => {
-                          'enabled' => 'disabled',
-                          'foo' => 'bar',
-                          'bar' => 'haz',
-                      }
-                  }
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n\ \ enabled: disabled\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ foo: bar\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ bar: haz\n/,
-              )}
+              let(:params) do
+                {
+                  process_enabled: true,
+                  agent_extra_options: {
+                    'process_config' => {
+                      'enabled' => 'disabled',
+                      'foo' => 'bar',
+                      'bar' => 'haz',
+                    },
+                  },
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n\ \ enabled: disabled\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ foo: bar\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ bar: haz\n},
+                )
+              }
             end
           end
 
           context 'with data scrubbing custom options' do
             context 'with data scrubbing disabled' do
-              let(:params) {{
-                  :process_enabled => true,
-                  :scrub_args => false
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n\ \ enabled: 'true'\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ scrub_args: false\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ custom_sensitive_words: \[\]\n/,
-              )}
+              let(:params) do
+                {
+                  process_enabled: true,
+                  scrub_args: false,
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n\ \ enabled: 'true'\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ scrub_args: false\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ custom_sensitive_words: \[\]\n},
+                )
+              }
             end
 
             context 'with data scrubbing enabled with custom sensitive_words' do
-              let(:params) {{
-                  :process_enabled => true,
-                  :custom_sensitive_words => ['consul_token','dd_key']
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^process_config:\n\ \ enabled: 'true'\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ scrub_args: true\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ -\ consul_token\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^\ \ -\ dd_key\n/,
-              )}
+              let(:params) do
+                {
+                  process_enabled: true,
+                  custom_sensitive_words: ['consul_token', 'dd_key'],
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^process_config:\n\ \ enabled: 'true'\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ scrub_args: true\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ -\ consul_token\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^\ \ -\ dd_key\n},
+                )
+              }
             end
 
             context 'with logs enabled' do
-              let(:params) {{
-                  :logs_enabled => true,
-                  :container_collect_all => true
-              }}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^logs_enabled: true\n/,
-              )}
-              it { should contain_file(config_yaml_file).with(
-              'content' => /^logs_config:\n\ \ container_collect_all: true\n/,
-              )}
+              let(:params) do
+                {
+                  logs_enabled: true,
+                  container_collect_all: true,
+                }
+              end
+
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^logs_enabled: true\n},
+                )
+              }
+              it {
+                is_expected.to contain_file(config_yaml_file).with(
+                  'content' => %r{^logs_config:\n\ \ container_collect_all: true\n},
+                )
+              }
             end
 
-            if !WINDOWS_OS.include?(operatingsystem)
+            unless WINDOWS_OS.include?(operatingsystem)
               context 'with service provider override' do
-                let(:params) {{
-                    :service_provider => 'upstart',
-                }}
+                let(:params) do
+                  {
+                    service_provider: 'upstart',
+                  }
+                end
+
                 it do
-                  should contain_service('datadog-agent')\
+                  is_expected.to contain_service('datadog-agent')\
                     .that_requires('package[datadog-agent]')
                 end
                 it do
-                  should contain_service('datadog-agent').with(
+                  is_expected.to contain_service('datadog-agent').with(
                     'provider' => 'upstart',
                     'ensure' => 'running',
                   )
                 end
               end
             end
-
           end
         end
       end
     end
   end
 
-  context "with facts to tags set" do
-    describe "ensure facts_array outputs a list of tags" do
-      let(:params) { { puppet_run_reports: true, facts_to_tags: ['osfamily', 'facts_array']} }
+  context 'with facts to tags set' do
+    describe 'a6 ensure facts_array outputs a list of tags' do
+      let(:params) do
+        {
+          agent_major_version: 6,
+          puppet_run_reports: true,
+          facts_to_tags: ['osfamily', 'facts_array'],
+        }
+      end
       let(:facts) do
         {
-            operatingsystem: 'CentOS',
-            osfamily: 'redhat',
-            facts_array: ['one', 'two', 'three']
+          operatingsystem: 'CentOS',
+          osfamily: 'redhat',
+          facts_array: ['one', 'two'],
         }
-
-        it { should contain_concat('/etc/dd-agent/datadog.conf') }
-        it { should contain_concat__fragment('datadog tags').with(/tags: osfamily:redhat, facts_array:one, facts_array:two, facts_array:three/) }
       end
+
+      it { is_expected.to contain_file('/etc/datadog-agent/datadog.yaml').with_content(%r{tags:\n- osfamily:redhat\n- facts_array:one\n- facts_array:two}) }
+    end
+
+    describe 'a5 ensure facts_array outputs a list of tags' do
+      let(:params) do
+        {
+          agent_major_version: 5,
+          puppet_run_reports: true,
+          facts_to_tags: ['osfamily', 'facts_array'],
+        }
+      end
+      let(:facts) do
+        {
+          operatingsystem: 'CentOS',
+          osfamily: 'redhat',
+          facts_array: ['one', 'two'],
+        }
+      end
+
+      it { is_expected.to contain_concat('/etc/dd-agent/datadog.conf') }
+      it { is_expected.to contain_concat__fragment('datadog tags').with_content('tags: ') }
+      it { is_expected.to contain_concat__fragment('datadog tag osfamily:redhat').with_content('osfamily:redhat, ') }
+      it { is_expected.to contain_concat__fragment('datadog tag facts_array:one').with_content('facts_array:one, ') }
+      it { is_expected.to contain_concat__fragment('datadog tag facts_array:two').with_content('facts_array:two, ') }
     end
   end
 end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -85,8 +85,10 @@ describe 'datadog_agent' do
     ALL_OS.each do |operatingsystem|
       describe "datadog_agent 5 class common actions on #{operatingsystem}" do
         let(:params) do
-          { puppet_run_reports: true,
-            agent_major_version: 5 }
+          {
+            puppet_run_reports: true,
+            agent_major_version: 5,
+          }
         end
         let(:facts) do
           {
@@ -379,8 +381,10 @@ describe 'datadog_agent' do
             context 'with user provided paramaters' do
               context 'with a custom dd_url' do
                 let(:params) do
-                  { dd_url: 'https://notaurl.datadoghq.com',
-                    agent_major_version: 5 }
+                  {
+                    dd_url: 'https://notaurl.datadoghq.com',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -391,8 +395,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom proxy_host' do
                 let(:params) do
-                  { proxy_host: 'localhost',
-                    agent_major_version: 5 }
+                  {
+                    proxy_host: 'localhost',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -403,8 +409,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom proxy_port' do
                 let(:params) do
-                  { proxy_port: '1234',
-                    agent_major_version: 5 }
+                  {
+                    proxy_port: '1234',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -415,8 +423,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom proxy_port, specified as an integer' do
                 let(:params) do
-                  { proxy_port: 1234,
-                    agent_major_version: 5 }
+                  {
+                    proxy_port: 1234,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -427,8 +437,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom proxy_user' do
                 let(:params) do
-                  { proxy_user: 'notauser',
-                    agent_major_version: 5 }
+                  {
+                    proxy_user: 'notauser',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -439,8 +451,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom api_key' do
                 let(:params) do
-                  { api_key: 'notakey',
-                    agent_major_version: 5 }
+                  {
+                    api_key: 'notakey',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -451,8 +465,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom hostname' do
                 let(:params) do
-                  { host: 'notahost',
-                    agent_major_version: 5 }
+                  {
+                    host: 'notahost',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -463,8 +479,10 @@ describe 'datadog_agent' do
               end
               context 'with non_local_traffic set to true' do
                 let(:params) do
-                  { non_local_traffic: true,
-                    agent_major_version: 5 }
+                  {
+                    non_local_traffic: true,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -476,8 +494,10 @@ describe 'datadog_agent' do
               # Should expand testing to cover changes to the case upcase
               context 'with log level set to critical' do
                 let(:params) do
-                  { log_level: 'critical',
-                    agent_major_version: 5 }
+                  {
+                    log_level: 'critical',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -488,8 +508,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom hostname' do
                 let(:params) do
-                  { host: 'notahost',
-                    agent_major_version: 5 }
+                  {
+                    host: 'notahost',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -500,8 +522,10 @@ describe 'datadog_agent' do
               end
               context 'with log_to_syslog set to false' do
                 let(:params) do
-                  { log_to_syslog: false,
-                    agent_major_version: 5 }
+                  {
+                    log_to_syslog: false,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -512,8 +536,10 @@ describe 'datadog_agent' do
               end
               context 'with skip_ssl_validation set to true' do
                 let(:params) do
-                  { skip_ssl_validation: true,
-                    agent_major_version: 5 }
+                  {
+                    skip_ssl_validation: true,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -524,8 +550,10 @@ describe 'datadog_agent' do
               end
               context 'with collect_ec2_tags set to yes' do
                 let(:params) do
-                  { collect_ec2_tags: true,
-                    agent_major_version: 5 }
+                  {
+                    collect_ec2_tags: true,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -536,8 +564,10 @@ describe 'datadog_agent' do
               end
               context 'with collect_instance_metadata set to no' do
                 let(:params) do
-                  { collect_instance_metadata: false,
-                    agent_major_version: 5 }
+                  {
+                    collect_instance_metadata: false,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -548,8 +578,10 @@ describe 'datadog_agent' do
               end
               context 'with recent_point_threshold set to 60' do
                 let(:params) do
-                  { recent_point_threshold: '60',
-                    agent_major_version: 5 }
+                  {
+                    recent_point_threshold: '60',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -560,8 +592,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom port set to 17125' do
                 let(:params) do
-                  { listen_port: '17125',
-                    agent_major_version: 5 }
+                  {
+                    listen_port: '17125',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -572,8 +606,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom port set to 17125, specified as an integer' do
                 let(:params) do
-                  { listen_port: 17_125,
-                    agent_major_version: 5 }
+                  {
+                    listen_port: 17_125,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -584,8 +620,10 @@ describe 'datadog_agent' do
               end
               context 'listening for graphite data on port 17124' do
                 let(:params) do
-                  { graphite_listen_port: '17124',
-                    agent_major_version: 5 }
+                  {
+                    graphite_listen_port: '17124',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -596,8 +634,10 @@ describe 'datadog_agent' do
               end
               context 'listening for graphite data on port 17124, port specified as an integer' do
                 let(:params) do
-                  { graphite_listen_port: 17_124,
-                    agent_major_version: 5 }
+                  {
+                    graphite_listen_port: 17_124,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -608,8 +648,10 @@ describe 'datadog_agent' do
               end
               context 'with configuration for a custom checks.d' do
                 let(:params) do
-                  { additional_checksd: '/etc/dd-agent/checks_custom.d',
-                    agent_major_version: 5 }
+                  {
+                    additional_checksd: '/etc/dd-agent/checks_custom.d',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -620,8 +662,10 @@ describe 'datadog_agent' do
               end
               context 'with configuration for a custom checks.d' do
                 let(:params) do
-                  { additional_checksd: '/etc/dd-agent/checks_custom.d',
-                    agent_major_version: 5 }
+                  {
+                    additional_checksd: '/etc/dd-agent/checks_custom.d',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -632,8 +676,10 @@ describe 'datadog_agent' do
               end
               context 'with configuration for a custom checks.d' do
                 let(:params) do
-                  { additional_checksd: '/etc/dd-agent/checks_custom.d',
-                    agent_major_version: 5 }
+                  {
+                    additional_checksd: '/etc/dd-agent/checks_custom.d',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -644,8 +690,10 @@ describe 'datadog_agent' do
               end
               context 'with using the Tornado HTTP client' do
                 let(:params) do
-                  { use_curl_http_client: true,
-                    agent_major_version: 5 }
+                  {
+                    use_curl_http_client: true,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -656,8 +704,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom bind_host' do
                 let(:params) do
-                  { bind_host: 'test',
-                    agent_major_version: 5 }
+                  {
+                    bind_host: 'test',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -668,8 +718,10 @@ describe 'datadog_agent' do
               end
               context 'with pup enabled' do
                 let(:params) do
-                  { use_pup: true,
-                    agent_major_version: 5 }
+                  {
+                    use_pup: true,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -680,8 +732,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom pup_port' do
                 let(:params) do
-                  { pup_port: '17126',
-                    agent_major_version: 5 }
+                  {
+                    pup_port: '17126',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -692,8 +746,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom pup_port, specified as an integer' do
                 let(:params) do
-                  { pup_port: 17_126,
-                    agent_major_version: 5 }
+                  {
+                    pup_port: 17_126,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -704,8 +760,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom pup_interface' do
                 let(:params) do
-                  { pup_interface: 'notalocalhost',
-                    agent_major_version: 5 }
+                  {
+                    pup_interface: 'notalocalhost',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -716,8 +774,10 @@ describe 'datadog_agent' do
               end
               context 'with a custom pup_url' do
                 let(:params) do
-                  { pup_url: 'http://localhost:17126',
-                    agent_major_version: 5 }
+                  {
+                    pup_url: 'http://localhost:17126',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -728,8 +788,10 @@ describe 'datadog_agent' do
               end
               context 'with use_dogstatsd set to no' do
                 let(:params) do
-                  { use_dogstatsd: false,
-                    agent_major_version: 5 }
+                  {
+                    use_dogstatsd: false,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -740,8 +802,10 @@ describe 'datadog_agent' do
               end
               context 'with use_dogstatsd set to yes' do
                 let(:params) do
-                  { use_dogstatsd: true,
-                    agent_major_version: 5 }
+                  {
+                    use_dogstatsd: true,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -752,8 +816,10 @@ describe 'datadog_agent' do
               end
               context 'with dogstatsd_port set to 8126 - must be specified as an integer!' do
                 let(:params) do
-                  { dogstatsd_port: 8126,
-                    agent_major_version: 5 }
+                  {
+                    dogstatsd_port: 8126,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -764,8 +830,10 @@ describe 'datadog_agent' do
               end
               context 'with dogstatsd_port set to 8126' do
                 let(:params) do
-                  { dogstatsd_port: 8126,
-                    agent_major_version: 5 }
+                  {
+                    dogstatsd_port: 8126,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -776,8 +844,10 @@ describe 'datadog_agent' do
               end
               context 'with dogstatsd_target set to localhost:17124' do
                 let(:params) do
-                  { dogstatsd_target: 'http://localhost:17124',
-                    agent_major_version: 5 }
+                  {
+                    dogstatsd_target: 'http://localhost:17124',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -788,8 +858,10 @@ describe 'datadog_agent' do
               end
               context 'with dogstatsd_interval set to 5' do
                 let(:params) do
-                  { dogstatsd_interval: '5',
-                    agent_major_version: 5 }
+                  {
+                    dogstatsd_interval: '5',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -800,8 +872,10 @@ describe 'datadog_agent' do
               end
               context 'with dogstatsd_interval set to 5' do
                 let(:params) do
-                  { dogstatsd_interval: '5',
-                    agent_major_version: 5 }
+                  {
+                    dogstatsd_interval: '5',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -812,8 +886,10 @@ describe 'datadog_agent' do
               end
               context 'with dogstatsd_normalize set to false' do
                 let(:params) do
-                  { dogstatsd_normalize: false,
-                    agent_major_version: 5 }
+                  {
+                    dogstatsd_normalize: false,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -824,8 +900,10 @@ describe 'datadog_agent' do
               end
               context 'with statsd_forward_host set to localhost:3958' do
                 let(:params) do
-                  { statsd_forward_host: 'localhost:3958',
-                    agent_major_version: 5 }
+                  {
+                    statsd_forward_host: 'localhost:3958',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -836,8 +914,10 @@ describe 'datadog_agent' do
               end
               context 'with statsd_forward_port set to 8126' do
                 let(:params) do
-                  { statsd_forward_port: '8126',
-                    agent_major_version: 5 }
+                  {
+                    statsd_forward_port: '8126',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -848,8 +928,10 @@ describe 'datadog_agent' do
               end
               context 'with statsd_forward_port set to 8126, specified as an integer' do
                 let(:params) do
-                  { statsd_forward_port: 8126,
-                    agent_major_version: 5 }
+                  {
+                    statsd_forward_port: 8126,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -860,8 +942,10 @@ describe 'datadog_agent' do
               end
               context 'with device_blacklist_re set to test' do
                 let(:params) do
-                  { device_blacklist_re: 'test',
-                    agent_major_version: 5 }
+                  {
+                    device_blacklist_re: 'test',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -872,8 +956,10 @@ describe 'datadog_agent' do
               end
               context 'with device_blacklist_re set to test' do
                 let(:params) do
-                  { device_blacklist_re: 'test',
-                    agent_major_version: 5 }
+                  {
+                    device_blacklist_re: 'test',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -884,9 +970,11 @@ describe 'datadog_agent' do
               end
               context 'with ganglia_host set to localhost and ganglia_port set to 12345' do
                 let(:params) do
-                  { ganglia_host: 'testhost',
+                  {
+                    ganglia_host: 'testhost',
                     ganglia_port: '12345',
-                    agent_major_version: 5 }
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -902,9 +990,11 @@ describe 'datadog_agent' do
               end
               context 'with ganglia_host set to localhost and ganglia_port set to 12345, port specified as an integer' do
                 let(:params) do
-                  { ganglia_host: 'testhost',
+                  {
+                    ganglia_host: 'testhost',
                     ganglia_port: 12_345,
-                    agent_major_version: 5 }
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -915,8 +1005,10 @@ describe 'datadog_agent' do
               end
               context 'with dogstreams set to /path/to/log1:/path/to/parser' do
                 let(:params) do
-                  { dogstreams: ['/path/to/log1:/path/to/parser'],
-                    agent_major_version: 5 }
+                  {
+                    dogstreams: ['/path/to/log1:/path/to/parser'],
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -927,8 +1019,10 @@ describe 'datadog_agent' do
               end
               context 'with custom_emitters set to /test/emitter' do
                 let(:params) do
-                  { custom_emitters: '/test/emitter/',
-                    agent_major_version: 5 }
+                  {
+                    custom_emitters: '/test/emitter/',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -939,8 +1033,10 @@ describe 'datadog_agent' do
               end
               context 'with custom_emitters set to /test/emitter' do
                 let(:params) do
-                  { custom_emitters: '/test/emitter/',
-                    agent_major_version: 5 }
+                  {
+                    custom_emitters: '/test/emitter/',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -951,8 +1047,10 @@ describe 'datadog_agent' do
               end
               context 'with collector_log_file set to /test/log' do
                 let(:params) do
-                  { collector_log_file: '/test/log',
-                    agent_major_version: 5 }
+                  {
+                    collector_log_file: '/test/log',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -963,8 +1061,10 @@ describe 'datadog_agent' do
               end
               context 'with forwarder_log_file set to /test/log' do
                 let(:params) do
-                  { forwarder_log_file: '/test/log',
-                    agent_major_version: 5 }
+                  {
+                    forwarder_log_file: '/test/log',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -975,8 +1075,10 @@ describe 'datadog_agent' do
               end
               context 'with forwarder_log_file set to /test/log' do
                 let(:params) do
-                  { forwarder_log_file: '/test/log',
-                    agent_major_version: 5 }
+                  {
+                    forwarder_log_file: '/test/log',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -987,8 +1089,10 @@ describe 'datadog_agent' do
               end
               context 'with dogstatsd_log_file set to /test/log' do
                 let(:params) do
-                  { dogstatsd_log_file: '/test/log',
-                    agent_major_version: 5 }
+                  {
+                    dogstatsd_log_file: '/test/log',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -999,8 +1103,10 @@ describe 'datadog_agent' do
               end
               context 'with pup_log_file set to /test/log' do
                 let(:params) do
-                  { pup_log_file: '/test/log',
-                    agent_major_version: 5 }
+                  {
+                    pup_log_file: '/test/log',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -1011,8 +1117,10 @@ describe 'datadog_agent' do
               end
               context 'with syslog location set to localhost' do
                 let(:params) do
-                  { syslog_host: 'localhost',
-                    agent_major_version: 5 }
+                  {
+                    syslog_host: 'localhost',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -1023,8 +1131,10 @@ describe 'datadog_agent' do
               end
               context 'with syslog port set to 8080' do
                 let(:params) do
-                  { syslog_port: '8080',
-                    agent_major_version: 5 }
+                  {
+                    syslog_port: '8080',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -1035,8 +1145,10 @@ describe 'datadog_agent' do
               end
               context 'with syslog port set to 8080, specified as an integer' do
                 let(:params) do
-                  { syslog_port: 8080,
-                    agent_major_version: 5 }
+                  {
+                    syslog_port: 8080,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -1047,8 +1159,10 @@ describe 'datadog_agent' do
               end
               context 'with apm_enabled set to true' do
                 let(:params) do
-                  { apm_enabled: true,
-                    agent_major_version: 5 }
+                  {
+                    apm_enabled: true,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -1059,9 +1173,11 @@ describe 'datadog_agent' do
               end
               context 'with apm_enabled set to true and env specified' do
                 let(:params) do
-                  { apm_enabled: true,
+                  {
+                    apm_enabled: true,
                     apm_env: 'foo',
-                    agent_major_version: 5 }
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -1087,12 +1203,14 @@ describe 'datadog_agent' do
               end
               context 'with apm_enabled and apm_analyzed_spans set' do
                 let(:params) do
-                  { apm_enabled: true,
+                  {
+                    apm_enabled: true,
                     agent_major_version: 5,
                     apm_analyzed_spans: {
                       'foo|bar' => 0.5,
                       'haz|qux' => 0.1,
-                    } }
+                    },
+                  }
                 end
 
                 it {
@@ -1118,12 +1236,14 @@ describe 'datadog_agent' do
               end
               context 'with service_discovery enabled' do
                 let(:params) do
-                  { service_discovery_backend: 'docker',
+                  {
+                    service_discovery_backend: 'docker',
                     sd_config_backend: 'etcd',
                     sd_backend_host: 'localhost',
                     sd_backend_port: 8080,
                     sd_jmx_enable: true,
-                    agent_major_version: 5 }
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -1154,8 +1274,10 @@ describe 'datadog_agent' do
               end
               context 'with extra_template enabled' do
                 let(:params) do
-                  { extra_template: 'custom_datadog/extra_template_test.erb',
-                    agent_major_version: 5 }
+                  {
+                    extra_template: 'custom_datadog/extra_template_test.erb',
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {
@@ -1231,8 +1353,10 @@ describe 'datadog_agent' do
               end
               context 'with process_agent enabled' do
                 let(:params) do
-                  { process_enabled: true,
-                    agent_major_version: 5 }
+                  {
+                    process_enabled: true,
+                    agent_major_version: 5,
+                  }
                 end
 
                 it {

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -1,79 +1,82 @@
 require 'spec_helper'
 
 describe 'datadog_agent::ubuntu' do
-
   context 'agent 5' do
-    let(:params){ {:agent_major_version => 5} }
-
     if RSpec::Support::OS.windows?
       return
     end
-
+    let(:params) { { agent_major_version: 5 } }
     let(:facts) do
       {
         osfamily: 'debian',
-        operatingsystem: 'Ubuntu'
+        operatingsystem: 'Ubuntu',
       }
     end
 
     it do
-      should contain_file('/etc/apt/sources.list.d/datadog5.list')
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog5.list')
         .with_ensure('absent')
-      should contain_file('/etc/apt/sources.list.d/datadog6.list')
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog6.list')
         .with_ensure('absent')
-      should contain_file('/etc/apt/sources.list.d/datadog.list')\
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
         .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+main})
     end
 
     # it should install the mirror
-    it { should_not contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
+    it { is_expected.not_to contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
     it do
-      should contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog')
+      is_expected.to contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog')
     end
     context 'overriding keyserver' do
-      let(:params) {{
-        apt_keyserver: 'hkp://pool.sks-keyservers.net:80',
-      }}
+      let(:params) do
+        {
+          apt_keyserver: 'hkp://pool.sks-keyservers.net:80',
+        }
+      end
+
       it do
-        should contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog')\
+        is_expected.to contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog')\
           .with_server('hkp://pool.sks-keyservers.net:80')
       end
     end
 
     it do
-      should contain_file('/etc/apt/sources.list.d/datadog.list')\
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
         .that_notifies('exec[apt_update]')
     end
-    it { should contain_exec('apt_update') }
+    it { is_expected.to contain_exec('apt_update') }
 
     # it should install the packages
     it do
-      should contain_package('datadog-agent-base')\
+      is_expected.to contain_package('datadog-agent-base')\
         .with_ensure('absent')\
         .that_comes_before('package[datadog-agent]')
     end
     it do
-      should contain_package('datadog-agent')\
+      is_expected.to contain_package('datadog-agent')\
         .that_requires('file[/etc/apt/sources.list.d/datadog.list]')\
         .that_requires('exec[apt_update]')
     end
 
     # it should be able to start the service and enable the service by default
     it do
-      should contain_service('datadog-agent')\
+      is_expected.to contain_service('datadog-agent')\
         .that_requires('package[datadog-agent]')
     end
 
     context 'overriding provider' do
-      let(:params) {{
-        service_provider: 'upstart',
-      }}
+      let(:params) do
+        {
+          service_provider: 'upstart',
+        }
+      end
+
       it do
-        should contain_service('datadog-agent')\
+        is_expected.to contain_service('datadog-agent')\
           .that_requires('package[datadog-agent]')
       end
       it do
-        should contain_service('datadog-agent').with(
+        is_expected.to contain_service('datadog-agent').with(
           'provider' => 'upstart',
           'ensure' => 'running',
         )
@@ -82,63 +85,65 @@ describe 'datadog_agent::ubuntu' do
   end
 
   context 'agent 6' do
-
-    let(:params){ {:agent_major_version => 6} }
+    let(:params) { { agent_major_version: 6 } }
 
     let(:facts) do
       {
         osfamily: 'debian',
-        operatingsystem: 'Ubuntu'
+        operatingsystem: 'Ubuntu',
       }
     end
 
     it do
-      should contain_file('/etc/apt/sources.list.d/datadog5.list')
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog5.list')
         .with_ensure('absent')
-      should contain_file('/etc/apt/sources.list.d/datadog6.list')
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog6.list')
         .with_ensure('absent')
-      should contain_file('/etc/apt/sources.list.d/datadog.list')\
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
         .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
     end
 
     # it should install the mirror
-    it { should_not contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
-    it { should contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog') }
+    it { is_expected.not_to contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
+    it { is_expected.to contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog') }
 
     it do
-      should contain_file('/etc/apt/sources.list.d/datadog6.list')\
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog6.list')\
         .that_notifies('exec[apt_update]')
     end
-    it { should contain_exec('apt_update') }
+    it { is_expected.to contain_exec('apt_update') }
 
     # it should install the packages
     it do
-      should contain_package('datadog-agent-base')\
+      is_expected.to contain_package('datadog-agent-base')\
         .with_ensure('absent')\
         .that_comes_before('package[datadog-agent]')
     end
     it do
-      should contain_package('datadog-agent')\
+      is_expected.to contain_package('datadog-agent')\
         .that_requires('file[/etc/apt/sources.list.d/datadog6.list]')\
         .that_requires('exec[apt_update]')
     end
 
     # it should be able to start the service and enable the service by default
     it do
-      should contain_service('datadog-agent')\
+      is_expected.to contain_service('datadog-agent')\
         .that_requires('package[datadog-agent]')
     end
 
     context 'overriding provider' do
-      let(:params) {{
-        service_provider: 'upstart',
-      }}
+      let(:params) do
+        {
+          service_provider: 'upstart',
+        }
+      end
+
       it do
-        should contain_service('datadog-agent')\
+        is_expected.to contain_service('datadog-agent')\
           .that_requires('package[datadog-agent]')
       end
       it do
-        should contain_service('datadog-agent').with(
+        is_expected.to contain_service('datadog-agent').with(
           'provider' => 'upstart',
           'ensure' => 'running',
         )
@@ -147,63 +152,65 @@ describe 'datadog_agent::ubuntu' do
   end
 
   context 'agent 7' do
-
-    let(:params){ {:agent_major_version => 7} }
+    let(:params) { { agent_major_version: 7 } }
 
     let(:facts) do
       {
         osfamily: 'debian',
-        operatingsystem: 'Ubuntu'
+        operatingsystem: 'Ubuntu',
       }
     end
 
     it do
-      should contain_file('/etc/apt/sources.list.d/datadog5.list')
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog5.list')
         .with_ensure('absent')
-      should contain_file('/etc/apt/sources.list.d/datadog6.list')
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog6.list')
         .with_ensure('absent')
-      should contain_file('/etc/apt/sources.list.d/datadog.list')\
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
         .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+7})
     end
 
     # it should install the mirror
-    it { should_not contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
-    it { should contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog') }
+    it { is_expected.not_to contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
+    it { is_expected.to contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog') }
 
     it do
-      should contain_file('/etc/apt/sources.list.d/datadog6.list')\
+      is_expected.to contain_file('/etc/apt/sources.list.d/datadog6.list')\
         .that_notifies('exec[apt_update]')
     end
-    it { should contain_exec('apt_update') }
+    it { is_expected.to contain_exec('apt_update') }
 
     # it should install the packages
     it do
-      should contain_package('datadog-agent-base')\
+      is_expected.to contain_package('datadog-agent-base')\
         .with_ensure('absent')\
         .that_comes_before('package[datadog-agent]')
     end
     it do
-      should contain_package('datadog-agent')\
+      is_expected.to contain_package('datadog-agent')\
         .that_requires('file[/etc/apt/sources.list.d/datadog6.list]')\
         .that_requires('exec[apt_update]')
     end
 
     # it should be able to start the service and enable the service by default
     it do
-      should contain_service('datadog-agent')\
+      is_expected.to contain_service('datadog-agent')\
         .that_requires('package[datadog-agent]')
     end
 
     context 'overriding provider' do
-      let(:params) {{
-        service_provider: 'upstart',
-      }}
+      let(:params) do
+        {
+          service_provider: 'upstart',
+        }
+      end
+
       it do
-        should contain_service('datadog-agent')\
+        is_expected.to contain_service('datadog-agent')\
           .that_requires('package[datadog-agent]')
       end
       it do
-        should contain_service('datadog-agent').with(
+        is_expected.to contain_service('datadog-agent').with(
           'provider' => 'upstart',
           'ensure' => 'running',
         )

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -5,7 +5,11 @@ describe 'datadog_agent::ubuntu' do
     if RSpec::Support::OS.windows?
       return
     end
-    let(:params) { { agent_major_version: 5 } }
+    let(:params) do
+      {
+        agent_major_version: 5,
+      }
+    end
     let(:facts) do
       {
         osfamily: 'debian',
@@ -85,7 +89,11 @@ describe 'datadog_agent::ubuntu' do
   end
 
   context 'agent 6' do
-    let(:params) { { agent_major_version: 6 } }
+    let(:params) do
+      {
+        agent_major_version: 6,
+      }
+    end
 
     let(:facts) do
       {
@@ -152,7 +160,11 @@ describe 'datadog_agent::ubuntu' do
   end
 
   context 'agent 7' do
-    let(:params) { { agent_major_version: 7 } }
+    let(:params) do
+      {
+        agent_major_version: 7,
+      }
+    end
 
     let(:facts) do
       {

--- a/spec/defines/datadog_agent__install_integration_spec.rb
+++ b/spec/defines/datadog_agent__install_integration_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
-describe "datadog_agent::install_integration" do
+describe 'datadog_agent::install_integration' do
   context 'all supported operating systems' do
     ALL_OS.each do |operatingsystem|
-      let(:facts) do {
+      let(:facts) do
+        {
           operatingsystem: operatingsystem,
           osfamily: getosfamily(operatingsystem),
           operatingsystemrelease: getosrelease(operatingsystem),
@@ -11,38 +12,40 @@ describe "datadog_agent::install_integration" do
       end
 
       if WINDOWS_OS.include?(operatingsystem)
-        let (:agent_binary) { 'C:/Program Files/Datadog/Datadog Agent/embedded/agent.exe' }
+        let(:agent_binary) { 'C:/Program Files/Datadog/Datadog Agent/embedded/agent.exe' }
       else
-        let (:agent_binary) { '/opt/datadog-agent/bin/agent/agent' }
+        let(:agent_binary) { '/opt/datadog-agent/bin/agent/agent' }
       end
 
-      describe "installing an integration" do
+      describe 'installing an integration' do
         let(:pre_condition) { "class {'::datadog_agent': }" }
-        let (:title) { "test" }
-        let (:params) {{
-          :integration_name => "datadog-mongo",
-          :version => "1.9.0",
-        }}
+        let(:title) { 'test' }
+        let(:params) do
+          {
+            integration_name: 'datadog-mongo',
+            version: '1.9.0',
+          }
+        end
 
-        it { should compile }
+        it { is_expected.to compile }
 
-        it { is_expected.to contain_exec("install datadog-mongo==1.9.0").with_command("#{agent_binary} integration install datadog-mongo==1.9.0") }
-
+        it { is_expected.to contain_exec('install datadog-mongo==1.9.0').with_command("#{agent_binary} integration install datadog-mongo==1.9.0") }
       end
 
-      describe "removing an integration" do
+      describe 'removing an integration' do
         let(:pre_condition) { "class {'::datadog_agent': }" }
-        let (:title) { "test" }
-        let (:params) {{
-          :integration_name => "datadog-mongo",
-          :version => "1.9.0",
-          :ensure => "absent",
-        }}
+        let(:title) { 'test' }
+        let(:params) do
+          {
+            integration_name: 'datadog-mongo',
+            version: '1.9.0',
+            ensure: 'absent',
+          }
+        end
 
-        it { should compile }
+        it { is_expected.to compile }
 
-        it { is_expected.to contain_exec("remove datadog-mongo==1.9.0").with_command("#{agent_binary} integration remove datadog-mongo==1.9.0") }
-
+        it { is_expected.to contain_exec('remove datadog-mongo==1.9.0').with_command("#{agent_binary} integration remove datadog-mongo==1.9.0") }
       end
     end
   end

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -16,7 +16,9 @@ describe 'datadog_agent::integration' do
       let(:params) do
         {
           instances: [
-            { 'one' => 'two' },
+            {
+              one: 'two',
+            },
           ],
         }
       end
@@ -38,7 +40,9 @@ describe 'datadog_agent::integration' do
         let(:params) do
           {
             instances: [
-              { 'one' => 'two' },
+              {
+                one: 'two',
+              },
             ],
             logs: ['one', 'two'],
           }

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -1,48 +1,53 @@
 require 'spec_helper'
 
-describe "datadog_agent::integration" do
+describe 'datadog_agent::integration' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
       if agent_major_version == 5
         let(:conf_file) { '/etc/dd-agent/conf.d/test.yaml' }
+
       else
         let(:conf_dir) { "#{CONF_DIR}/test.d" }
         let(:conf_file) { "#{conf_dir}/conf.yaml" }
       end
 
-      let (:title) { "test" }
-      let (:params) {{
-          :instances => [
-              { 'one' => "two" }
-          ]
-      }}
-
-      it { should compile }
-      if agent_major_version == 5
-        it { should contain_file("#{conf_dir}").that_comes_before("File[#{conf_file}]") }
+      let(:title) { 'test' }
+      let(:params) do
+        {
+          instances: [
+            { 'one' => 'two' },
+          ],
+        }
       end
-      it { should contain_file("#{conf_file}").with_content(/init_config: /) }
+
+      it { is_expected.to compile }
+      if agent_major_version == 5
+        it { is_expected.to contain_file(conf_dir.to_s).that_comes_before("File[#{conf_file}]") }
+      end
+      it { is_expected.to contain_file(conf_file.to_s).with_content(%r{init_config: }) }
       gem_spec = Gem.loaded_specs['puppet']
       if gem_spec.version >= Gem::Version.new('4.0.0')
-        it { should contain_file("#{conf_file}").with_content(/---\ninit_config: \ninstances:\n- one: two\n/) }
+        it { is_expected.to contain_file(conf_file.to_s).with_content(%r{---\ninit_config: \ninstances:\n- one: two\n}) }
       else
-        it { should contain_file("#{conf_file}").with_content(/--- \n  init_config: \n  instances: \n    - one: two/) }
+        it { is_expected.to contain_file(conf_file.to_s).with_content(%r{--- \n  init_config: \n  instances: \n    - one: two}) }
       end
-      it { should contain_file("#{conf_file}").that_notifies("Service[#{SERVICE_NAME}]") }
+      it { is_expected.to contain_file(conf_file.to_s).that_notifies("Service[#{SERVICE_NAME}]") }
 
       context 'with logs' do
-        let(:params) {{
-          :instances => [
-              { 'one' => "two" }
-          ],
-          :logs => %w(one two),
-        }}
+        let(:params) do
+          {
+            instances: [
+              { 'one' => 'two' },
+            ],
+            logs: ['one', 'two'],
+          }
+        end
 
         if gem_spec.version >= Gem::Version.new('4.0.0')
-          it { should contain_file(conf_file).with_content(%r{logs:\n- one\n- two}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{logs:\n- one\n- two}) }
         else
-          it { should contain_file(conf_file).with_content(%r{logs:\n  - one\n  - two}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{logs:\n  - one\n  - two}) }
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,70 +1,69 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 
-DEBIAN_OS = %w(Ubuntu Debian)
-REDHAT_OS = %w(RedHat CentOS Fedora Amazon Scientific OracleLinux)
-WINDOWS_OS = %w(Windows)
+DEBIAN_OS = ['Ubuntu', 'Debian'].freeze
+REDHAT_OS = ['RedHat', 'CentOS', 'Fedora', 'Amazon', 'Scientific', 'OracleLinux'].freeze
+WINDOWS_OS = ['Windows'].freeze
 
 if RSpec::Support::OS.windows?
   ALL_OS                     = WINDOWS_OS
-  ALL_SUPPORTED_AGENTS       = [ 6, 7 ]
-  CONF_DIR                  = 'C:/ProgramData/Datadog/conf.d'
-  DD_USER                    = 'ddagentuser'
-  DD_GROUP                   = 'S-1-5-32-544'
-  SERVICE_NAME               = 'datadogagent'
-  PACKAGE_NAME               = 'Datadog Agent'
-  PERMISSIONS_FILE           = '0664'
-  PERMISSIONS_PROTECTED_FILE = '0660'
+  ALL_SUPPORTED_AGENTS       = [6, 7].freeze
+  CONF_DIR = 'C:/ProgramData/Datadog/conf.d'.freeze
+  DD_USER                    = 'ddagentuser'.freeze
+  DD_GROUP                   = 'S-1-5-32-544'.freeze
+  SERVICE_NAME               = 'datadogagent'.freeze
+  PACKAGE_NAME               = 'Datadog Agent'.freeze
+  PERMISSIONS_FILE           = '0664'.freeze
+  PERMISSIONS_PROTECTED_FILE = '0660'.freeze
 else
   ALL_OS                     = DEBIAN_OS + REDHAT_OS
-  ALL_SUPPORTED_AGENTS       = [ 5, 6, 7 ]
-  CONF_DIR                  = '/etc/datadog-agent/conf.d'
-  DD_USER                    = 'dd-agent'
-  DD_GROUP                   = 'dd-agent'
-  SERVICE_NAME               = 'datadog-agent'
-  PACKAGE_NAME               = 'datadog-agent'
-  PERMISSIONS_FILE           = '0644'
-  PERMISSIONS_PROTECTED_FILE = '0600'
+  ALL_SUPPORTED_AGENTS       = [5, 6, 7].freeze
+  CONF_DIR = '/etc/datadog-agent/conf.d'.freeze
+  DD_USER                    = 'dd-agent'.freeze
+  DD_GROUP                   = 'dd-agent'.freeze
+  SERVICE_NAME               = 'datadog-agent'.freeze
+  PACKAGE_NAME               = 'datadog-agent'.freeze
+  PERMISSIONS_FILE           = '0644'.freeze
+  PERMISSIONS_PROTECTED_FILE = '0600'.freeze
 end
-
 
 def getosfamily(operatingsystem)
   if DEBIAN_OS.include?(operatingsystem)
-    return 'debian'
+    'debian'
   elsif REDHAT_OS.include?(operatingsystem)
-    return 'redhat'
+    'redhat'
   else
-    return 'windows'
+    'windows'
   end
 end
 
 def getosrelease(operatingsystem)
   if DEBIAN_OS.include?(operatingsystem)
-    return '14.04'
+    '14.04'
   elsif REDHAT_OS.include?(operatingsystem)
-    return '7'
+    '7'
   else
-    return '2019'
+    '2019'
   end
 end
 
 RSpec.configure do |c|
   c.default_facts = {
     'architecture'               => 'x86_64',
-    'operatingsystem'            => (if RSpec::Support::OS.windows? then 'Windows' else 'Ubuntu' end),
-    'osfamily'                   => (if RSpec::Support::OS.windows? then 'windows' else 'Debian' end),
-    'operatingsystemmajrelease'  => (if RSpec::Support::OS.windows? then '2019' else '14' end),
-    'operatingsystemminrelease'  => (if RSpec::Support::OS.windows? then 'SP1' else '04' end),
-    'operatingsystemrelease'     => (if RSpec::Support::OS.windows? then '2019 SP1' else '14.04' end),
-    'lsbdistrelease'             => (if RSpec::Support::OS.windows? then '2019 SP1' else '14.04' end),
-    'lsbdistcodename'            => (if RSpec::Support::OS.windows? then '2019' else '14.04' end),
+    'operatingsystem'            => (RSpec::Support::OS.windows? ? 'Windows' : 'Ubuntu'),
+    'osfamily'                   => (RSpec::Support::OS.windows? ? 'windows' : 'Debian'),
+    'operatingsystemmajrelease'  => (RSpec::Support::OS.windows? ? '2019' : '14'),
+    'operatingsystemminrelease'  => (RSpec::Support::OS.windows? ? 'SP1' : '04'),
+    'operatingsystemrelease'     => (RSpec::Support::OS.windows? ? '2019 SP1' : '14.04'),
+    'lsbdistrelease'             => (RSpec::Support::OS.windows? ? '2019 SP1' : '14.04'),
+    'lsbdistcodename'            => (RSpec::Support::OS.windows? ? '2019' : '14.04'),
     'os'                         => {
-      'name'    => (if RSpec::Support::OS.windows? then 'Windows' else 'Ubuntu' end),
-      'family'  => (if RSpec::Support::OS.windows? then 'windows' else 'Debian' end),
+      'name'    => (RSpec::Support::OS.windows? ? 'Windows' : 'Ubuntu'),
+      'family'  => (RSpec::Support::OS.windows? ? 'windows' : 'Debian'),
       'release' => {
-        'major' => (if RSpec::Support::OS.windows? then '2019' else '14' end),
-        'minor' => (if RSpec::Support::OS.windows? then 'SP1' else '04' end),
-        'full'  => (if RSpec::Support::OS.windows? then '2019 SP1' else '14.04' end)
-      }
-    }
+        'major' => (RSpec::Support::OS.windows? ? '2019' : '14'),
+        'minor' => (RSpec::Support::OS.windows? ? 'SP1' : '04'),
+        'full'  => (RSpec::Support::OS.windows? ? '2019 SP1' : '14.04'),
+      },
+    },
   }
 end


### PR DESCRIPTION
- Enables rubocop.
- Fixes rubocop ofenses.
- Fixes broken `facts_to_tags` on A5, which was broken because the tests
didn't run because the syntax was not correct (uncovered by rubocop).
- Adds test for `facts_to_tags` on A6/A7.