### PR TITLE
Add trusted_facts_to_tags argument to add Agent tags from trusted facts

### DIFF
--- a/functions/tag6.pp
+++ b/functions/tag6.pp
@@ -5,10 +5,11 @@
 function datadog_agent::tag6(
   Variant[Array, String] $tag_names,
   Variant[String, Boolean] $lookup_fact = false,
+  Variant[Hash, Undef] $lookup_table = $facts,
 ) {
   if $tag_names =~ Array {
     $tags = $tag_names.reduce([]) |$_tags , $tag| {
-        concat($_tags, datadog_agent::tag6($tag, $lookup_fact))
+        concat($_tags, datadog_agent::tag6($tag, $lookup_fact, $lookup_table))
     }
   } else {
     if $lookup_fact =~ String {
@@ -18,9 +19,9 @@ function datadog_agent::tag6(
     }
 
     if $lookup {
-      $match_as_string = $facts[$tag_names]
+      $match_as_string = $lookup_table[$tag_names]
       if $match_as_string == undef {
-        $value = $facts.dig(*split($tag_names, '[.]'))
+        $value = $lookup_table.dig(*split($tag_names, '[.]'))
       } else {
         $value = $match_as_string
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,9 @@
 #   $facts_to_tags
 #       Optional array of facts' names that you can use to define tags following
 #       the scheme: "fact_name:fact_value".
+#   $trusted_facts_to_tags
+#       Optional array of trusted facts' names that you can use to define tags following
+#       the scheme: "fact_name:fact_value".
 #   $puppet_run_reports
 #       Will send results from your puppet agent runs back to the datadog service.
 #   $manage_dogapi_gem
@@ -243,6 +246,7 @@ class datadog_agent(
   $hiera_integrations = false,
   Boolean $hiera_tags = false,
   Array $facts_to_tags = [],
+  Array $trusted_facts_to_tags = [],
   Boolean $puppet_run_reports = false,
   String $puppetmaster_user = $settings::user,
   String $puppet_gem_provider = $datadog_agent::params::gem_provider,
@@ -689,8 +693,9 @@ class datadog_agent(
       notify  => Service[$datadog_agent::params::service_name]
     }
 
-    $_local_tags = datadog_agent::tag6($local_tags, false)
-    $_facts_tags = datadog_agent::tag6($facts_to_tags, true)
+    $_local_tags = datadog_agent::tag6($local_tags, false, undef)
+    $_facts_tags = datadog_agent::tag6($facts_to_tags, true, $facts)
+    $_trusted_facts_tags = datadog_agent::tag6($trusted_facts_to_tags, true, $trusted)
 
     $_agent_config = {
       'api_key' => $api_key,
@@ -707,7 +712,7 @@ class datadog_agent(
       'dogstatsd_non_local_traffic' => $non_local_traffic,
       'log_file' => $agent_log_file,
       'log_level' => $log_level,
-      'tags' => unique(flatten(union($_local_tags, $_facts_tags))),
+      'tags' => unique(flatten(union($_local_tags, $_facts_tags, $_trusted_facts_tags))),
     }
 
     $agent_config = deep_merge($_agent_config, $extra_config)

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -2171,6 +2171,45 @@ describe 'datadog_agent' do
     end
   end
 
+  context 'with trusted_facts to tags set' do
+    Puppet::Util::Log.level = :debug
+    Puppet::Util::Log.newdestination(:console)
+
+    describe 'a6 ensure facts_array outputs a list of tags' do
+      let(:params) do
+        {
+          agent_major_version: 6,
+          puppet_run_reports: true,
+          facts_to_tags: ['osfamily'],
+          trusted_facts_to_tags: ['extensions.trusted_fact', 'extensions.facts_array', 'extensions.facts_hash.actor.first_name'],
+        }
+      end
+      let(:facts) do
+        {
+          'operatingsystem' => 'CentOS',
+          'osfamily' => 'redhat',
+        }
+      end
+      let(:trusted_facts) do
+        {
+          'trusted_fact' => 'test',
+          'facts_array' => ['one', 'two'],
+          'facts_hash' => {
+            'actor' => {
+              'first_name' => 'Macaulay',
+              'last_name' => 'Culkin',
+            },
+          },
+        }
+      end
+
+      it do
+        is_expected.to contain_file('/etc/datadog-agent/datadog.yaml')
+          .with_content(%r{tags:\n- osfamily:redhat\n- extensions.trusted_fact:test\n- extensions.facts_array:one\n- extensions.facts_array:two\n- extensions.facts_hash.actor.first_name:Macaulay})
+      end
+    end
+  end
+
   context 'with facts to tags set' do
     describe 'a6 ensure facts_array outputs a list of tags' do
       let(:params) do


### PR DESCRIPTION
### What does this PR do?

Adds an argument `trusted_facts_to_tags` that behaves much like `facts_to_tags` but for trusted facts.

Note it's not possible to do the same for report tags (like with `report_fact_tags`), since there is no Puppet API to access trusted facts from outside Puppet code.

### Motivation

Feature request.
