### PR TITLE
Msiexec tag array

### DIFF
--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -11,6 +11,8 @@ class datadog_agent::windows(
   String $api_key = $datadog_agent::api_key,
   String $hostname = $datadog_agent::host,
   Array  $tags = $datadog_agent::tags,
+  Hash $tags_hash = $tags.map | $t | { "${t}" }
+  String $tags_transform = inline_template("<%= @tags_hash.join(',') %>")
   Enum['present', 'absent'] $ensure = 'present',
 ) inherits datadog_agent::params {
 
@@ -67,7 +69,7 @@ class datadog_agent::windows(
       ensure          => $ensure_version,
       provider        => 'windows',
       source          => $msi_full_path,
-      install_options => ['/norestart', {'APIKEY' => $api_key, 'HOSTNAME' => $hostname, 'TAGS' => $tags}]
+      install_options => ['/norestart', {'APIKEY' => $api_key, 'HOSTNAME' => $hostname, 'TAGS' => $tags_transform}]
     }
 
   } else {

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -11,8 +11,8 @@ class datadog_agent::windows(
   String $api_key = $datadog_agent::api_key,
   String $hostname = $datadog_agent::host,
   Array  $tags = $datadog_agent::tags,
-  Hash $tags_hash = $tags.map | $t | { "${t}" }
-  String $tags_transform = inline_template("<%= @tags_hash.join(',') %>")
+  String $tags_join = join($tags,","),
+  String $tags_quote_wrap = "\"$tags_join\"",
   Enum['present', 'absent'] $ensure = 'present',
 ) inherits datadog_agent::params {
 
@@ -69,7 +69,7 @@ class datadog_agent::windows(
       ensure          => $ensure_version,
       provider        => 'windows',
       source          => $msi_full_path,
-      install_options => ['/norestart', {'APIKEY' => $api_key, 'HOSTNAME' => $hostname, 'TAGS' => $tags_transform}]
+      install_options => ['/norestart', {'APIKEY' => $api_key, 'HOSTNAME' => $hostname, 'TAGS' => $tags_quote_wrap}]
     }
 
   } else {

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -11,8 +11,8 @@ class datadog_agent::windows(
   String $api_key = $datadog_agent::api_key,
   String $hostname = $datadog_agent::host,
   Array  $tags = $datadog_agent::tags,
-  String $tags_join = join($tags,","),
-  String $tags_quote_wrap = "\"$tags_join\"",
+  String $tags_join = join($tags,','),
+  String $tags_quote_wrap = "\"${tags_join}\"",
   Enum['present', 'absent'] $ensure = 'present',
 ) inherits datadog_agent::params {
 


### PR DESCRIPTION
### What does this PR do?

I spotted a bug with the windows manifest - When the package gets updated with an array of tags, the tags are passed literally on the command line and msiexec opens an interactive help window, hanging puppet.

### Motivation

It broke our release (we have had an array of tags before, the issue only affected us when the agent got updated).

### Additional Notes

### Describe your test plan

1. I branched your module from github to our own repositories, then added it in to our r10k configuration and removed the "mod" declaration from our Puppetfile so that we no longer used the forge version.

2. I tested as-was, and saw the same error. The error was a result of the following msiexec being run:
`Debug: Executing: 'msiexec.exe /qn /norestart /i C:\Windows\temp\datadog-agent-7-7.22.1.amd64.msi /norestart APIKEY=redacted HOSTNAME=websvr3-stag TAGS=["version:Monolith_uk.1.23.0", "env:stag"]'`

3. I updated my branch with the code in this PR and ran puppet again, puppet ran successfully and the resultant msiexec was:
`Debug: Executing: 'msiexec.exe /qn /norestart /i C:\Windows\temp\datadog-agent-7-7.22.1.amd64.msi /norestart APIKEY=redacted HOSTNAME=websvr3-stag TAGS="version:Monolith_uk.1.23.0,env:stag"'`

4. Finally I updated my branch to remove the second tag, to ensure the functionality works properly with a single member, and the resultant msiexec was:
`Debug: Executing: 'msiexec.exe /qn /norestart /i C:\Windows\temp\datadog-agent-7-7.22.1.amd64.msi /norestart APIKEY=redacted HOSTNAME=websvr3-stag TAGS="version:Monolith_uk.1.23.0"'`

Output from both step 3 (array of tags containing more than 1 member) and step 4 (array of tags containing a single member) conforms to [datadog's own command-line installation documentation for windows](https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=commandline).