### PR TITLE
Add some more logging to puppet reports

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -64,6 +64,7 @@ Puppet::Reports.register_report(:datadog_reports) do
         @msg_host = m[:hostname]
       end
     end
+    Puppet.info "Processing reports for #{@msg_host}"
 
     event_title = ''
     alert_type = ''


### PR DESCRIPTION
### What does this PR do?

Add an `info` log line for each host we receive reports about.

### Motivation

Help with debugging.

