### PR TITLE
Use new S3 URL format

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,7 +200,7 @@
 #       Where to download the agent from. When undef, it uses the following defaults:
 #       APT: https://apt.datadoghq.com/
 #       RPM: https://yum.datadoghq.com/stable/7/x86_64/ (with matching agent version and architecture)
-#       Windows: https://https://s3.amazonaws.com/ddagent-windows-stable/
+#       Windows: https://https://ddagent-windows-stable.s3.amazonaws.com/
 #       String. Default: undef
 #   $apt_release
 #       The distribution channel to be used for the APT repo. Eg: 'stable' or 'beta'.

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -22,7 +22,7 @@ class datadog_agent::windows(
   if ($agent_repo_uri != undef) {
     $baseurl = $agent_repo_uri
   } else {
-    $baseurl = 'https://s3.amazonaws.com/ddagent-windows-stable/'
+    $baseurl = 'https://ddagent-windows-stable.s3.amazonaws.com/'
   }
 
   if $agent_version == 'latest' {
@@ -70,7 +70,7 @@ class datadog_agent::windows(
     }
   } else {
     exec { 'datadog_6_14_fix':
-      command  => "((New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/ddagent-windows-stable/scripts/fix_6_14.ps1', \$env:temp + '\\fix_6_14.ps1')); &\$env:temp\\fix_6_14.ps1",
+      command  => "((New-Object System.Net.WebClient).DownloadFile('https://ddagent-windows-stable.s3.amazonaws.com/scripts/fix_6_14.ps1', \$env:temp + '\\fix_6_14.ps1')); &\$env:temp\\fix_6_14.ps1",
       provider => 'powershell',
     }
 


### PR DESCRIPTION
### What does this PR do?

Switch S3 URLs to virtual-hosted style.

### Motivation

Comply with the new standard. Even if old buckets should not be affected, let's be consistent in the path style we use.
