### PR TITLE
Allow removing check config files

### DIFF
--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -1,8 +1,9 @@
 define datadog_agent::integration (
-  Array $instances,
-  Optional[Hash] $init_config = undef,
-  Optional[Array] $logs       = undef,
-  String $integration         = $title,
+  Array $instances                  = [],
+  Optional[Hash] $init_config       = undef,
+  Optional[Array] $logs             = undef,
+  String $integration               = $title,
+  Enum['present', 'absent'] $ensure = 'present',
 ){
 
   include datadog_agent
@@ -20,8 +21,10 @@ define datadog_agent::integration (
     $dst = "${datadog_agent::params::legacy_conf_dir}/${integration}.yaml"
   }
 
+  $file_ensure = $ensure ? { default => file, 'absent' => absent }
+
   file { $dst:
-    ensure  => file,
+    ensure  => $file_ensure,
     owner   => $datadog_agent::dd_user,
     group   => $datadog_agent::dd_group,
     mode    => $datadog_agent::params::permissions_file,

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -13,28 +13,33 @@ describe 'datadog_agent::integration' do
       end
 
       let(:title) { 'test' }
-      let(:params) do
-        {
-          instances: [
-            {
-              one: 'two',
-            },
-          ],
-        }
-      end
 
-      it { is_expected.to compile }
+      gem_spec = Gem.loaded_specs['puppet']
+
       if agent_major_version == 5
         it { is_expected.to contain_file(conf_dir.to_s).that_comes_before("File[#{conf_file}]") }
       end
-      it { is_expected.to contain_file(conf_file.to_s).with_content(%r{init_config: }) }
-      gem_spec = Gem.loaded_specs['puppet']
-      if gem_spec.version >= Gem::Version.new('4.0.0')
-        it { is_expected.to contain_file(conf_file.to_s).with_content(%r{---\ninit_config: \ninstances:\n- one: two\n}) }
-      else
-        it { is_expected.to contain_file(conf_file.to_s).with_content(%r{--- \n  init_config: \n  instances: \n    - one: two}) }
-      end
       it { is_expected.to contain_file(conf_file.to_s).that_notifies("Service[#{SERVICE_NAME}]") }
+
+      context 'with instances' do
+        let(:params) do
+          {
+            instances: [
+              {
+                one: 'two',
+              },
+            ],
+          }
+        end
+
+        it { is_expected.to compile }
+        if gem_spec.version >= Gem::Version.new('4.0.0')
+          it { is_expected.to contain_file(conf_file.to_s).with_content(%r{---\ninit_config: \ninstances:\n- one: two\n}) }
+        else
+          it { is_expected.to contain_file(conf_file.to_s).with_content(%r{--- \n  init_config: \n  instances: \n    - one: two}) }
+        end
+        it { is_expected.to contain_file(conf_file).with_ensure('file') }
+      end
 
       context 'with logs' do
         let(:params) do
@@ -48,11 +53,24 @@ describe 'datadog_agent::integration' do
           }
         end
 
+        it { is_expected.to compile }
         if gem_spec.version >= Gem::Version.new('4.0.0')
           it { is_expected.to contain_file(conf_file).with_content(%r{logs:\n- one\n- two}) }
         else
           it { is_expected.to contain_file(conf_file).with_content(%r{logs:\n  - one\n  - two}) }
         end
+        it { is_expected.to contain_file(conf_file).with_ensure('file') }
+      end
+
+      context 'with ensure absent' do
+        let(:params) do
+          {
+            ensure: 'absent',
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_file(conf_file).with_ensure('absent') }
       end
     end
   end


### PR DESCRIPTION
### What does this PR do?

Adds a new 'ensure' argument to `datadog_agent::integration` that can be
`present` (default) or `absent` (to remove the file).

### Motivation

Fixes: #674
