### PR TITLE
Add manage_dogapi_gem, making the management of ruby in reports optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,7 @@
 #   $puppet_run_reports
 #       Will send results from your puppet agent runs back to the datadog service.
 #   $manage_dogapi_gem
-#       Invoke the ruby class to manage ruby install
+#       When reports are enabled, ensure the dogapi gem (required) is installed.
 #   $puppetmaster_user
 #       Will chown the api key used by the report processor to this user.
 #       Defaults to the user the puppetmaster is configured to run as.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@
 #       the scheme: "fact_name:fact_value".
 #   $puppet_run_reports
 #       Will send results from your puppet agent runs back to the datadog service.
-#   $manage_ruby
+#   $manage_dogapi_gem
 #       Invoke the ruby class to manage ruby install
 #   $puppetmaster_user
 #       Will chown the api key used by the report processor to this user.
@@ -245,7 +245,7 @@ class datadog_agent(
   $service_ensure = 'running',
   $service_enable = true,
   Boolean $manage_repo = true,
-  Boolean $manage_ruby = true,
+  Boolean $manage_dogapi_gem = true,
   $hostname_extraction_regex = undef,
   Boolean $hostname_fqdn = false,
   $dogstatsd_port = 8125,
@@ -709,7 +709,7 @@ class datadog_agent(
     class { 'datadog_agent::reports':
       api_key                   => $api_key,
       datadog_site              => $datadog_site,
-      manage_ruby               => $manage_ruby,
+      manage_dogapi_gem         => $manage_dogapi_gem,
       puppet_gem_provider       => $puppet_gem_provider,
       dogapi_version            => $datadog_agent::params::dogapi_version,
       puppetmaster_user         => $puppetmaster_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,8 @@
 #       the scheme: "fact_name:fact_value".
 #   $puppet_run_reports
 #       Will send results from your puppet agent runs back to the datadog service.
+#   $manage_ruby
+#       Invoke the ruby class to manage ruby install
 #   $puppetmaster_user
 #       Will chown the api key used by the report processor to this user.
 #       Defaults to the user the puppetmaster is configured to run as.
@@ -243,6 +245,7 @@ class datadog_agent(
   $service_ensure = 'running',
   $service_enable = true,
   Boolean $manage_repo = true,
+  Boolean $manage_ruby = true,
   $hostname_extraction_regex = undef,
   Boolean $hostname_fqdn = false,
   $dogstatsd_port = 8125,
@@ -706,6 +709,7 @@ class datadog_agent(
     class { 'datadog_agent::reports':
       api_key                   => $api_key,
       datadog_site              => $datadog_site,
+      manage_ruby               => $manage_ruby,
       puppet_gem_provider       => $puppet_gem_provider,
       dogapi_version            => $datadog_agent::params::dogapi_version,
       puppetmaster_user         => $puppetmaster_user,

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -17,7 +17,7 @@ class datadog_agent::reports(
   $api_key,
   $puppetmaster_user,
   $dogapi_version,
-  $manage_ruby = true,
+  $manage_dogapi_gem = true,
   $hostname_extraction_regex = undef,
   $datadog_site = 'datadoghq.com',
   $puppet_gem_provider = $datadog_agent::params::gem_provider,
@@ -31,7 +31,7 @@ class datadog_agent::reports(
 
     include datadog_agent
 
-    if $manage_ruby {
+    if $manage_dogapi_gem {
       $rubydev_package = $datadog_agent::params::rubydev_package
 
       # check to make sure that you're not installing rubydev somewhere else

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -29,8 +29,9 @@ class datadog_agent::reports(
 
   } else {
 
+    include datadog_agent
+
     if $manage_ruby {
-      include datadog_agent
       $rubydev_package = $datadog_agent::params::rubydev_package
 
       # check to make sure that you're not installing rubydev somewhere else

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -197,7 +197,7 @@ describe 'datadog_agent::reports' do
         dogapi_version: 'installed',
         puppetmaster_user: 'puppet',
         puppet_gem_provider: 'gem',
-        manage_ruby: false,
+        manage_dogapi_gem: false,
       }
     end
 

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -188,4 +188,41 @@ describe 'datadog_agent::reports' do
       it { is_expected.to contain_file(conf_file).without_content(%r{hostname_extraction_regex:}) }
     end
   end
+
+  context 'disabled ruby-manage' do
+    let(:params) do
+      {
+        api_key: 'notanapikey',
+        hostname_extraction_regex: nil,
+        dogapi_version: 'installed',
+        puppetmaster_user: 'puppet',
+        puppet_gem_provider: 'gem',
+        manage_ruby: false,
+      }
+    end
+
+    describe 'datadog_agent class dogapi version override' do
+      let(:facts) do
+        {
+          operatingsystem: 'Debian',
+          osfamily: 'debian',
+        }
+      end
+
+      it { is_expected.not_to contain_class('ruby').with_rubygems_update(false) }
+      it { is_expected.not_to contain_class('ruby::params') }
+      it { is_expected.not_to contain_package('ruby').with_ensure('installed') }
+      it { is_expected.not_to contain_package('rubygems').with_ensure('installed') }
+
+      it { is_expected.not_to contain_package('ruby-dev') }
+
+      it { is_expected.not_to contain_package('dogapi') }
+
+      it do
+        is_expected.to contain_file('/etc/datadog-agent/datadog-reports.yaml')\
+          .with_owner('puppet')\
+          .with_group('root')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Rebase of https://github.com/DataDog/puppet-datadog-agent/pull/227

Also included installing dogapi within the conditional. Since the code that we are making optional was there solely (if I understand correctly) to be able to install dogapi, it makes sense to me to treat it all together.

I'm not sure the name `manage_ruby` still makes sense though, maybe something like `manage_dogapi_gem` would be better?