### PR TITLE
Add install_info file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -384,6 +384,8 @@ class datadog_agent(
     $local_integrations = $integrations
   }
 
+  $_puppetversion = lookup({ 'name' => '::puppetversion', 'default_value' => 'unknown'})
+
   include datadog_agent::params
   case upcase($log_level) {
     'CRITICAL': { $_loglevel = 'CRITICAL' }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -558,6 +558,15 @@ class datadog_agent(
         order   => '08',
       }
     }
+
+    file {'/etc/dd-agent/install_info':
+      owner   => $dd_user,
+      group   => $dd_group,
+      mode    => '0640',
+      content => template('datadog_agent/install_info.erb'),
+      require => File['/etc/dd-agent'],
+    }
+
   } else { #Agent 6/7
 
     # notify of broken params on agent6/7
@@ -714,6 +723,14 @@ class datadog_agent(
         require => File['C:/ProgramData/Datadog'],
       }
 
+      file { 'C:/ProgramData/Datadog/install_info':
+        owner   => $dd_user,
+        group   => $dd_group,
+        mode    => '0660',
+        content => template('datadog_agent/install_info.erb'),
+        require => File['C:/ProgramData/Datadog'],
+      }
+
     } else {
 
       file { '/etc/datadog-agent/datadog.yaml':
@@ -722,6 +739,14 @@ class datadog_agent(
         mode    => '0640',
         content => template('datadog_agent/datadog.yaml.erb'),
         notify  => Service[$datadog_agent::params::service_name],
+        require => File['/etc/datadog-agent'],
+      }
+
+      file { '/etc/datadog-agent/install_info':
+        owner   => $dd_user,
+        group   => $dd_group,
+        mode    => '0640',
+        content => template('datadog_agent/install_info.erb'),
         require => File['/etc/datadog-agent'],
       }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class datadog_agent::params {
   $apt_backup_keyserver           = 'hkp://pool.sks-keyservers.net:80'
   $apt_keyserver                  = 'hkp://keyserver.ubuntu.com:80'
   $sysprobe_service_name          = 'datadog-agent-sysprobe'
+  $module_metadata                = load_module_metadata($module_name)
 
   case $::operatingsystem {
     'Ubuntu','Debian' : {

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -1592,16 +1592,36 @@ describe 'datadog_agent' do
 
         config_dir = WINDOWS_OS.include?(operatingsystem) ? 'C:/ProgramData/Datadog' : '/etc/datadog-agent'
         config_yaml_file = config_dir + '/datadog.yaml'
+        install_info_file = config_dir + '/install_info'
         log_file = WINDOWS_OS.include?(operatingsystem) ? 'C:/ProgramData/Datadog/logs/agent.log' : '\/var\/log\/datadog\/agent.log'
 
         it { is_expected.to contain_file(config_dir) }
         it { is_expected.to contain_file(config_yaml_file) }
+        it { is_expected.to contain_file(install_info_file) }
         it { is_expected.to contain_file(config_dir + '/conf.d').with_ensure('directory') }
 
         # Agent 5 files
         it { is_expected.not_to contain_file('/etc/dd-agent') }
         it { is_expected.not_to contain_concat('/etc/dd-agent/datadog.conf') }
         it { is_expected.not_to contain_file('/etc/dd-agent/conf.d').with_ensure('directory') }
+
+        describe 'install_info check' do
+          it {
+            is_expected.to contain_file(install_info_file).with(
+              'content' => %r{^\ \ tool:puppet\n},
+            )
+          }
+          it {
+            is_expected.to contain_file(install_info_file).with(
+              'content' => %r{^\ \ tool_version:puppet-[0-9]\.[0-9]\.[0-9]\n},
+            )
+          }
+          it {
+            is_expected.to contain_file(install_info_file).with(
+              'content' => %r{^\ \ installer_version:datadog_module-[0-9]\.[0-9]\.[0-9]\n},
+            )
+          }
+        end
 
         describe 'agent6 parameter check' do
           context 'with defaults' do

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -1608,17 +1608,17 @@ describe 'datadog_agent' do
         describe 'install_info check' do
           it {
             is_expected.to contain_file(install_info_file).with(
-              'content' => %r{^\ \ tool:puppet\n},
+              'content' => %r{^\ \ tool:\s*puppet\n},
             )
           }
           it {
             is_expected.to contain_file(install_info_file).with(
-              'content' => %r{^\ \ tool_version:puppet-[0-9]\.[0-9]\.[0-9]\n},
+              'content' => %r{^\ \ tool_version:\s*puppet-(\d\.\d\.\d|unknown)\n},
             )
           }
           it {
             is_expected.to contain_file(install_info_file).with(
-              'content' => %r{^\ \ installer_version:datadog_module-[0-9]\.[0-9]\.[0-9]\n},
+              'content' => %r{^\ \ installer_version:\s*datadog_module-\d\.\d\.\d\n},
             )
           }
         end

--- a/templates/install_info.erb
+++ b/templates/install_info.erb
@@ -1,0 +1,5 @@
+---
+install_method:
+  tool: puppet
+  tool_version: puppet-<%= @puppetversion %>
+  installer_version: datadog_module-<%= @module_metadata['version'] %>

--- a/templates/install_info.erb
+++ b/templates/install_info.erb
@@ -1,5 +1,5 @@
 ---
 install_method:
   tool: puppet
-  tool_version: puppet-<%= @puppetversion %>
+  tool_version: puppet-<%= @_puppetversion %>
   installer_version: datadog_module-<%= @module_metadata['version'] %>


### PR DESCRIPTION
### What does this PR do?
<!--A brief description of the change being made with this pull request.-->
Creates `install_info` file with information about the install method used (overwrites any other existing file).

### Describe your test plan

I added some spec tests. Unfortunately in the test environment one can't get the puppet version, so that has to be tested manually:
<!--Write there any instructions and details you may have to test your PR.-->
- Checkout this branch and run `pdk build` to create a .tar.gz of this version
- Install it using `sudo puppet module install <path to tar>`
- Apply it following the repo README
- Check that the `install_info` file was created with correct content and permissions