### PR TITLE
Allow digging into fields of facts when they are a hash on old puppets

### DIFF
--- a/functions/tag6.pp
+++ b/functions/tag6.pp
@@ -18,7 +18,12 @@ function datadog_agent::tag6(
     }
 
     if $lookup {
-      $value = getvar($tag_names)
+      $match_as_string = getvar($tag_names)
+      if $match_as_string == undef {
+        $value = $facts.dig(*split($tag_names, '[.]'))
+      } else {
+        $value = $match_as_string
+      }
       if $value =~ Array {
         $tags = prefix($value, "${tag_names}:")
       } else {

--- a/functions/tag6.pp
+++ b/functions/tag6.pp
@@ -18,7 +18,7 @@ function datadog_agent::tag6(
     }
 
     if $lookup {
-      $match_as_string = getvar($tag_names)
+      $match_as_string = $facts[$tag_names]
       if $match_as_string == undef {
         $value = $facts.dig(*split($tag_names, '[.]'))
       } else {

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -2177,25 +2177,28 @@ describe 'datadog_agent' do
         {
           agent_major_version: 6,
           puppet_run_reports: true,
-          facts_to_tags: ['osfamily', 'facts_array', 'facts_hash.actor.first_name', 'looks.like.a.hash'],
+          facts_to_tags: ['osfamily', 'facts_array', 'facts_hash.actor.first_name', 'looks.like.a.path'],
         }
       end
       let(:facts) do
         {
-          operatingsystem: 'CentOS',
-          osfamily: 'redhat',
-          facts_array: ['one', 'two'],
-          facts_hash: {
-            actor: {
-              first_name: "Macaulay",
-              last_name: "Culkin",
+          'operatingsystem' => 'CentOS',
+          'osfamily' => 'redhat',
+          'facts_array' => ['one', 'two'],
+          'facts_hash' => {
+            'actor' => {
+              'first_name' => 'Macaulay',
+              'last_name' => 'Culkin',
             },
           },
-          'looks.like.a.hash': 'but_its_not',
+          'looks.like.a.path' => 'but_its_not',
         }
       end
 
-      it { is_expected.to contain_file('/etc/datadog-agent/datadog.yaml').with_content(%r{tags:\n- osfamily:redhat\n- facts_array:one\n- facts_array:two\n- facts_hash.actor.first_name:Macaulay\n- looks.like.a.hash:but_its_not}) }
+      it do
+        is_expected.to contain_file('/etc/datadog-agent/datadog.yaml')
+          .with_content(%r{tags:\n- osfamily:redhat\n- facts_array:one\n- facts_array:two\n- facts_hash.actor.first_name:Macaulay\n- looks.like.a.path:but_its_not})
+      end
     end
 
     describe 'a5 ensure facts_array outputs a list of tags' do

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -2177,7 +2177,7 @@ describe 'datadog_agent' do
         {
           agent_major_version: 6,
           puppet_run_reports: true,
-          facts_to_tags: ['osfamily', 'facts_array'],
+          facts_to_tags: ['osfamily', 'facts_array', 'facts_hash.actor.first_name', 'looks.like.a.hash'],
         }
       end
       let(:facts) do
@@ -2185,10 +2185,17 @@ describe 'datadog_agent' do
           operatingsystem: 'CentOS',
           osfamily: 'redhat',
           facts_array: ['one', 'two'],
+          facts_hash: {
+            actor: {
+              first_name: "Macaulay",
+              last_name: "Culkin",
+            },
+          },
+          'looks.like.a.hash': 'but_its_not',
         }
       end
 
-      it { is_expected.to contain_file('/etc/datadog-agent/datadog.yaml').with_content(%r{tags:\n- osfamily:redhat\n- facts_array:one\n- facts_array:two}) }
+      it { is_expected.to contain_file('/etc/datadog-agent/datadog.yaml').with_content(%r{tags:\n- osfamily:redhat\n- facts_array:one\n- facts_array:two\n- facts_hash.actor.first_name:Macaulay\n- looks.like.a.hash:but_its_not}) }
     end
 
     describe 'a5 ensure facts_array outputs a list of tags' do


### PR DESCRIPTION
### What does this PR do?

If a `facts_to_tags` tag looks like a hash path (eg: 'networking.domain'),
dig that path into the hash and use the inner value for the tag.

For backwards compatibility, if the name looks like a hash path
but there's a fact that's an exact string match (eg: there's a fact named
'networking.domain') then that will be used for the tag.

Note that on Puppet 6.0 and later `getvar` [already behaves like this](https://puppet.com/docs/puppet/6.18/function.html#getvar),
so this only makes it work on old Puppets.

### Motivation

Feature request.