### PR TITLE
Relax constraint on puppetlabs/powershell dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">=2.3.0 <3.0.0"
+      "version_requirement": ">=2.3.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
### What does this PR do?

<!--A brief description of the change being made with this pull request.-->

- Relax puppetlabs/powershell dependency to allow installing versions 3 and 4

### Motivation

<!--What inspired you to submit this pull request?-->

- Customer request

### Additional Notes

<!--Anything else we should know when reviewing?-->

- The supported Puppet version stated on the metadata was incorrect, the versions that we currently support and these new versions do not work with Puppet 4.

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->

- The CI installed our module correctly using version 4 of the Powershell dependency.