### PR TITLE
Add init_config argument to process integration

### DIFF
--- a/manifests/integrations/process.pp
+++ b/manifests/integrations/process.pp
@@ -42,6 +42,7 @@
 #
 class datadog_agent::integrations::process(
   Boolean $hiera_processes = false,
+  $init_config = {},
   Array $processes = [],
   ) inherits datadog_agent::params {
   include datadog_agent

--- a/templates/agent-conf.d/process.yaml.erb
+++ b/templates/agent-conf.d/process.yaml.erb
@@ -64,4 +64,4 @@
 require 'yaml'
 %>
 
-<%= {'init_config'=>nil, 'instances'=>@local_processes}.to_yaml %>
+<%= {'init_config'=>@init_config, 'instances'=>@local_processes}.to_yaml %>


### PR DESCRIPTION
allow to change "init_config" settings, like
 class { 'datadog_agent::integrations::process':
    init_config => {
      'pid_cache_duration'                 => 5,
      'shared_process_list_cache_duration' => 5,
    },