### PR TITLE
Release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+# 3.6.0 / 2020-09-28
+
+* [FEATURE] Add OOM kill check. [#653][]
+* [BUGFIX] Relax constraint on Powershell dependency [#654][]
+
 # 3.5.0 / 2020-08-27
 
 * [FEATURE] Update report processor to add tag function based on Puppet facts. See [#641][] (Thanks [@murdok5][])
@@ -774,6 +779,8 @@ Please read the [docs]() for more details.
 [#639]: https://github.com/DataDog/puppet-datadog-agent/issues/639
 [#641]: https://github.com/DataDog/puppet-datadog-agent/issues/641
 [#643]: https://github.com/DataDog/puppet-datadog-agent/issues/643
+[#653]: https://github.com/DataDog/puppet-datadog-agent/issues/653
+[#654]: https://github.com/DataDog/puppet-datadog-agent/issues/654
 [@Aramack]: https://github.com/Aramack
 [@BIAndrews]: https://github.com/BIAndrews
 [@ChannoneArif-nbcuni]: https://github.com/ChannoneArif-nbcuni

--- a/manifests/integrations/oom_kill.pp
+++ b/manifests/integrations/oom_kill.pp
@@ -25,9 +25,6 @@ class datadog_agent::integrations::oom_kill(
   include datadog_agent
 
   $dst_dir = "${datadog_agent::params::conf_dir}/oom_kill.d"
-  file { $legacy_dst:
-    ensure => 'absent'
-  }
   file { $dst_dir:
     ensure  => directory,
     owner   => $datadog_agent::params::dd_user,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-datadog_agent",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "author": "James Turnbull <james@lovedthanlost.net>, Rob Terhaar <rob@atlanticdynamic>, Jaime Fullaondo <jaime.fullaondo@datadoghq.com>, Albert Vaca <albert.vaca@datadoghq.com>",
   "summary": "Install the Datadog monitoring agent and report Puppet runs to Datadog",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What does this PR do?

- Bump version in metadata
- Update changelog
- Fix recently merged oom_kill check trying to delete an A5 file that's not defined.
