### PR TITLE
Update MSI validation resource to prevent false change reports

### DIFF
--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -39,12 +39,32 @@ class datadog_agent::windows(
       provider => 'windows',
     }
 
+<<<<<<< HEAD
+    exec { 'assert-acceptable-msi':,
+      command   => 'Exit 1',
+      unless    => @(ACCEPTABLE),
+=======
     exec { 'validate':
-      command   => "\$blacklist = '928b00d2f952219732cda9ae0515351b15f9b9c1ea1d546738f9dc0fda70c336','78b2bb2b231bcc185eb73dd367bfb6cb8a5d45ba93a46a7890fd607dc9188194';\$fileStream = [system.io.file]::openread('${msi_full_path}'); \$hasher = [System.Security.Cryptography.HashAlgorithm]::create('sha256'); \$hash = \$hasher.ComputeHash(\$fileStream); \$fileStream.close(); \$fileStream.dispose();\$hexhash = [system.bitconverter]::tostring(\$hash).ToLower().replace('-','');if (\$blacklist.Contains(\$hexhash)) { Exit 1 }",
+      command => 'write-output 'Exit 1'',
       provider  => 'powershell',
       logoutput => 'on_failure',
       require   => File['installer'],
-      notify    => Package[$datadog_agent::params::package_name]
+      notify    => Package[$datadog_agent::params::package_name],
+      onlyif    => @(SCRIPT)
+>>>>>>> f11f5e9... Update windows.pp
+        $blacklist = '928b00d2f952219732cda9ae0515351b15f9b9c1ea1d546738f9dc0fda70c336','78b2bb2b231bcc185eb73dd367bfb6cb8a5d45ba93a46a7890fd607dc9188194';
+        $fileStream = [system.io.file]::openread('${msi_full_path}');
+        $hasher = [System.Security.Cryptography.HashAlgorithm]::create('sha256');
+        $hash = $hasher.ComputeHash($fileStream);
+        $fileStream.close();
+        $fileStream.dispose();
+        $hexhash = [system.bitconverter]::tostring($hash).ToLower().replace('-','');
+        if ($blacklist.Contains($hexhash)) { Exit 1 } else { Exit 0 }
+        | ACCEPTABLE
+      provider  => 'powershell',
+      logoutput => 'on_failure',
+      require   => File['installer'],
+      notify    => Package[$datadog_agent::params::package_name],
     }
 
     if $agent_version == 'latest' {


### PR DESCRIPTION
### What does this PR do?

The MSI validation resource (Exec) currently reports corrective change on each run.  This modifies the resource with an unless parameter to prevent false positives on reporting.

### Motivation

Working on this integration for a customer.

### Additional Notes

n/a

### Describe your test plan

I tested this on Windows 2016 and 2019 in my lab.
