### PR TITLE
Update report processor to add tag function based on Puppet facts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,18 @@ Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaste
     - To support reporting, your Puppet master needs the [dogapi][3] gem installed by running the Puppet Agent on your master with this configuration or installing it manually with `gem`. You may need to restart your `puppetserver` service after installing the `dogapi` gem.
     - `puppetserver_gem` is defined as a module dependency. It is installed automatically when the module is installed.
 
-4. (Optional) Include integrations to use with the Agent, for example:
+4. (Optional) Enable tagging of reports with facts
+    Tags can be added to reports that are sent to DataDog as Events.  These tags can be sourced from Puppet facts for the given node the report is regarding.  These should be 1:1 and not involve strcutured facts (hashes, array's, etc) to ensure readability. To enable simply set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts - for example `["virtual","trusted.extensions.pp_role","operatingsystem"]` will result in 3 separate tags per report event.
+
+    NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(S).
+
+    Tips:
+    - Use dot index to specific a target fact, otherwise the entire fact data set will become the value as a string (not very useful)
+    - Do not duplicate common data from monitoring like hostname, uptime, memory, etc
+    - Coordinate core facts like role, owner, template, datacenter that help you build meaningful coorlation to the same tags from metrics
+
+
+5. (Optional) Include integrations to use with the Agent, for example:
 
    ```conf
    include 'datadog_agent::integrations::mongo'

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaste
     - `puppetserver_gem` is defined as a module dependency. It is installed automatically when the module is installed.
 
 4. (Optional) Enable tagging of reports with facts
-    Tags can be added to reports that are sent to DataDog as Events.  These tags can be sourced from Puppet facts for the given node the report is regarding.  These should be 1:1 and not involve strcutured facts (hashes, array's, etc) to ensure readability. To enable simply set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts - for example `["virtual","trusted.extensions.pp_role","operatingsystem"]` will result in 3 separate tags per report event.
+    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","trusted.extensions.pp_role","operatingsystem"]` results in three separate tags per report event.
 
-    NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(S).
+    NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(s).
 
     Tips:
-    - Use dot index to specific a target fact, otherwise the entire fact data set will become the value as a string (not very useful)
-    - Do not duplicate common data from monitoring like hostname, uptime, memory, etc
-    - Coordinate core facts like role, owner, template, datacenter that help you build meaningful coorlation to the same tags from metrics
+    - Use dot index to specify a target fact; otherwise, the entire fact data set becomes the value as a string (not very useful)
+    - Do not duplicate common data from monitoring like hostname, uptime, memory, etc.
+    - Coordinate core facts like role, owner, template, datacenter, etc., that help you build meaningful correlations to the same tags from metrics
 
 
 5. (Optional) Include integrations to use with the Agent, for example:

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -13,6 +13,7 @@ Puppet::Reports.register_report(:datadog_reports) do
   config = YAML.load_file(configfile)
   API_KEY = config[:datadog_api_key]
   API_URL = config[:api_url]
+  REPORT_FACT_TAGS = config[:report_fact_tags] || []
 
   if ENV['DD_PROXY_HTTP'].nil?
     ENV['DD_PROXY_HTTP'] = config[:proxy_http]
@@ -128,6 +129,9 @@ Puppet::Reports.register_report(:datadog_reports) do
       end
     end
 
+    facts = Puppet::Node::Facts.indirection.find(host).values
+    dog_tags = REPORT_FACT_TAGS.map { |name| "#{name}:#{facts.dig(*name.split('.'))}" }
+
     Puppet.debug "Sending events for #{@msg_host} to Datadog"
     @dog.emit_event(Dogapi::Event.new(event_data,
                                       msg_title: event_title,
@@ -135,6 +139,8 @@ Puppet::Reports.register_report(:datadog_reports) do
                                       event_object: @msg_host,
                                       alert_type: alert_type,
                                       priority: event_priority,
-                                      source_type_name: 'puppet'), host: @msg_host)
+                                      source_type_name: 'puppet',
+                                      tags: dog_tags),
+                                      host: @msg_host)
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,8 @@
 #       Valid values here are: true or false.
 #   $dogstatsd_port
 #       Set value of the 'dogstatsd_port' variable. Defaultis 8125.
+#   $report_fact_tags
+#       Sets tags for report events sent to Datadog from specified facts
 #   $statsd_forward_host
 #       Set the value of the statsd_forward_host varable. Used to forward all
 #       statsd metrics to another host.
@@ -776,6 +778,7 @@ class datadog_agent(
       hostname_extraction_regex => $hostname_extraction_regex,
       proxy_http                => $proxy_http,
       proxy_https               => $proxy_https,
+      report_fact_tags          => $report_fact_tags,
     }
   }
 

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -21,6 +21,7 @@ class datadog_agent::reports(
   $hostname_extraction_regex = undef,
   $proxy_http = undef,
   $proxy_https = undef,
+  $report_fact_tags = [],
   $datadog_site = 'datadoghq.com',
   $puppet_gem_provider = $datadog_agent::params::gem_provider,
 ) inherits datadog_agent::params {

--- a/templates/datadog-reports.yaml.erb
+++ b/templates/datadog-reports.yaml.erb
@@ -12,3 +12,10 @@
 <% if @proxy_https -%>
 :proxy_https: <%= @proxy_https %>
 <% end -%>
+<% if @report_fact_tags -%>
+#:report_fact_tags: <%= @report_fact_tags %>
+:report_fact_tags:
+<%- @report_fact_tags.each do |tag| -%>
+  - <%= tag %>
+  <%- end -%>
+<% end -%>

--- a/templates/datadog-reports.yaml.erb
+++ b/templates/datadog-reports.yaml.erb
@@ -13,7 +13,6 @@
 :proxy_https: <%= @proxy_https %>
 <% end -%>
 <% if @report_fact_tags -%>
-#:report_fact_tags: <%= @report_fact_tags %>
 :report_fact_tags:
 <%- @report_fact_tags.each do |tag| -%>
   - <%= tag %>


### PR DESCRIPTION
Modify report class to manage report tags from facts through Datadog
config yaml file.

### What does this PR do?

This PR enables a new parameter to be set that specifies which Puppet facts will be added as tags to each report sent to DataDog as an event.

### Motivation

Working with a customer we found that correlating DataDog events and metrics was challenging and using Puppet Facts would simplify this problem.

### Additional Notes

This is outside my typical expertise and as such I would request detailed review/comments/opinions/testing from anyone.

### Describe your test plan

Using a current release of Datadog and Puppet Enterprise at the time of this PR I validated functionality and updated the readme with specific tips and note on how to use. I modified the values, deployed the Puppet code, restarted puppetserver service, and validated the new facts were appearing on the next Puppet run reports in Datadog. 
