### PR TITLE
Readme refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaste
     }
     ```
 
-    Refer to the [comments in code][6] for all arguments available for the integration.
+    Refer to the [comments in code][6] for all arguments available for a given integration.
 
     If an integration does not have a [manifest with a dedicated class][7], you can still add a configuration for it. Below is an example for the `ntp` check:
 
@@ -141,7 +141,6 @@ To enable reporting of Puppet runs to your Datadog timeline, enable the report p
 
     [agent]
     # ...
-    pluginsync=true
     report=true
     ```
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This module installs the Datadog Agent and sends Puppet reports to Datadog.
 
-## Setup
-
 ### Requirements
 
 The Datadog Puppet module supports Linux and Windows and is compatible with Puppet >= 4.6.x or Puppet Enterprise version >= 2016.4. For detailed information on compatibility, check the [module page on Puppet Forge][1].
@@ -87,7 +85,7 @@ Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaste
 
 5. (Optional) To collect metrics and events about Puppet itself, refer to the section about [Reporting](#reporting).
 
-### Integration versions
+### Upgrading integrations
 
 To install and pin specific integration versions, use `datadog_agent::install_integration`. This calls the `datadog-agent integration` command to ensure a specific integration is installed or uninstalled, for example:
 
@@ -100,12 +98,12 @@ datadog_agent::install_integration { "mongo-1.9":
 }
 ```
 
-`ensure` has two options:
+The `ensure` argument can take two values:
 
 - `present` (default)
 - `absent` (removes a previously pinned version of an integration)
 
-To install a third-party integration set the `third_party` parameter to `true`.
+To install a third-party integration (eg: from the marketplace) set the `third_party` argument to `true`.
 
 Note it's not possible to downgrade an integration to a version older than the one bundled with the Agent.
 
@@ -207,8 +205,6 @@ If you see the following error, ensure `reports=datadog_reports` is defined in `
     puppet apply --modulepath <path_to_modules> <path_to_site.pp>
     ```
 
-## Client settings
-
 ### Tagging client nodes
 
 The Datadog Agent configuration file is recreated from the template every Puppet run. If you need to tag your nodes, add an array entry in Hiera:
@@ -232,7 +228,7 @@ Tips:
 
 ### Configuration variables
 
-These variables can be set in the `datadog_agent` class to control settings in the Agent. Refer to the [comments in code] for a full list of arguments:
+These variables can be set in the `datadog_agent` class to control settings in the Agent. Refer to the [comments in code][8] for the full list of supported arguments.
 
 | variable name                           | description                                                                                                                                                                                      |
 |-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -264,5 +260,6 @@ These variables can be set in the `datadog_agent` class to control settings in t
 [3]: https://github.com/DataDog/dogapi-rb
 [4]: https://app.datadoghq.com/account/settings#integrations
 [5]: https://app.datadoghq.com/event/stream
-[6]: https://github.com/DataDog/puppet-datadog-agent/blob/master/manifests/integrations/mongo.pp#L1
+[6]: https://github.com/DataDog/puppet-datadog-agent/blob/master/manifests/integrations/mongo.pp
 [7]: https://github.com/DataDog/puppet-datadog-agent/tree/master/manifests/integrations
+[8]: https://github.com/DataDog/puppet-datadog-agent/blob/master/manifests/init.pp

--- a/README.md
+++ b/README.md
@@ -16,14 +16,6 @@ Install the [datadog_agent][1] Puppet module in your Puppet master's module path
 puppet module install datadog-datadog_agent
 ```
 
-**Note**: For CentOS/RHEL versions <7.0 and for Ubuntu < 15.04, specify the service provider as `upstart`:
-
-```conf
-class{ 'datadog_agent':
-    service_provider => 'upstart'
-  }
-```
-
 #### Upgrading
 
 - By default Datadog Agent v7.x is installed. To use an earlier Agent version, change the setting `agent_major_version`.
@@ -39,68 +31,65 @@ class{ 'datadog_agent':
 Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaster` (or on a masterless host), follow these configuration steps:
 
 1. Obtain your [Datadog API key][2].
-2. Specify the module to install the Datadog Agent on your nodes.
+2. Add the Datadog class to your node manifests (eg: `/etc/puppetlabs/code/environments/production/manifests/site.pp`).
 
-   ```conf
-   include datadog_agent
-   ```
+    ```conf
+    class { 'datadog_agent':
+        api_key => "<YOUR_DD_API_KEY>",
+    }
+    ```
 
-    Or assign this module using the Puppet style Parameterized class:
+    If using a Datadog site other than the default 'datadoghq.com', set it here as well:
 
-   ```conf
-   class { 'datadog_agent':
-       api_key => "<YOUR_DD_API_KEY>",
-   }
-   ```
+    ```conf
+    class { 'datadog_agent':
+        api_key => "<YOUR_DD_API_KEY>",
+        datadog_site => "datadoghq.eu",
+    }
+    ```
 
-3. On your `puppetserver`, enable reporting:
+    For CentOS/RHEL versions <7.0 and for Ubuntu < 15.04, specify the service provider as `upstart`:
 
-   ```conf
-   class { 'datadog_agent':
-       api_key            => "<YOUR_DD_API_KEY>",
-       puppet_run_reports => true,
-   }
-   ```
+    ```conf
+    class { 'datadog_agent':
+        api_key => "<YOUR_DD_API_KEY>",
+        service_provider => 'upstart'
+    }
+    ```
 
-    - To support reporting, your Puppet master needs the [dogapi][3] gem installed by running the Puppet Agent on your master with this configuration or installing it manually with `gem`. You may need to restart your `puppetserver` service after installing the `dogapi` gem.
-    - `puppetserver_gem` is defined as a module dependency. It is installed automatically when the module is installed.
+    See the [Configuration variables](#configuration-variables) section for list of arguments you can use here.
 
-4. (Optional) Enable tagging of reports with facts
-    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","trusted.extensions.pp_role","operatingsystem"]` results in three separate tags per report event.
+4. (Optional) Include any integrations you want to use with the Agent. The following example installs the mongo integration:
 
-    NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(s).
+    ```conf
+    class { 'datadog_agent::integrations::mongo':
+        # integration arguments go here
+    }
+    ```
 
-    Tips:
-    - Use dot index to specify a target fact; otherwise, the entire fact data set becomes the value as a string (not very useful)
-    - Do not duplicate common data from monitoring like hostname, uptime, memory, etc.
-    - Coordinate core facts like role, owner, template, datacenter, etc., that help you build meaningful correlations to the same tags from metrics
+    Refer to the [comments in code][6] for all arguments available for the integration.
 
+    If an integration does not have a [manifest with a dedicated class][7], you can still add a configuration for it. Below is an example for the `ntp` check:
 
-5. (Optional) Include integrations to use with the Agent, for example:
+    ```conf
+    class { 'datadog_agent':
+        api_key      => "<YOUR_DD_API_KEY>",
+        integrations => {
+            "ntp" => {
+                init_config => {},
+                instances => [{
+                    offset_threshold => 30,
+                }],
+            },
+        },
+    }
+    ```
 
-   ```conf
-   include 'datadog_agent::integrations::mongo'
-   ```
+5. (Optional) To collect metrics and events about Puppet itself, refer to the section about [Reporting](#reporting).
 
-    If an integration does not have a [manifest with a dedicated class][6], you can still add a configuration for it. Below is an example for the `ntp` check:
+### Integration versions
 
-   ```conf
-   class { 'datadog_agent':
-       api_key      => "<YOUR_DD_API_KEY>",
-       integrations => {
-           "ntp" => {
-               init_config => {},
-               instances => [{
-                   offset_threshold => 30,
-               }],
-           },
-       },
-   }
-   ```
-
-#### Integration versions
-
-To install and pin specific integration versions, specify an integration and version number by using `datadog_agent::install_integration`. This uses the `datadog-agent integration` command to ensure a specific integration is installed or uninstalled, for example:
+To install and pin specific integration versions, use `datadog_agent::install_integration`. This calls the `datadog-agent integration` command to ensure a specific integration is installed or uninstalled, for example:
 
 ```conf
 datadog_agent::install_integration { "mongo-1.9":
@@ -118,100 +107,68 @@ datadog_agent::install_integration { "mongo-1.9":
 
 To install a third-party integration set the `third_party` parameter to `true`.
 
+Note it's not possible to downgrade an integration to a version older than the one bundled with the Agent.
+
 ### Reporting
 
-Ensure the [dogapi][3] gem is available on your system.
+To enable reporting of Puppet runs to your Datadog timeline, enable the report processor on your Puppet master and reporting for your clients. The clients send a run report after each check-in back to the master.
 
-To enable reporting of changes to your Datadog timeline, enable the report processor on your Puppet master and reporting for your clients. The clients send a run report after each check-in back to the master.
+1. Install the [dogapi][3] gem on your system.
 
-Set the `puppet_run_reports` option to true in the node configuration manifest for your master:
+2. Set the `puppet_run_reports` option to true in the node configuration manifest for your master:
 
-```ruby
-class { "datadog-agent":
-    api_key => "<YOUR_DD_API_KEY>",
-    puppet_run_reports => true
-    # ...
-}
-```
+    ```ruby
+    class { "datadog-agent":
+        api_key => "<YOUR_DD_API_KEY>",
+        puppet_run_reports => true
+        # ...
+    }
+    ```
 
-The Puppet configuration file is located in `/etc/puppetlabs/puppet/puppet.conf`.
-
-
-Add these configuration options to the appropriate location:
-
-```ini
-[main]
-# No modification needed to this section
-# ...
-
-[master]
-# Enable reporting to Datadog
-reports=datadog_reports
-# If you use other reports, add datadog_reports to the end,
-# for example: reports=store,log,datadog_reports
-# ...
-
-[agent]
-# ...
-pluginsync=true
-report=true
-```
-
-On all of your Puppet client nodes, add the following in the same location:
-
-```ini
-[agent]
-# ...
-report=true
-```
-
-#### Troubleshooting
-
-If you see the following error, ensure `reports=datadog_reports` is defined in `[master]`, not `[main]`.
-
-```text
-err: Could not send report:
-Error 400 on SERVER: Could not autoload datadog_reports:
-Class Datadog_reports is already defined in Puppet::Reports
-```
-
-### Step-by-step
-
-This is the minimal set of modifications to get started.
-
-1. Edit `/etc/puppetlabs/puppet/puppet.conf` to add the Puppet Agent:
+3. Add these configuration options to the Puppet master config (eg: `/etc/puppetlabs/puppet/puppet.conf`):
 
     ```ini
+    [main]
+    # No modification needed to this section
+    # ...
+
     [master]
-    report = true
-    reports = datadog_reports
-    pluginsync = true
+    # Enable reporting to Datadog
+    reports=datadog_reports
+    # If you use other reports, add datadog_reports to the end,
+    # for example: reports=store,log,datadog_reports
+    # ...
 
     [agent]
-    report = true
-    pluginsync = true
+    # ...
+    pluginsync=true
+    report=true
     ```
 
+4. On all of your Puppet client nodes, add the following in the same location:
 
-2. Edit `/etc/puppetlabs/code/environments/production/manifests/10_nodes.pp` to configure your Agent:
-
-    ```conf
-    node "default" {
-        class { "datadog_agent":
-            api_key => "<YOUR_DD_API_KEY>",
-        }
-    }
-    node "puppetmaster" {
-        class { "datadog_agent":
-            api_key            => "<YOUR_DD_API_KEY>",
-            puppet_run_reports => true
-        }
-    }
+    ```ini
+    [agent]
+    # ...
+    report=true
     ```
 
-     **Note**: For older versions of Puppet, edit `/etc/puppet/manifests/nodes.pp`.
+5. (Optional) Enable tagging of reports with facts:
 
-3. Run the Puppet Agent:
+    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","trusted.extensions.pp_role","operatingsystem"]` results in three separate tags per report event.
+
+    NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(s).
+
+    Tips:
+    - Use dot index to specify a target fact; otherwise, the entire fact data set becomes the value as a string (not very useful)
+    - Do not duplicate common data from monitoring like hostname, uptime, memory, etc.
+    - Coordinate core facts like role, owner, template, datacenter, etc., that help you build meaningful correlations to the same tags from metrics
+
+6. Verify your Puppet data is in Datadog by searching for `sources:puppet` in the [Event Stream][5].
+
+### Troubleshooting
+
+You can run the Puppet Agent manually to check for errors in the output:
 
     ```shell
     sudo systemctl restart puppetserver
@@ -227,9 +184,15 @@ This is the minimal set of modifications to get started.
     notice: Finished catalog run in 0.81 seconds
     ```
 
-4. Verify your Puppet data is in Datadog by searching for `sources:puppet` in the [Event Stream][5].
+If you see the following error, ensure `reports=datadog_reports` is defined in `[master]`, not `[main]`.
 
-## Masterless Puppet
+    ```text
+    err: Could not send report:
+    Error 400 on SERVER: Could not autoload datadog_reports:
+    Class Datadog_reports is already defined in Puppet::Reports
+    ```
+
+### Masterless Puppet
 
 1. The Datadog module and its dependencies have to be installed on all nodes running masterless.
 2. Add this to each node's `site.pp` file:
@@ -240,12 +203,7 @@ This is the minimal set of modifications to get started.
     }
    ```
 
-3. Configure reports in the `[main]` section of `puppet.conf`:
-    ```conf
-    [main]
-    reports=datadog_reports
-    ```
-4. Run puppet in masterless configuration:
+3. Run puppet in masterless configuration:
     ```shell
     puppet apply --modulepath <path_to_modules> <path_to_site.pp>
     ```
@@ -275,7 +233,7 @@ Tips:
 
 ### Configuration variables
 
-These variables can be set in the `datadog_agent` class to control settings in the Agent:
+These variables can be set in the `datadog_agent` class to control settings in the Agent. Refer to the [comments in code] for a full list of arguments:
 
 | variable name                           | description                                                                                                                                                                                      |
 |-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -283,7 +241,7 @@ These variables can be set in the `datadog_agent` class to control settings in t
 | `agent_version`                         | Lets you pin a specific minor version of the Agent to install, for example: `1:7.16.0-1`. Leave empty to install the latest version.                                                             |
 | `collect_ec2_tags`                      | Collect an instance's custom EC2 tags as Agent tags by using `true`.                                                                                                                             |
 | `collect_instance_metadata`             | Collect an instance's EC2 metadata as Agent tags by using `true`.                                                                                                                                |
-| `datadog_site`                          | The Datadog site to report to. Defaults to `datadoghq.com`, set to `datadoghq.eu` to report to the EU site (Agent v6 and v7 only).                                                               |
+| `datadog_site`                          | The Datadog site to report to (Agent v6 and v7 only). Defaults to `datadoghq.com`, can be set to `datadoghq.eu` or `us3.datadoghq.com`.                                                         |
 | `dd_url`                                | The Datadog intake server URL. You are unlikely to need to change this. Overrides `datadog_site`                                                                                                 |
 | `host`                                  | Overrides the node's host name.                                                                                                                                                                  |
 | `local_tags`                            | An array of `<KEY:VALUE>` strings that are set as tags for the node.                                                                                                                             |
@@ -307,4 +265,5 @@ These variables can be set in the `datadog_agent` class to control settings in t
 [3]: https://github.com/DataDog/dogapi-rb
 [4]: https://app.datadoghq.com/account/settings#integrations
 [5]: https://app.datadoghq.com/event/stream
-[6]: https://github.com/DataDog/puppet-datadog-agent/tree/master/manifests/integrations
+[6]: https://github.com/DataDog/puppet-datadog-agent/blob/master/manifests/integrations/mongo.pp#L1
+[7]: https://github.com/DataDog/puppet-datadog-agent/tree/master/manifests/integrations

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@
 #       Defaults to https://app.datadoghq.com.
 #   $datadog_site:
 #       The site of the Datadog intake to send Agent data to. Defaults to 'datadoghq.com',
-#       set to 'datadoghq.eu' to send data to the EU site.
+#       can be set to 'datadoghq.eu' to send data to the EU site or 'us3.datadoghq.com'.
 #       This option is only available with agent version >= 6.6.0.
 #   $host:
 #       Force the hostname to whatever you want. (default: auto-detected)


### PR DESCRIPTION
### What does this PR do?

- Merge some sections of the README, deduplicating some content and reordering some other.
- Document the new us3.datadoghq.com site

### Motivation

The README was quite confusing:
- The "Installation" section didn't mention the default paths of the config files it asks you to change, but then the `Step-by-step` pretty much repeated the same info but this time with the config file paths.
- The `Installation` section partially told you to enable reporting, but the info was incomplete. The complete version was found in the `Reporting` section but it was missing the bits about tagging of reports from the `Installation` section.
