### PR TITLE
Trust new APT and RPM keys

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -12,18 +12,24 @@ class datadog_agent::redhat(
 
   if $manage_repo {
 
+    $keys = [
+        'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+        'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+        'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public',
+    ]
+
     case $agent_major_version {
       5 : {
         $defaulturl = "https://yum.datadoghq.com/rpm/${::architecture}/"
-        $gpgkeys = ['https://yum.datadoghq.com/DATADOG_RPM_KEY.public']
+        $gpgkeys = $keys
       }
       6 : {
         $defaulturl = "https://yum.datadoghq.com/stable/6/${::architecture}/"
-        $gpgkeys = ['https://yum.datadoghq.com/DATADOG_RPM_KEY.public']
+        $gpgkeys = $keys
       }
       7 : {
         $defaulturl = "https://yum.datadoghq.com/stable/7/${::architecture}/"
-        $gpgkeys = ['https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public', 'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public']
+        $gpgkeys = $keys[1,2]
       }
       default: { fail('invalid agent_major_version') }
     }
@@ -34,29 +40,12 @@ class datadog_agent::redhat(
       $baseurl = $defaulturl
     }
 
-    $public_key_local = '/etc/pki/rpm-gpg/DATADOG_RPM_KEY.public'
-
-    file { 'DATADOG_RPM_KEY_20200908.public':
-        owner  => root,
-        group  => root,
-        mode   => '0600',
-        path   => $public_key_local,
-        source => 'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public'
-    }
-
-    exec { 'install-gpg-key':
-        command => "/bin/rpm --import ${public_key_local}",
-        onlyif  => "/usr/bin/gpg --dry-run --quiet --with-fingerprint -n ${public_key_local} | grep 'C655 9B69 0CA8 82F0 23BD  F3F6 3F4D 1729 FD4B F915' || gpg --dry-run --import --import-options import-show ${public_key_local} | grep 'C6559B690CA882F023BDF3F63F4D1729FD4BF915'",
-        unless  => '/bin/rpm -q gpg-pubkey-fd4bf915',
-        require => File['DATADOG_RPM_KEY_20200908.public'],
-    }
-
     yumrepo { 'datadog-beta':
       ensure => absent,
     }
 
     yumrepo {'datadog5':
-    ensure   => absent,
+      ensure   => absent,
     }
 
     yumrepo {'datadog6':
@@ -69,7 +58,6 @@ class datadog_agent::redhat(
       gpgkey   => join($gpgkeys, "\n       "),
       descr    => 'Datadog, Inc.',
       baseurl  => $baseurl,
-      require  => Exec['install-gpg-key'],
     }
 
     package { $datadog_agent::params::package_name:

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -15,15 +15,15 @@ class datadog_agent::redhat(
     case $agent_major_version {
       5 : {
         $defaulturl = "https://yum.datadoghq.com/rpm/${::architecture}/"
-        $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
+        $gpgkeys = ['https://yum.datadoghq.com/DATADOG_RPM_KEY.public']
       }
       6 : {
         $defaulturl = "https://yum.datadoghq.com/stable/6/${::architecture}/"
-        $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY.public'
+        $gpgkeys = ['https://yum.datadoghq.com/DATADOG_RPM_KEY.public']
       }
       7 : {
         $defaulturl = "https://yum.datadoghq.com/stable/7/${::architecture}/"
-        $gpgkey = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public'
+        $gpgkeys = ['https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public', 'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public']
       }
       default: { fail('invalid agent_major_version') }
     }
@@ -36,19 +36,19 @@ class datadog_agent::redhat(
 
     $public_key_local = '/etc/pki/rpm-gpg/DATADOG_RPM_KEY.public'
 
-    file { 'DATADOG_RPM_KEY_E09422B3.public':
+    file { 'DATADOG_RPM_KEY_20200908.public':
         owner  => root,
         group  => root,
         mode   => '0600',
         path   => $public_key_local,
-        source => 'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public'
+        source => 'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public'
     }
 
     exec { 'install-gpg-key':
         command => "/bin/rpm --import ${public_key_local}",
-        onlyif  => "/usr/bin/gpg --dry-run --quiet --with-fingerprint -n ${public_key_local} | grep 'A4C0 B90D 7443 CF6E 4E8A  A341 F106 8E14 E094 22B3' || gpg --dry-run --import --import-options import-show ${public_key_local} | grep 'A4C0B90D7443CF6E4E8AA341F1068E14E09422B3'",
-        unless  => '/bin/rpm -q gpg-pubkey-e09422b3',
-        require => File['DATADOG_RPM_KEY_E09422B3.public'],
+        onlyif  => "/usr/bin/gpg --dry-run --quiet --with-fingerprint -n ${public_key_local} | grep 'C655 9B69 0CA8 82F0 23BD  F3F6 3F4D 1729 FD4B F915' || gpg --dry-run --import --import-options import-show ${public_key_local} | grep 'C6559B690CA882F023BDF3F63F4D1729FD4BF915'",
+        unless  => '/bin/rpm -q gpg-pubkey-fd4bf915',
+        require => File['DATADOG_RPM_KEY_20200908.public'],
     }
 
     yumrepo { 'datadog-beta':
@@ -56,7 +56,7 @@ class datadog_agent::redhat(
     }
 
     yumrepo {'datadog5':
-      ensure   => absent,
+    ensure   => absent,
     }
 
     yumrepo {'datadog6':
@@ -66,7 +66,7 @@ class datadog_agent::redhat(
     yumrepo {'datadog':
       enabled  => 1,
       gpgcheck => 1,
-      gpgkey   => $gpgkey,
+      gpgkey   => join($gpgkeys, "\n       "),
       descr    => 'Datadog, Inc.',
       baseurl  => $baseurl,
       require  => Exec['install-gpg-key'],

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -5,12 +5,12 @@
 
 class datadog_agent::ubuntu(
   Integer $agent_major_version = $datadog_agent::params::default_agent_major_version,
-  String $apt_key = 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE',
+  Array[String] $apt_keys = ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE', 'D75CEA17048B9ACBF186794B32637D44F14F620E'],
   String $agent_version = $datadog_agent::params::agent_version,
   Optional[String] $agent_repo_uri = undef,
   String $release = $datadog_agent::params::apt_default_release,
   Boolean $skip_apt_key_trusting = false,
-  Optional[String] $apt_keyserver = undef,
+  String $apt_keyserver = $datadog_agent::params::apt_keyserver,
 ) inherits datadog_agent::params {
 
   if $agent_version =~ /^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/ {
@@ -28,12 +28,12 @@ class datadog_agent::ubuntu(
   }
 
   if !$skip_apt_key_trusting {
-    $key = {
-      'id' => $apt_key,
-      'server' => $apt_keyserver,
+    $apt_keys.each |String $apt_key| {
+      apt::key { $apt_key:
+        id     => $apt_key,
+        server => $apt_keyserver,
+      }
     }
-  } else {
-    $key = {}
   }
 
   if ($agent_repo_uri != undef) {
@@ -59,7 +59,6 @@ class datadog_agent::ubuntu(
     location => $location,
     release  => $release,
     repos    => $repos,
-    key      => $key,
   }
 
   package { 'datadog-agent-base':

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -71,5 +71,4 @@ class datadog_agent::ubuntu(
     require => [Apt::Source['datadog'],
                 Class['apt::update']],
   }
-
 }

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -118,7 +118,8 @@ describe 'datadog_agent::redhat' do
         is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')
       end
     end

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -27,7 +27,9 @@ describe 'datadog_agent::redhat' do
         is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
           .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
       end
     end
@@ -72,7 +74,9 @@ describe 'datadog_agent::redhat' do
         is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/6/x86_64/')
       end
     end

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -27,10 +27,12 @@ describe 'datadog_agent::ubuntu' do
     end
 
     # it should install the mirror
-    it { is_expected.not_to contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
+    it { is_expected.not_to contain_apt__key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
     it do
-      is_expected.to contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog')
+      is_expected.to contain_apt__key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE')
+      is_expected.to contain_apt__key('D75CEA17048B9ACBF186794B32637D44F14F620E')
     end
+
     context 'overriding keyserver' do
       let(:params) do
         {
@@ -39,7 +41,9 @@ describe 'datadog_agent::ubuntu' do
       end
 
       it do
-        is_expected.to contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog')\
+        is_expected.to contain_apt__key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE')\
+          .with_server('hkp://pool.sks-keyservers.net:80')
+        is_expected.to contain_apt__key('D75CEA17048B9ACBF186794B32637D44F14F620E')\
           .with_server('hkp://pool.sks-keyservers.net:80')
       end
     end
@@ -87,8 +91,11 @@ describe 'datadog_agent::ubuntu' do
     end
 
     # it should install the mirror
-    it { is_expected.not_to contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
-    it { is_expected.to contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog') }
+    it { is_expected.not_to contain_apt__key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
+    it do
+      is_expected.to contain_apt__key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE')
+      is_expected.to contain_apt__key('D75CEA17048B9ACBF186794B32637D44F14F620E')
+    end
 
     it do
       is_expected.to contain_file('/etc/apt/sources.list.d/datadog6.list')\
@@ -133,8 +140,8 @@ describe 'datadog_agent::ubuntu' do
     end
 
     # it should install the mirror
-    it { is_expected.not_to contain_apt__key('Add key: 935F5A436A5A6E8788F0765B226AE980C7A7DA52 from Apt::Source datadog') }
-    it { is_expected.to contain_apt__key('Add key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE from Apt::Source datadog') }
+    it { is_expected.not_to contain_apt__key('935F5A436A5A6E8788F0765B226AE980C7A7DA52') }
+    it { is_expected.to contain_apt__key('A2923DFF56EDA6E76E55E492D3A80E30382E94DE') }
 
     it do
       is_expected.to contain_file('/etc/apt/sources.list.d/datadog6.list')\


### PR DESCRIPTION
### What does this PR do?

<!--A brief description of the change being made with this pull request.-->

- Trust new APT and RPM keys
- Amend spec tests

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->

- Manual tests and also run CI test suite locally with `bundle exec rake test`

#### Manual tests

Apply the module with the manifests below, it should install the Agent if using this branch's module and fail if using master.
Apply a module with no options, it should install correctly.

##### Ubuntu

```puppet
class { 'datadog_agent':
    api_key => "notnullapikey",
    agent_repo_uri => '<test repo goes here>',
    apt_release => 'nightly',
    agent_version => '7.23.0~devel.git.35.4b4d662',
}
```

##### Redhat

```puppet
class { 'datadog_agent':
    api_key => "notnullapikey",
    agent_repo_uri => '<test repo goes here>/nightly/7/x86_64/',
    agent_version => '7.23.0~devel.git.37.5884362',
}
```