### PR TITLE
Make test environments use the local module

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -37,5 +37,4 @@ We can edit the manifest and run `vagrant up --provision` to upload the new vers
 
 # Test
 
-In the CentOS VM, run `sudo /usr/local/bin/puppet apply --modulepath=./modules ./manifests/site.pp` in `/home/vagrant/puppet` to apply to manifest on the VM.
-In the Ubuntu VM, run `sudo /opt/puppetlabs/bin/puppet apply --modulepath=./modules ./manifests/site.pp` in `/home/vagrant/puppet` to apply to manifest on the VM.
+In a VM, run `sudo puppet apply --modulepath=./modules ./manifests/site.pp` in `/home/vagrant/puppet` to apply to manifest on the VM.

--- a/environments/centos7/Vagrantfile
+++ b/environments/centos7/Vagrantfile
@@ -1,14 +1,19 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/centos7"
-  config.vm.provision "file", source: "../../../environments/etc", destination: "$HOME/puppet"
+  config.vm.provision "file", source: "../../environments/etc", destination: "$HOME/puppet"
+  config.vm.synced_folder "../../", "/puppet-datadog-agent"
   config.vm.provision "shell", inline: <<-SHELL
-    rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+    #install puppet 5
+    rpm -ivh http://yum.puppetlabs.com/puppet5-release-el-7.noarch.rpm
     yum install -y puppet
-    systemctl start puppet
-    systemctl enable puppet
+    ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
 
-    gem install r10k -v 2.6.7
+    # install modules
     cd /home/vagrant/puppet
-    sudo su vagrant -c "/usr/local/bin/r10k puppetfile install --moduledir=/tmp/modules"
+    /opt/puppetlabs/puppet/bin/gem install r10k -v 2.6.7
+    /opt/puppetlabs/puppet/bin/r10k puppetfile install --moduledir=/home/vagrant/puppet/modules
+
+    # link local module
+    ln -s /puppet-datadog-agent /home/vagrant/puppet/modules/datadog_agent
   SHELL
 end

--- a/environments/centos8/Vagrantfile
+++ b/environments/centos8/Vagrantfile
@@ -1,14 +1,19 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/centos8"
-  config.vm.provision "file", source: "../../../environments/etc", destination: "$HOME/puppet"
+  config.vm.provision "file", source: "../../environments/etc", destination: "$HOME/puppet"
+  config.vm.synced_folder "../../", "/puppet-datadog-agent"
   config.vm.provision "shell", inline: <<-SHELL
+    #install puppet 6
     dnf install -y https://yum.puppetlabs.com/puppet-release-el-8.noarch.rpm
     dnf install -y puppet
-    systemctl start puppet
-    systemctl enable puppet
+    ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
 
-    /opt/puppetlabs/puppet/bin/gem install r10k -v 2.6.7
+    # install modules
     cd /home/vagrant/puppet
-    sudo su vagrant -c "/opt/puppetlabs/puppet/bin/r10k puppetfile install --moduledir=/tmp/modules"
+    /opt/puppetlabs/puppet/bin/gem install r10k -v 2.6.7
+    /opt/puppetlabs/puppet/bin/r10k puppetfile install --moduledir=/home/vagrant/puppet/modules
+
+    # link local module
+    ln -s /puppet-datadog-agent /home/vagrant/puppet/modules/datadog_agent
   SHELL
 end

--- a/environments/etc/Puppetfile
+++ b/environments/etc/Puppetfile
@@ -1,3 +1,5 @@
+# Track control branch and fall-back to master if no matching branch.
+mod 'datadog_agent', :local => true
 mod 'puppetlabs-apt', '2.4.0'
 mod 'puppetlabs-concat', '4.0.0'
 mod 'puppetlabs-puppetserver_gem', '1.0.0'

--- a/environments/ubuntu1604/Vagrantfile
+++ b/environments/ubuntu1604/Vagrantfile
@@ -1,10 +1,19 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "puppetlabs/ubuntu-16.04-64-puppet"
   config.vm.box_version = "1.0.0"
-  config.vm.provision "file", source: "../../../environments/etc", destination: "$HOME/puppet"
+  config.vm.provision "file", source: "../../environments/etc", destination: "$HOME/puppet"
+  config.vm.synced_folder "../../", "/puppet-datadog-agent"
   config.vm.provision "shell", inline: <<-SHELL
-    /opt/puppetlabs/puppet/bin/gem install r10k -v 2.6.7
+
+    #install puppet 4
+    ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
+
+    # install modules
     cd /home/vagrant/puppet
-    su vagrant -c "/opt/puppetlabs/puppet/bin/r10k puppetfile install --moduledir=/tmp/modules"
+    /opt/puppetlabs/puppet/bin/gem install r10k -v 2.6.7
+    /opt/puppetlabs/puppet/bin/r10k puppetfile install --moduledir=/home/vagrant/puppet/modules
+
+    # link local module
+    ln -s /puppet-datadog-agent /home/vagrant/puppet/modules/datadog_agent
   SHELL
 end


### PR DESCRIPTION
- Mounts the local module inside the VM, so you can iterate on changes faster.
- Symlinks the `puppet` binary into the PATH (simplifies the README)
- Install puppet 4 instead of puppet 3 in the CentOS7 VM, since we don't support puppet 3.
- Fixes vagrant init scripts (they were calling vagrant within vagrant).