### PR TITLE
add support for trusted fact tags and add info line for puppetserver …

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,3 +135,5 @@ Style/NumericPredicate:
   Enabled: false
 Layout/FirstHashElementLineBreak:
   Enabled: true
+Style/EmptyLiteral:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To enable reporting of Puppet runs to your Datadog timeline, enable the report p
 
 5. (Optional) Enable tagging of reports with facts:
 
-    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","operatingsystem"]`. To enable trustd fact tagging, set the parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example `["trusted.certname","trusted.extensions.pp_role","trusted hostname"]`.
+    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","operatingsystem"]`. To enable trusted fact tagging, set the parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example `["trusted.certname","trusted.extensions.pp_role","trusted hostname"]`.
 
     NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(s).
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To enable reporting of Puppet runs to your Datadog timeline, enable the report p
 
 5. (Optional) Enable tagging of reports with facts:
 
-    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","trusted.extensions.pp_role","operatingsystem"]` results in three separate tags per report event.
+    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","operatingsystem"]`. To enable trustd fact tagging, set the parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example `["trusted.certname","trusted.extensions.pp_role","trusted hostname"]`.
 
     NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(s).
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To enable reporting of Puppet runs to your Datadog timeline, enable the report p
 
 5. (Optional) Enable tagging of reports with facts:
 
-    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","operatingsystem"]`. To enable trusted fact tagging, set the parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example `["trusted.certname","trusted.extensions.pp_role","trusted.hostname"]`.
+    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","operatingsystem"]`. To enable trusted fact tagging, set the parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example `["certname","extensions.pp_role","hostname"]`.
 
     NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(s).
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To enable reporting of Puppet runs to your Datadog timeline, enable the report p
 
 5. (Optional) Enable tagging of reports with facts:
 
-    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","operatingsystem"]`. To enable trusted fact tagging, set the parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example `["trusted.certname","trusted.extensions.pp_role","trusted hostname"]`.
+    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","operatingsystem"]`. To enable trusted fact tagging, set the parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example `["trusted.certname","trusted.extensions.pp_role","trusted.hostname"]`.
 
     NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(s).
 

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -138,7 +138,6 @@ Puppet::Reports.register_report(:datadog_reports) do
     facts = Puppet::Node::Facts.indirection.find(host).values
     facts_tags = REPORT_FACT_TAGS.map { |name| "#{name}:#{facts.dig(*name.split('.'))}" }
     trusted_facts = (Puppet.lookup(:trusted_information) { Hash.new }).to_h
-    trusted_facts = { "trusted" => trusted_facts.to_h }
     trusted_fact_tags = REPORT_TRUSTED_FACT_TAGS.map { |name| "#{name}:#{trusted_facts.dig(*name.split('.'))}" }
     dog_tags = facts_tags + trusted_fact_tags
 

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -142,7 +142,7 @@ Puppet::Reports.register_report(:datadog_reports) do
     trusted_fact_tags = REPORT_TRUSTED_FACT_TAGS.map { |name| "#{name}:#{trusted_facts.dig(*name.split('.'))}" }
     dog_tags = facts_tags + trusted_fact_tags
 
-    Puppet.debug "Sending events for #{@msg_host} to Datadog"
+    Puppet.debug "Sending events for #{@msg_host} to Datadog. Trusted facts #{@trusted_facts.to_s}. Trusted facts tags #{@trusted_fact_tags.to_s}."
     @dog.emit_event(Dogapi::Event.new(event_data,
                                       msg_title: event_title,
                                       event_type: 'config_management.run',

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -135,6 +135,9 @@ Puppet::Reports.register_report(:datadog_reports) do
     end
 
     facts = Puppet::Node::Facts.indirection.find(host).values
+    trusted_facts = Puppet.lookup(:trusted_information) { Hash.new }
+    trusted_facts_m = { "trusted" => trusted_facts.to_h }
+    facts.merge!(trusted_facts_m)
     dog_tags = REPORT_FACT_TAGS.map { |name| "#{name}:#{facts.dig(*name.split('.'))}" }
 
     Puppet.debug "Sending events for #{@msg_host} to Datadog"
@@ -147,5 +150,6 @@ Puppet::Reports.register_report(:datadog_reports) do
                                       source_type_name: 'puppet',
                                       tags: dog_tags),
                     host: @msg_host)
+    Puppet.info "Event sent for #{@msg_host} to Datadog"
   end
 end

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -141,8 +141,8 @@ Puppet::Reports.register_report(:datadog_reports) do
     trusted_fact_tags = REPORT_TRUSTED_FACT_TAGS.map { |name| "#{name}:#{trusted_facts.dig(*name.split('.'))}" }
     dog_tags = facts_tags + trusted_fact_tags
 
