### PR TITLE
Pass proxy configuration from agent_extra_options to dogapi

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -14,6 +14,13 @@ Puppet::Reports.register_report(:datadog_reports) do
   API_KEY = config[:datadog_api_key]
   API_URL = config[:api_url]
 
+  if ENV['DD_PROXY_HTTP'].nil?
+    ENV['DD_PROXY_HTTP'] = config[:proxy_http]
+  end
+  if ENV['DD_PROXY_HTTPS'].nil?
+    ENV['DD_PROXY_HTTPS'] = config[:proxy_https]
+  end
+
   # if need be initialize the regex
   if !config[:hostname_extraction_regex].nil?
     begin

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -730,6 +730,15 @@ class datadog_agent(
   }
 
   if $puppet_run_reports {
+    $proxy_config = $agent_extra_options[proxy]
+    if $proxy_config != undef {
+      $proxy_http = $proxy_config[http]
+      $proxy_https = $proxy_config[https]
+    } else {
+      $proxy_http = undef
+      $proxy_https = undef
+    }
+
     class { 'datadog_agent::reports':
       api_key                   => $api_key,
       datadog_site              => $datadog_site,
@@ -738,6 +747,8 @@ class datadog_agent(
       dogapi_version            => $datadog_agent::params::dogapi_version,
       puppetmaster_user         => $puppetmaster_user,
       hostname_extraction_regex => $hostname_extraction_regex,
+      proxy_http                => $proxy_http,
+      proxy_https               => $proxy_https,
     }
   }
 

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -19,6 +19,8 @@ class datadog_agent::reports(
   $dogapi_version,
   $manage_dogapi_gem = true,
   $hostname_extraction_regex = undef,
+  $proxy_http = undef,
+  $proxy_https = undef,
   $datadog_site = 'datadoghq.com',
   $puppet_gem_provider = $datadog_agent::params::gem_provider,
 ) inherits datadog_agent::params {

--- a/templates/datadog-reports.yaml.erb
+++ b/templates/datadog-reports.yaml.erb
@@ -6,3 +6,9 @@
 <% if @hostname_extraction_regex -%>
 :hostname_extraction_regex: '<%= @hostname_extraction_regex %>'
 <% end -%>
+<% if @proxy_http -%>
+:proxy_http: <%= @proxy_http %>
+<% end -%>
+<% if @proxy_https -%>
+:proxy_https: <%= @proxy_https %>
+<% end -%>


### PR DESCRIPTION
### What does this PR do?

In case the Agent is configured to use a proxy, use the same proxy when calling dogapi to send puppet reports.

### Motivation

When behind a proxy, users had to configure it twice: once in their puppet manifest for the Agent to use, and another time as environment variables for puppetserver (which ends up calling dogapi). This makes the second step no longer needed.

### Additional Notes

This is technically a breaking change, but I can't imagine a scenario where the previous behaviour is wanted.

### Describe your test plan

Tested by modifying dogapi to log the value of the proxy and checking the value in agent_extra_options got there.
