### PR TITLE
Fix Package not depending on the right Yumrepo

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -72,11 +72,13 @@ class datadog_agent::redhat(
       require  => Exec['install-gpg-key'],
     }
 
-    Package { require => Yumrepo['datadog6']}
+    package { $datadog_agent::params::package_name:
+      ensure  => $agent_version,
+      require => Yumrepo['datadog'],
+    }
+  } else {
+    package { $datadog_agent::params::package_name:
+      ensure  => $agent_version,
+    }
   }
-
-  package { $datadog_agent::params::package_name:
-    ensure  => $agent_version,
-  }
-
 }


### PR DESCRIPTION
### What does this PR do?

The `package` resource required the `Yumrepo` called `datadog6` instead of `datadog`, which was wrong.

Also I think we were using an empty `package` resource to force the `yumrepo` being created, but we can actually use that same `package` instance to install the datadog-agent package if we specify it instead of doing that right after. Changed that as well.

### Motivation

Should fix: #659

