### PR TITLE
Fix Fedora Agent v5 install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -455,14 +455,13 @@ class datadog_agent(
     }
   }
 
-
   if $::operatingsystem == 'Fedora' and $_agent_major_version == 5 {
+    # We need chkinfo to enable the A5 service on Fedora
     package { 'chkconfig':
       ensure => present,
       before => 'datadog_agent::service',
     }
   }
-
 
   # Declare service
   class { 'datadog_agent::service' :

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -455,6 +455,15 @@ class datadog_agent(
     }
   }
 
+
+  if $::operatingsystem == 'Fedora' and $_agent_major_version == 5 {
+    package { 'chkconfig':
+      ensure => present,
+      before => 'datadog_agent::service',
+    }
+  }
+
+
   # Declare service
   class { 'datadog_agent::service' :
     service_ensure   => $service_ensure,


### PR DESCRIPTION
### What does this PR do?

<!--A brief description of the change being made with this pull request.-->

Fix Agent v5 install on Fedora

### Motivation

<!--What inspired you to submit this pull request?-->

We need the `chkinfo` package to enable the service in Fedora
