### PR TITLE
Add OOM kill check

### DIFF
--- a/manifests/integrations/oom_kill.pp
+++ b/manifests/integrations/oom_kill.pp
@@ -1,0 +1,50 @@
+# Class: datadog_agent::integrations::oom_kill
+#
+# This class will install the necessary configuration for the oom_kill integration
+# For it to work you also need to enable the system-probe with enable_oom_kill set to true.
+#
+# Parameters:
+#   $instances:
+#       Array of hashes for all oom_kill configs and associates tags. See example
+#
+# Sample Usage:
+#
+#   class { 'datadog_agent::integrations::oom_kill':
+#     instances => [
+#         {
+#             'collect_oom_kill'  => true,
+#             'tags' => ['instance:foo'],
+#         },
+#     ],
+#   }
+#
+
+class datadog_agent::integrations::oom_kill(
+  Array $instances = [],
+) inherits datadog_agent::params {
+  include datadog_agent
+
+  $dst_dir = "${datadog_agent::params::conf_dir}/oom_kill.d"
+  file { $legacy_dst:
+    ensure => 'absent'
+  }
+  file { $dst_dir:
+    ensure  => directory,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => $datadog_agent::params::permissions_directory,
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+  $dst = "${dst_dir}/conf.yaml"
+
+  file { $dst:
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => $datadog_agent::params::permissions_protected_file,
+    content => template('datadog_agent/agent-conf.d/oom_kill.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/manifests/system_probe.pp
+++ b/manifests/system_probe.pp
@@ -2,6 +2,7 @@ class datadog_agent::system_probe(
   Boolean $enabled = false,
   Optional[String] $log_file = undef,
   Optional[String] $sysprobe_socket = undef,
+  Optional[Boolean] $enable_oom_kill = false,
 
   Boolean $service_enable = true,
   String $service_ensure = 'running',
@@ -37,6 +38,7 @@ class datadog_agent::system_probe(
       'enabled' => $enabled,
       'sysprobe_socket' => $sysprobe_socket,
       'log_file' => $log_file,
+      'enable_oom_kill' => $enable_oom_kill,
     }
   }
 

--- a/templates/agent-conf.d/oom_kill.yaml.erb
+++ b/templates/agent-conf.d/oom_kill.yaml.erb
@@ -1,0 +1,17 @@
+### MANAGED BY PUPPET
+
+# init_config:
+
+# instances:
+#     # For every instance, you have an `collect_oom_kill` and (optionally)
+#     # a list of tags.
+
+#     -   collect_oom_kill: true
+#         tags:
+#             -   instance:foo
+
+<%
+require 'yaml'
+%>
+
+<%= {'init_config'=>nil, 'instances'=>@instances}.to_yaml %>


### PR DESCRIPTION
### What does this PR do?

- Add the [OOM kill integration](https://docs.datadoghq.com/integrations/oom_kill/)
- Add `enable_oom_kill` config to system probe

### Motivation

FR

### Additional Notes


### Describe your test plan

```
node default {
  class { 'datadog_agent':
    api_key => 'somenonnullapikeythats32charlong',
    process_enabled => true,
    integrations => {
        "oom_kill" => {
            instances => [{
		'collect_oom_kill'  => true,
                'tags' => ['foo:bar'],
            }],
        },
    },
  }
  class {'datadog_agent::system_probe':
    enabled => true,
    enable_oom_kill => true,
  }
}
```
