### PR TITLE
Fixes CONTRIBUTING.md links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,13 +28,13 @@ pre-commit install
 
 ### Manual testing
 
-To test the roles provided by this project, you can follow the instructions in the manual tests [readme.md](./environments/readme.md).
+To test the roles provided by this project, you can follow the instructions in the manual tests [readme.md](./environments/README.md).
 
 ### Integration testing
 
 This project uses [Kitchen](https://github.com/test-kitchen/test-kitchen) as its integration tests engine. To really verify integration tests, you should have [Vagrant](https://www.vagrantup.com/) installed on your machine as it is used as a driver-engine.
 
-Kitchen allows you to test specific recipes described in [kitchen.yml](./kitchen.yml). For now, there is only a basic one on Ubuntu, but that should be enough to develop others or to add features in TDD.
+Kitchen allows you to test specific recipes described in [kitchen.yml](./.kitchen.yml). For now, there is only a basic one on Ubuntu, but that should be enough to develop others or to add features in TDD.
 
 To list available targets, you can use the `list` command:
 


### PR DESCRIPTION
Some links were broken because of a previous reordering of files.
This PR fixes them.