### PR TITLE
Only declare the Agent package if not already declared

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -449,9 +449,11 @@ class datadog_agent(
       default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
     }
   } else {
-    package { $datadog_agent::params::package_name:
-      ensure => present,
-      source => 'Agent installation not managed by Puppet, make sure the Agent is installed beforehand.',
+    if ! defined(Package[$datadog_agent::params::package_name]) {
+      package { $datadog_agent::params::package_name:
+        ensure => present,
+        source => 'Agent installation not managed by Puppet, make sure the Agent is installed beforehand.',
+      }
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

We need the Agent `package` to be declared even when we don't install it, 
since there's code that depends on it. Our current approach is to always
declare it, which works if the package is installed by something other than
Puppet (eg: chocolatey), since our declaration would not try to install it
again and the code that depends on that declaration would still be happy.
However, in case the package is being installed by a different Puppet
module, it would fail with a `Duplicate declaration` error.

### Motivation

Bug report.
