### PR TITLE
Add manage_install option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -431,6 +431,10 @@ class datadog_agent(
       }
       default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
     }
+  } else {
+    package { $datadog_agent::params::package_name:
+      ensure  => present,
+    }
   }
 
   # Start service

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -433,6 +433,8 @@ class datadog_agent(
     }
   } else {
     package { $datadog_agent::params::package_name:
+      ensure => present,
+      source => 'Agent installation not managed by Puppet, make sure the Agent is installed beforehand.',
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -433,30 +433,15 @@ class datadog_agent(
     }
   } else {
     package { $datadog_agent::params::package_name:
-      ensure  => present,
     }
   }
 
-  # Start service
-  if ($::operatingsystem == 'Windows') {
-    if ($win_ensure == present) {
-      service { $datadog_agent::params::service_name:
-        ensure  => $service_ensure,
-        enable  => $service_enable,
-        require => Package[$datadog_agent::params::package_name]
-      }
-    }
-  } else {
-    service { $datadog_agent::params::service_name:
-      ensure    => $service_ensure,
-      enable    => $service_enable,
-      provider  => $service_provider,
-      hasstatus => false,
-      pattern   => 'dd-agent',
-      require   => Package[$datadog_agent::params::package_name],
-    }
+  # Declare service
+  class { 'datadog_agent::service' :
+    service_ensure   => $service_ensure,
+    service_enable   => $service_enable,
+    service_provider => $service_provider,
   }
-
 
   if ($::operatingsystem != 'Windows') {
     if ($dd_groups) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,8 +67,10 @@
 #       Set the value of the statsd_forward_port varable. Used to forward all
 #       statsd metrics to another host.
 #   $manage_repo
-#       Boolean to indicate whether this module should attempt to manage
-#       the package repo. Only for RPM-based distros. Default true.
+#       Deprecated. Use $manage_install instead.
+#   $manage_install
+#       Boolean to indicate whether this module should attempt to install the
+#       Agent, or assume it will be installed by other means. Default true.
 #   $graphite_listen_port
 #       Set graphite listener port
 #   $extra_template
@@ -243,6 +245,7 @@ class datadog_agent(
   $service_ensure = 'running',
   $service_enable = true,
   Boolean $manage_repo = true,
+  Boolean $manage_install = true,
   $hostname_extraction_regex = undef,
   Boolean $hostname_fqdn = false,
   $dogstatsd_port = 8125,
@@ -391,50 +394,52 @@ class datadog_agent(
     $_apt_keyserver = $apt_keyserver
   }
 
-  case $::operatingsystem {
-    'Ubuntu','Debian' : {
-      class { 'datadog_agent::ubuntu':
-        agent_major_version   => $_agent_major_version,
-        agent_version         => $agent_version,
-        service_ensure        => $service_ensure,
-        service_enable        => $service_enable,
-        service_provider      => $service_provider,
-        agent_repo_uri        => $agent_repo_uri,
-        release               => $apt_release,
-        skip_apt_key_trusting => $skip_apt_key_trusting,
-        apt_keyserver         => $_apt_keyserver,
+  if $manage_install {
+    case $::operatingsystem {
+      'Ubuntu','Debian' : {
+        class { 'datadog_agent::ubuntu':
+          agent_major_version   => $_agent_major_version,
+          agent_version         => $agent_version,
+          service_ensure        => $service_ensure,
+          service_enable        => $service_enable,
+          service_provider      => $service_provider,
+          agent_repo_uri        => $agent_repo_uri,
+          release               => $apt_release,
+          skip_apt_key_trusting => $skip_apt_key_trusting,
+          apt_keyserver         => $_apt_keyserver,
+        }
       }
+      'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux' : {
+        class { 'datadog_agent::redhat':
+          agent_major_version => $_agent_major_version,
+          agent_repo_uri      => $agent_repo_uri,
+          manage_repo         => $manage_repo,
+          agent_version       => $agent_version,
+          service_ensure      => $service_ensure,
+          service_enable      => $service_enable,
+          service_provider    => $service_provider,
+        }
+      }
+      'Windows' : {
+        class { 'datadog_agent::windows' :
+          agent_major_version => $_agent_major_version,
+          agent_repo_uri      => $agent_repo_uri,
+          agent_version       => $agent_version,
+          service_ensure      => $service_ensure,
+          service_enable      => $service_enable,
+          msi_location        => $win_msi_location,
+          api_key             => $api_key,
+          hostname            => $host,
+          service_name        => $datadog_agent::params::service_name,
+          tags                => $local_tags,
+          ensure              => $win_ensure
+        }
+        if ($win_ensure == absent) {
+          return() #Config files will remain unchanged on uninstall
+        }
+      }
+      default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
     }
-    'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux' : {
-      class { 'datadog_agent::redhat':
-        agent_major_version => $_agent_major_version,
-        agent_repo_uri      => $agent_repo_uri,
-        manage_repo         => $manage_repo,
-        agent_version       => $agent_version,
-        service_ensure      => $service_ensure,
-        service_enable      => $service_enable,
-        service_provider    => $service_provider,
-      }
-    }
-    'Windows' : {
-      class { 'datadog_agent::windows' :
-        agent_major_version => $_agent_major_version,
-        agent_repo_uri      => $agent_repo_uri,
-        agent_version       => $agent_version,
-        service_ensure      => $service_ensure,
-        service_enable      => $service_enable,
-        msi_location        => $win_msi_location,
-        api_key             => $api_key,
-        hostname            => $host,
-        service_name        => $datadog_agent::params::service_name,
-        tags                => $local_tags,
-        ensure              => $win_ensure
-      }
-      if ($win_ensure == absent) {
-        return() #Config files will remain unchanged on uninstall
-      }
-    }
-    default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
   }
 
   if ($::operatingsystem != 'Windows') {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,8 @@
 #       Set the value of the statsd_forward_port varable. Used to forward all
 #       statsd metrics to another host.
 #   $manage_repo
-#       Deprecated. Use $manage_install instead.
+#       Deprecated. Only works for RPM. Install datadog-agent manually and then set
+#       manage_install=false to achieve the same behaviour as setting this to false.
 #   $manage_install
 #       Boolean to indicate whether this module should attempt to install the
 #       Agent, or assume it will be installed by other means. Default true.

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -8,9 +8,6 @@ class datadog_agent::redhat(
   Optional[String] $agent_repo_uri = undef,
   Boolean $manage_repo = true,
   String $agent_version = $datadog_agent::params::agent_version,
-  String $service_ensure = 'running',
-  Boolean $service_enable = true,
-  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
   if $manage_repo {
@@ -80,25 +77,6 @@ class datadog_agent::redhat(
 
   package { $datadog_agent::params::package_name:
     ensure  => $agent_version,
-  }
-
-  if $service_provider {
-    service { $datadog_agent::params::service_name:
-      ensure    => $service_ensure,
-      enable    => $service_enable,
-      provider  => $service_provider,
-      hasstatus => false,
-      pattern   => 'dd-agent',
-      require   => Package[$datadog_agent::params::package_name],
-    }
-  } else {
-    service { $datadog_agent::params::service_name:
-      ensure    => $service_ensure,
-      enable    => $service_enable,
-      hasstatus => false,
-      pattern   => 'dd-agent',
-      require   => Package[$datadog_agent::params::package_name],
-    }
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,40 @@
+# Class: datadog_agent::service
+#
+# This class declares the datadog-agent service
+#
+
+class datadog_agent::service(
+  $service_ensure = 'running',
+  Boolean $service_enable = true,
+  Optional[String] $service_provider = undef,
+) inherits datadog_agent::params {
+
+  if ($::operatingsystem == 'Windows') {
+      service { $datadog_agent::params::service_name:
+        ensure  => $service_ensure,
+        enable  => $service_enable,
+        require => Package[$datadog_agent::params::package_name]
+      }
+  } else {
+    if $service_provider {
+      service { $datadog_agent::params::service_name:
+        ensure    => $service_ensure,
+        enable    => $service_enable,
+        provider  => $service_provider,
+        hasstatus => false,
+        pattern   => 'dd-agent',
+        require   => Package[$datadog_agent::params::package_name],
+      }
+    } else {
+      service { $datadog_agent::params::service_name:
+        ensure    => $service_ensure,
+        enable    => $service_enable,
+        hasstatus => false,
+        pattern   => 'dd-agent',
+        require   => Package[$datadog_agent::params::package_name],
+      }
+    }
+  }
+
+
+}

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -10,9 +10,6 @@ class datadog_agent::ubuntu(
   Optional[String] $agent_repo_uri = undef,
   String $release = $datadog_agent::params::apt_default_release,
   Boolean $skip_apt_key_trusting = false,
-  String $service_ensure = 'running',
-  Boolean $service_enable = true,
-  Optional[String] $service_provider = undef,
   Optional[String] $apt_keyserver = undef,
 ) inherits datadog_agent::params {
 
@@ -77,22 +74,4 @@ class datadog_agent::ubuntu(
                 Class['apt::update']],
   }
 
-  if $service_provider {
-    service { $datadog_agent::params::service_name:
-      ensure    => $service_ensure,
-      enable    => $service_enable,
-      provider  => $service_provider,
-      hasstatus => false,
-      pattern   => 'dd-agent',
-      require   => Package[$datadog_agent::params::package_name],
-    }
-  } else {
-    service { $datadog_agent::params::service_name:
-      ensure    => $service_ensure,
-      enable    => $service_enable,
-      hasstatus => false,
-      pattern   => 'dd-agent',
-      require   => Package[$datadog_agent::params::package_name],
-    }
-  }
 }

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -6,14 +6,11 @@
 class datadog_agent::windows(
   Integer $agent_major_version = $datadog_agent::params::default_agent_major_version,
   String $agent_version = $datadog_agent::params::agent_version,
-  String $service_ensure = 'running',
   Optional[String] $agent_repo_uri = undef,
   String $msi_location = 'C:/Windows/temp',
   String $api_key = $datadog_agent::api_key,
   String $hostname = $datadog_agent::host,
-  String $service_name = $datadog_agent::service_name_win,
   Array  $tags = $datadog_agent::tags,
-  Boolean $service_enable = true,
   Enum['present', 'absent'] $ensure = 'present',
 ) inherits datadog_agent::params {
 
@@ -63,11 +60,6 @@ class datadog_agent::windows(
       install_options => ['/norestart', {'APIKEY' => $api_key, 'HOSTNAME' => $hostname, 'TAGS' => $tags}]
     }
 
-    service { $service_name:
-      ensure  => $service_ensure,
-      enable  => $service_enable,
-      require => Package[$datadog_agent::params::package_name]
-    }
   } else {
     exec { 'datadog_6_14_fix':
       command  => "((New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/ddagent-windows-stable/scripts/fix_6_14.ps1', \$env:temp + '\\fix_6_14.ps1')); &\$env:temp\\fix_6_14.ps1",

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -44,37 +44,13 @@ describe 'datadog_agent::redhat' do
         is_expected.not_to contain_yumrepo('datadog6')
       end
     end
-    context 'overriding provider' do
-      let(:params) do
-        {
-          service_provider: 'upstart',
-          agent_major_version: 5,
-        }
-      end
-
-      it do
-        is_expected.to contain_service('datadog-agent')\
-          .that_requires('package[datadog-agent]')
-      end
-      it do
-        is_expected.to contain_service('datadog-agent').with(
-          'provider' => 'upstart',
-          'ensure' => 'running',
-        )
-      end
-    end
-
     # it should install the packages
     it do
       is_expected.to contain_package('datadog-agent')\
         .with_ensure('latest')
     end
 
-    # it should be able to start the service and enable the service by default
-    it do
-      is_expected.to contain_service('datadog-agent')\
-        .that_requires('Package[datadog-agent]')
-    end
+
   end
 
   context 'agent 6' do
@@ -115,25 +91,6 @@ describe 'datadog_agent::redhat' do
         is_expected.not_to contain_yumrepo('datadog6')
       end
     end
-    context 'overriding provider' do
-      let(:params) do
-        {
-          service_provider: 'upstart',
-          agent_major_version: 6,
-        }
-      end
-
-      it do
-        is_expected.to contain_service('datadog-agent')\
-          .that_requires('package[datadog-agent]')
-      end
-      it do
-        is_expected.to contain_service('datadog-agent').with(
-          'provider' => 'upstart',
-          'ensure' => 'running',
-        )
-      end
-    end
 
     # it should install the packages
     it do
@@ -141,11 +98,6 @@ describe 'datadog_agent::redhat' do
         .with_ensure('latest')
     end
 
-    # it should be able to start the service and enable the service by default
-    it do
-      is_expected.to contain_service('datadog-agent')\
-        .that_requires('Package[datadog-agent]')
-    end
   end
 
   context 'agent 7' do
@@ -187,25 +139,6 @@ describe 'datadog_agent::redhat' do
         is_expected.not_to contain_yumrepo('datadog6')
       end
     end
-    context 'overriding provider' do
-      let(:params) do
-        {
-          service_provider: 'upstart',
-          agent_major_version: 7,
-        }
-      end
-
-      it do
-        is_expected.to contain_service('datadog-agent')\
-          .that_requires('package[datadog-agent]')
-      end
-      it do
-        is_expected.to contain_service('datadog-agent').with(
-          'provider' => 'upstart',
-          'ensure' => 'running',
-        )
-      end
-    end
 
     # it should install the packages
     it do
@@ -213,10 +146,5 @@ describe 'datadog_agent::redhat' do
         .with_ensure('latest')
     end
 
-    # it should be able to start the service and enable the service by default
-    it do
-      is_expected.to contain_service('datadog-agent')\
-        .that_requires('Package[datadog-agent]')
-    end
   end
 end

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -49,8 +49,6 @@ describe 'datadog_agent::redhat' do
       is_expected.to contain_package('datadog-agent')\
         .with_ensure('latest')
     end
-
-
   end
 
   context 'agent 6' do
@@ -97,7 +95,6 @@ describe 'datadog_agent::redhat' do
       is_expected.to contain_package('datadog-agent')\
         .with_ensure('latest')
     end
-
   end
 
   context 'agent 7' do
@@ -145,6 +142,5 @@ describe 'datadog_agent::redhat' do
       is_expected.to contain_package('datadog-agent')\
         .with_ensure('latest')
     end
-
   end
 end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -134,6 +134,27 @@ describe 'datadog_agent' do
     end
   end
 
+  context 'service' do
+    it do
+      is_expected.to contain_service('datadog-agent').with('ensure' => 'running').that_requires('package[datadog-agent]')
+    end
+  end
+
+  context 'service overriding provider' do
+    let(:params) do
+      {
+        service_provider: 'systemd',
+      }
+    end
+    it do
+      is_expected.to contain_service('datadog-agent').with(
+        'provider' => 'systemd',
+        'ensure' => 'running',
+      )
+    end
+  end
+
+
   # Test all supported OSes
   context 'all supported operating systems' do
     ALL_OS.each do |operatingsystem|

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -134,30 +134,44 @@ describe 'datadog_agent' do
     end
   end
 
-  context 'service' do
-    it do
-      is_expected.to contain_service('datadog-agent').with('ensure' => 'running').that_requires('package[datadog-agent]')
-    end
-  end
-
-  context 'service overriding provider' do
-    let(:params) do
-      {
-        service_provider: 'systemd',
-      }
-    end
-
-    it do
-      is_expected.to contain_service('datadog-agent').with(
-        'provider' => 'systemd',
-        'ensure' => 'running',
-      )
-    end
-  end
-
   # Test all supported OSes
   context 'all supported operating systems' do
     ALL_OS.each do |operatingsystem|
+      let(:facts) do
+        {
+          operatingsystem: operatingsystem,
+          osfamily: getosfamily(operatingsystem),
+        }
+      end
+
+      if WINDOWS_OS.include?(operatingsystem)
+        describe 'starts service on #{operatingsystem}' do
+          it do
+            is_expected.to contain_service('datadogagent').with('ensure' => 'running').that_requires('package[Datadog Agent]')
+          end
+        end
+      else
+        describe 'starts service on #{operatingsystem}' do
+          it do
+            is_expected.to contain_service('datadog-agent').with('ensure' => 'running').that_requires('package[datadog-agent]')
+          end
+        end
+        describe 'starts service overriding provider on #{operatingsystem}' do
+          let(:params) do
+            {
+              service_provider: 'systemd',
+            }
+          end
+
+          it do
+            is_expected.to contain_service('datadog-agent').with(
+              'provider' => 'systemd',
+              'ensure' => 'running',
+            )
+          end
+        end
+      end
+
       describe "datadog_agent 5 class common actions on #{operatingsystem}" do
         let(:params) do
           {
@@ -1502,25 +1516,6 @@ describe 'datadog_agent' do
                   )
                 }
               end
-
-              context 'with service provider override' do
-                let(:params) do
-                  {
-                    service_provider: 'upstart',
-                  }
-                end
-
-                it do
-                  is_expected.to contain_service('datadog-agent')\
-                    .that_requires('package[datadog-agent]')
-                end
-                it do
-                  is_expected.to contain_service('datadog-agent').with(
-                    'provider' => 'upstart',
-                    'ensure' => 'running',
-                  )
-                end
-              end
             end
           end
 
@@ -1548,7 +1543,7 @@ describe 'datadog_agent' do
         end
       end
 
-      describe "datadog_agent 6 class with reports on #{operatingsystem}" do
+      describe "datadog_agent 6/7 class with reports on #{operatingsystem}" do
         let(:params) do
           {
             puppet_run_reports: true,
@@ -1574,7 +1569,7 @@ describe 'datadog_agent' do
         end
       end
 
-      describe "datadog_agent 6 class common actions on #{operatingsystem}" do
+      describe "datadog_agent 6/7 class common actions on #{operatingsystem}" do
         let(:params) do
           {
             puppet_run_reports: false,
@@ -2096,27 +2091,6 @@ describe 'datadog_agent' do
                   'content' => %r{^logs_config:\n\ \ container_collect_all: true\n},
                 )
               }
-            end
-
-            unless WINDOWS_OS.include?(operatingsystem)
-              context 'with service provider override' do
-                let(:params) do
-                  {
-                    service_provider: 'upstart',
-                  }
-                end
-
-                it do
-                  is_expected.to contain_service('datadog-agent')\
-                    .that_requires('package[datadog-agent]')
-                end
-                it do
-                  is_expected.to contain_service('datadog-agent').with(
-                    'provider' => 'upstart',
-                    'ensure' => 'running',
-                  )
-                end
-              end
             end
           end
         end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -146,6 +146,7 @@ describe 'datadog_agent' do
         service_provider: 'systemd',
       }
     end
+
     it do
       is_expected.to contain_service('datadog-agent').with(
         'provider' => 'systemd',
@@ -153,7 +154,6 @@ describe 'datadog_agent' do
       )
     end
   end
-
 
   # Test all supported OSes
   context 'all supported operating systems' do

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -62,30 +62,6 @@ describe 'datadog_agent::ubuntu' do
         .that_requires('exec[apt_update]')
     end
 
-    # it should be able to start the service and enable the service by default
-    it do
-      is_expected.to contain_service('datadog-agent')\
-        .that_requires('package[datadog-agent]')
-    end
-
-    context 'overriding provider' do
-      let(:params) do
-        {
-          service_provider: 'upstart',
-        }
-      end
-
-      it do
-        is_expected.to contain_service('datadog-agent')\
-          .that_requires('package[datadog-agent]')
-      end
-      it do
-        is_expected.to contain_service('datadog-agent').with(
-          'provider' => 'upstart',
-          'ensure' => 'running',
-        )
-      end
-    end
   end
 
   context 'agent 6' do
@@ -133,30 +109,6 @@ describe 'datadog_agent::ubuntu' do
         .that_requires('exec[apt_update]')
     end
 
-    # it should be able to start the service and enable the service by default
-    it do
-      is_expected.to contain_service('datadog-agent')\
-        .that_requires('package[datadog-agent]')
-    end
-
-    context 'overriding provider' do
-      let(:params) do
-        {
-          service_provider: 'upstart',
-        }
-      end
-
-      it do
-        is_expected.to contain_service('datadog-agent')\
-          .that_requires('package[datadog-agent]')
-      end
-      it do
-        is_expected.to contain_service('datadog-agent').with(
-          'provider' => 'upstart',
-          'ensure' => 'running',
-        )
-      end
-    end
   end
 
   context 'agent 7' do
@@ -204,29 +156,5 @@ describe 'datadog_agent::ubuntu' do
         .that_requires('exec[apt_update]')
     end
 
-    # it should be able to start the service and enable the service by default
-    it do
-      is_expected.to contain_service('datadog-agent')\
-        .that_requires('package[datadog-agent]')
-    end
-
-    context 'overriding provider' do
-      let(:params) do
-        {
-          service_provider: 'upstart',
-        }
-      end
-
-      it do
-        is_expected.to contain_service('datadog-agent')\
-          .that_requires('package[datadog-agent]')
-      end
-      it do
-        is_expected.to contain_service('datadog-agent').with(
-          'provider' => 'upstart',
-          'ensure' => 'running',
-        )
-      end
-    end
   end
 end

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -61,7 +61,6 @@ describe 'datadog_agent::ubuntu' do
         .that_requires('file[/etc/apt/sources.list.d/datadog.list]')\
         .that_requires('exec[apt_update]')
     end
-
   end
 
   context 'agent 6' do
@@ -108,7 +107,6 @@ describe 'datadog_agent::ubuntu' do
         .that_requires('file[/etc/apt/sources.list.d/datadog6.list]')\
         .that_requires('exec[apt_update]')
     end
-
   end
 
   context 'agent 7' do
@@ -155,6 +153,5 @@ describe 'datadog_agent::ubuntu' do
         .that_requires('file[/etc/apt/sources.list.d/datadog6.list]')\
         .that_requires('exec[apt_update]')
     end
-
   end
 end


### PR DESCRIPTION
- Add `manage_install` parameter to disable installing the Agent
- Split service and repo management, since service code is the same for all Linuxes while repo code is not.

Fixes: #476
Fixes: #604