### PR TITLE
Fix CentOS8+Puppet6 test env

### DIFF
--- a/environments/centos8/Vagrantfile
+++ b/environments/centos8/Vagrantfile
@@ -6,12 +6,11 @@ Vagrant.configure("2") do |config|
     #install puppet 6
     dnf install -y https://yum.puppetlabs.com/puppet-release-el-8.noarch.rpm
     dnf install -y puppet
-    ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
 
     # install modules
     cd /home/vagrant/puppet
-    /opt/puppetlabs/puppet/bin/gem install r10k -v 2.6.7
-    /opt/puppetlabs/puppet/bin/r10k puppetfile install --moduledir=/home/vagrant/puppet/modules
+    gem install r10k -v 2.6.7
+    r10k puppetfile install --moduledir=/home/vagrant/puppet/modules
 
     # link local module
     ln -s /puppet-datadog-agent /home/vagrant/puppet/modules/datadog_agent


### PR DESCRIPTION
### Motivation

Puppet 6 package doesn't install it in `/opt`.
