### PR TITLE
Adds support for collecting elasticsearch index_stats

### DIFF
--- a/manifests/integrations/elasticsearch.pp
+++ b/manifests/integrations/elasticsearch.pp
@@ -25,6 +25,7 @@
 #
 class datadog_agent::integrations::elasticsearch(
   Boolean $cluster_stats               = false,
+  Boolean $index_stats                 = false,
   Optional[String] $password           = undef,
   Boolean$pending_task_stats           = true,
   Boolean $pshard_stats                = false,
@@ -47,6 +48,7 @@ class datadog_agent::integrations::elasticsearch(
   if !$instances and $url {
     $_instances = [{
       'cluster_stats'      => $cluster_stats,
+      'index_stats'        => $index_stats,
       'password'           => $password,
       'pending_task_stats' => $pending_task_stats,
       'pshard_stats'       => $pshard_stats,

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -93,8 +93,6 @@ describe 'datadog_agent::integrations::elasticsearch' do
           }
         end
 
-
-
         it { is_expected.to contain_file(conf_file).with_content(%r{instances:}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      cluster_stats: true}) }

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -26,6 +26,7 @@ describe 'datadog_agent::integrations::elasticsearch' do
       context 'with default parameters' do
         it { is_expected.to contain_file(conf_file).with_content(%r{    - url: http://localhost:9200}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      cluster_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      index_stats: false}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
         it { is_expected.not_to contain_file(conf_file).with_content(%r{      username}) }
@@ -66,6 +67,7 @@ describe 'datadog_agent::integrations::elasticsearch' do
             instances: [
               {
                 'cluster_stats'      => true,
+                'index_stats'        => false,
                 'password'           => 'password',
                 'pending_task_stats' => false,
                 'pshard_stats'       => true,
@@ -78,6 +80,7 @@ describe 'datadog_agent::integrations::elasticsearch' do
               },
               {
                 'cluster_stats'      => false,
+                'index_stats'        => true,
                 'password'           => 'password_2',
                 'pending_task_stats' => true,
                 'pshard_stats'       => false,
@@ -90,9 +93,12 @@ describe 'datadog_agent::integrations::elasticsearch' do
           }
         end
 
+
+
         it { is_expected.to contain_file(conf_file).with_content(%r{instances:}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      cluster_stats: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      index_stats: false}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      pending_task_stats: false}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      username: username}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      password: password}) }
@@ -103,6 +109,7 @@ describe 'datadog_agent::integrations::elasticsearch' do
         it { is_expected.to contain_file(conf_file).with_content(%r{      tags:\n        - tag1:key1}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{    - url: https://bar:2424}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      cluster_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      index_stats: true}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      username: username_2}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      password: password_2}) }

--- a/templates/agent-conf.d/elastic.yaml.erb
+++ b/templates/agent-conf.d/elastic.yaml.erb
@@ -12,6 +12,7 @@ instances:
       password: <%= instance['password'] %>
 <%- end -%>
       cluster_stats: <%= instance['cluster_stats'] %>
+      index_stats: <%= instance['index_stats'] %>
       pshard_stats: <%= instance['pshard_stats'] %>
       pending_task_stats: <%= instance['pending_task_stats'] %>
 <%- if instance['url'].match(/^https/) -%>


### PR DESCRIPTION
### What does this PR do?

Datadog integration now supports collecting index_stats. This PR adds
support to include those stats.

### Motivation

We want to collect index stats and we currently install datadog integrations via puppet.
