### PR TITLE
Run Kitchen tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,28 @@ jobs:
           name: Run tests
           command: rvm $RUBY_VERSION --verbose do bundle exec rake test
 
+  kitchen-tests:
+    machine: true
+    environment:
+      KITCHEN_LOCAL_YAML: .kitchen.docker.yml
+      STRICT_VARIABLES: 'yes'
+      RUBY_VERSION: '2.5.3'
+    steps:
+      - checkout
+      - run:
+          name: Install Ruby versions
+          command: rvm install $RUBY_VERSION
+      - run:
+          name: Install bundler
+          command: rvm $RUBY_VERSION --verbose do gem install bundler:1.17.3
+      - run:
+          name: Install gem dependencies
+          command: rvm $RUBY_VERSION --verbose do bundle install --path .bundle
+      - run:
+          name: Execute Kitchen tests
+          command: rvm $RUBY_VERSION --verbose do bundle exec rake circle
+          no_output_timeout: 900
+
 workflows:
   version: 2
   build_and_test:
@@ -297,3 +319,4 @@ workflows:
       - specs-ruby26-puppet60
       - specs-ruby26-puppet65
       - verify-gemfile-lock-dependencies
+      - kitchen-tests

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,0 +1,77 @@
+---
+driver:
+  name: docker
+
+provisioner:
+  name: puppet_apply
+  manifests_path: environments/etc/manifests
+  modules_path: /tmp/modules
+  require_puppet_repo: true
+  require_chef_for_busser: false
+  puppet_debug: true
+  puppet_verbose: true
+  custom_pre_apply_command: 'cp -r /tmp/modules/* /tmp/kitchen/modules/'
+
+platforms:
+  - name: centos-7
+    driver_config:
+      # we use a custom image that runs systemd
+      image: 'datadog/docker-library:chef_kitchen_systemd_centos_7'
+      run_command: /root/start.sh
+
+    driver:
+      provision_command:
+        - rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+        - yum install -y puppet
+
+        - mkdir /home/kitchen/puppet
+        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+
+        - gem install r10k -v 2.6.7
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+
+  - name: centos-8
+    driver_config:
+      # we use a custom image that runs systemd
+      image: 'datadog/docker-library:chef_kitchen_systemd_centos_8'
+      run_command: /root/start.sh
+
+    driver:
+      provision_command:
+        - dnf install -y https://yum.puppetlabs.com/puppet-release-el-8.noarch.rpm
+        - dnf install -y puppet
+
+        - mkdir /home/kitchen/puppet
+        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+
+        - gem install r10k -v 2.6.7
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+
+  - name: ubuntu-16.04 # we use the official image
+    driver:
+      provision_command:
+        - apt-get install -y apt-utils apt-transport-https ca-certificates
+        - wget https://apt.puppetlabs.com/puppet6-release-xenial.deb
+        - dpkg -i puppet6-release-xenial.deb
+        - apt-get install -y puppet
+
+        - mkdir /home/kitchen/puppet
+        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+
+        - gem install r10k -v 2.6.7
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+
+verifier:
+  name: serverspec
+
+suites:
+  - name: dd-agent
+    manifests: init.pp
+    verifier:
+      default_pattern: true
+      additional_install_commmand: source /etc/profile.d/rvm.sh
+      env_vars:
+        TARGET_HOST: 127.0.0.1
+        TARGET_PORT: 2222
+        LOGIN_USER: root
+        LOGIN_PASSWORD: puppet

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development do
   gem "librarian-puppet"
   gem "kitchen-puppet"
   gem "kitchen-vagrant"
+  gem "kitchen-docker"
   gem "kitchen-verifier-serverspec"
 
   if RUBY_VERSION >= '2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     json_pure (1.8.6)
+    kitchen-docker (2.9.0)
+      test-kitchen (>= 1.0.0)
     kitchen-puppet (3.5.1)
       librarian-puppet (>= 3.0)
       net-ssh (>= 3)
@@ -312,6 +314,7 @@ PLATFORMS
 DEPENDENCIES
   fast_gettext
   json (= 2.1.0)
+  kitchen-docker
   kitchen-puppet
   kitchen-vagrant
   kitchen-verifier-serverspec

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
 require 'puppet-lint/tasks/puppet-lint'
 require 'rubocop/rake_task'
+require 'kitchen/rake_tasks'
 
 exclude_paths = [
   "pkg/**/*",
@@ -23,3 +24,32 @@ task :test => [
   'rubocop',
   'spec',
 ]
+
+desc 'Run Kitchen tests using CircleCI parallelism mode, split by worker'
+task :circle do
+  def kitchen_config
+    raw_config = Kitchen::Loader::YAML.new(
+      local_config: ENV['KITCHEN_LOCAL_YAML']
+    )
+
+    Kitchen::Config.new(loader: raw_config)
+  end
+
+  def total_workers
+    ENV.fetch('CIRCLE_NODE_TOTAL', 1).to_i
+  end
+
+  def current_worker
+    ENV.fetch('CIRCLE_NODE_INDEX', 0).to_i
+  end
+
+  def command
+    kitchen_config.instances.sort_by(&:name).each_with_object([]).with_index do |(instance, commands), index|
+      next unless index % total_workers == current_worker
+
+      commands << "kitchen test #{instance.name}"
+    end.join(' && ')
+  end
+
+  sh command unless command.empty?
+end


### PR DESCRIPTION
### What does this PR do?

It adds the configuration for having kitchen tests run on docker (using kitchen-docker). Those tests should be close to the vagrant ones.

### Motivation

Make the tests run on CI to know if a change breaks the tests.