-    #Uncomment below line for debug logging of tags
-    #Puppet.debug "Sending events for #{@msg_host} to Datadog with tags #{dog_tags.to_s}"
+    # Uncomment below line for debug logging of tags
+    # Puppet.debug "Sending events for #{@msg_host} to Datadog with tags #{dog_tags.to_s}"
     @dog.emit_event(Dogapi::Event.new(event_data,
                                       msg_title: event_title,
                                       event_type: 'config_management.run',

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -142,7 +142,8 @@ Puppet::Reports.register_report(:datadog_reports) do
     trusted_fact_tags = REPORT_TRUSTED_FACT_TAGS.map { |name| "#{name}:#{trusted_facts.dig(*name.split('.'))}" }
     dog_tags = facts_tags + trusted_fact_tags
 
-    Puppet.debug "Sending events for #{@msg_host} to Datadog. Trusted facts #{trusted_facts.to_s}. Trusted facts tags #{@trusted_fact_tags.to_s}."
+    #Uncomment below line for debug logging of tags
+    #Puppet.debug "Sending events for #{@msg_host} to Datadog with tags #{dog_tags.to_s}"
     @dog.emit_event(Dogapi::Event.new(event_data,
                                       msg_title: event_title,
                                       event_type: 'config_management.run',

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -138,6 +138,7 @@ Puppet::Reports.register_report(:datadog_reports) do
     facts = Puppet::Node::Facts.indirection.find(host).values
     facts_tags = REPORT_FACT_TAGS.map { |name| "#{name}:#{facts.dig(*name.split('.'))}" }
     trusted_facts = (Puppet.lookup(:trusted_information) { Hash.new }).to_h
+    trusted_facts = { "trusted" => trusted_facts.to_h }
     trusted_fact_tags = REPORT_TRUSTED_FACT_TAGS.map { |name| "#{name}:#{trusted_facts.dig(*name.split('.'))}" }
     dog_tags = facts_tags + trusted_fact_tags
 

--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -142,7 +142,7 @@ Puppet::Reports.register_report(:datadog_reports) do
     trusted_fact_tags = REPORT_TRUSTED_FACT_TAGS.map { |name| "#{name}:#{trusted_facts.dig(*name.split('.'))}" }
     dog_tags = facts_tags + trusted_fact_tags
 
-    Puppet.debug "Sending events for #{@msg_host} to Datadog. Trusted facts #{@trusted_facts.to_s}. Trusted facts tags #{@trusted_fact_tags.to_s}."
+    Puppet.debug "Sending events for #{@msg_host} to Datadog. Trusted facts #{trusted_facts.to_s}. Trusted facts tags #{@trusted_fact_tags.to_s}."
     @dog.emit_event(Dogapi::Event.new(event_data,
                                       msg_title: event_title,
                                       event_type: 'config_management.run',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,8 +28,8 @@
 #   $hiera_tags
 #       Boolean to grab tags from hiera to allow merging
 #   $facts_to_tags
-#       Optional array of facts' names that you can use to define tags following
-#       the scheme: "fact_name:fact_value".
+#       Optional array of facts' names that you can use to define tags following the scheme: "fact_name:fact_value".
+#       See also trusted_facts_to_tags, report_fact_tags and report_trusted_fact_tags.
 #   $trusted_facts_to_tags
 #       Optional array of trusted facts' names that you can use to define tags following
 #       the scheme: "fact_name:fact_value".
@@ -67,6 +67,8 @@
 #       Set value of the 'dogstatsd_port' variable. Defaultis 8125.
 #   $report_fact_tags
 #       Sets tags for report events sent to Datadog from specified facts
+#   $report_trusted_fact_tags
+#       Sets tags for report events sent to Datadog from specified trusted facts
 #   $statsd_forward_host
 #       Set the value of the statsd_forward_host varable. Used to forward all
 #       statsd metrics to another host.
@@ -264,6 +266,7 @@ class datadog_agent(
   $dogstatsd_port = 8125,
   $dogstatsd_socket = '',
   Array $report_fact_tags = [],
+  Array $report_trusted_fact_tags = [],
   String $statsd_forward_host = '',
   $statsd_forward_port = '',
   String $statsd_histogram_percentiles = '0.95',
@@ -785,6 +788,7 @@ class datadog_agent(
       proxy_http                => $proxy_http,
       proxy_https               => $proxy_https,
       report_fact_tags          => $report_fact_tags,
+      report_trusted_fact_tags  => $report_trusted_fact_tags,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,10 +29,12 @@
 #       Boolean to grab tags from hiera to allow merging
 #   $facts_to_tags
 #       Optional array of facts' names that you can use to define tags following the scheme: "fact_name:fact_value".
-#       See also trusted_facts_to_tags, report_fact_tags and report_trusted_fact_tags.
+#       See also trusted_facts_to_tags.
+#       Note: this is not for Puppet Report Tags.  See report_fact_tags
 #   $trusted_facts_to_tags
 #       Optional array of trusted facts' names that you can use to define tags following
 #       the scheme: "fact_name:fact_value".
+#       Note: this is not for Puppet Report Tags.  See report_trusted_fact_tags
 #   $puppet_run_reports
 #       Will send results from your puppet agent runs back to the datadog service.
 #   $manage_dogapi_gem

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -22,6 +22,7 @@ class datadog_agent::reports(
   $proxy_http = undef,
   $proxy_https = undef,
   $report_fact_tags = [],
+  $report_trusted_fact_tags = [],
   $datadog_site = 'datadoghq.com',
   $puppet_gem_provider = $datadog_agent::params::gem_provider,
 ) inherits datadog_agent::params {

--- a/templates/datadog-reports.yaml.erb
+++ b/templates/datadog-reports.yaml.erb
@@ -18,3 +18,9 @@
   - <%= tag %>
   <%- end -%>
 <% end -%>
+<% if @report_trusted_fact_tags -%>
+:report_trusted_fact_tags:
+<%- @report_trusted_fact_tags.each do |tag| -%>
+  - <%= tag %>
+  <%- end -%>
+<% end -%>


### PR DESCRIPTION
…log notifications

### What does this PR do?

Resolve issue where trusted facts were not working for report fact tags. 

### Motivation

Customer request based on experience/need.

### Additional Notes

Added an unrelated info line to the report processor to log successful sends to Datadog API

### Describe your test plan

Tested in a lab environment using Puppet Enterprise 2019.8.1 with current Datadog.
