### PR TITLE
Fix tests so they also check Agent 5 and 6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -354,7 +354,7 @@ class datadog_agent(
   }
 
   if $_agent_major_version != 5 and $_agent_major_version != 6 and $_agent_major_version != 7 {
-    fail('agent_major_version must be either 5, 6 or 7')
+    fail("agent_major_version must be either 5, 6 or 7, not ${_agent_major_version}")
   }
 
   # Allow ports to be passed as integers or strings.

--- a/spec/classes/datadog_agent_integrations_activemq_xml_spec.rb
+++ b/spec/classes/datadog_agent_integrations_activemq_xml_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::activemq_xml' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_activemq_xml_spec.rb
+++ b/spec/classes/datadog_agent_integrations_activemq_xml_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::activemq_xml' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/activemq_xml.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/activemq_xml.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/activemq_xml.yaml'
+                  else
+                    "#{CONF_DIR}/activemq_xml.d/conf.yaml"
+                  end
 
       context 'with default parameters' do
         it { is_expected.to compile }

--- a/spec/classes/datadog_agent_integrations_apache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_apache_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::apache' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/apache.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/apache.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/apache.yaml'
+                  else
+                    "#{CONF_DIR}/apache.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
 

--- a/spec/classes/datadog_agent_integrations_apache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_apache_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::apache' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_cacti_spec.rb
+++ b/spec/classes/datadog_agent_integrations_cacti_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::cacti' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/cacti.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/cacti.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/cacti.yaml'
+                  else
+                    "#{CONF_DIR}/cacti.d/conf.yaml"
+                  end
 
       context 'with default parameters' do
         it { is_expected.to compile }

--- a/spec/classes/datadog_agent_integrations_cacti_spec.rb
+++ b/spec/classes/datadog_agent_integrations_cacti_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::cacti' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_cassandra_spec.rb
+++ b/spec/classes/datadog_agent_integrations_cassandra_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::cassandra' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/cassandra.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/cassandra.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/cassandra.yaml'
+                  else
+                    "#{CONF_DIR}/cassandra.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('datadog_agent') }

--- a/spec/classes/datadog_agent_integrations_cassandra_spec.rb
+++ b/spec/classes/datadog_agent_integrations_cassandra_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::cassandra' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_ceph_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ceph_spec.rb
@@ -9,12 +9,14 @@ describe 'datadog_agent::integrations::ceph' do
   context 'supported agents' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/ceph.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/ceph.d/conf.yaml" }
-      end
-      let(:sudo_conf_file) { '/etc/sudoers.d/datadog_ceph' }
+
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/ceph.yaml'
+                  else
+                    "#{CONF_DIR}/ceph.d/conf.yaml"
+                  end
+
+      sudo_conf_file = '/etc/sudoers.d/datadog_ceph'
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_ceph_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ceph_spec.rb
@@ -6,8 +6,8 @@ describe 'datadog_agent::integrations::ceph' do
     return
   end
 
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_consul_spec.rb
+++ b/spec/classes/datadog_agent_integrations_consul_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::consul' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_consul_spec.rb
+++ b/spec/classes/datadog_agent_integrations_consul_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::consul' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/consul.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/consul.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/consul.yaml'
+                  else
+                    "#{CONF_DIR}/consul.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_directory_spec.rb
+++ b/spec/classes/datadog_agent_integrations_directory_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::directory' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/directory.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/directory.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/directory.yaml'
+                  else
+                    "#{CONF_DIR}/directory.d/conf.yaml"
+                  end
 
       context 'with default parameters' do
         it { is_expected.not_to compile }

--- a/spec/classes/datadog_agent_integrations_directory_spec.rb
+++ b/spec/classes/datadog_agent_integrations_directory_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::directory' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_disk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_disk_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::disk' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/disk.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/disk.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/disk.yaml'
+                  else
+                    "#{CONF_DIR}/disk.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_disk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_disk_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::disk' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_dns_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_dns_check_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::dns_check' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/dns_check.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/dns_check.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/dns_check.yaml'
+                  else
+                    "#{CONF_DIR}/dns_check.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_dns_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_dns_check_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::dns_check' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
@@ -10,11 +10,11 @@ describe 'datadog_agent::integrations::docker_daemon' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/docker.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/docker.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/docker.yaml'
+                  else
+                    "#{CONF_DIR}/docker.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
@@ -11,12 +11,13 @@ describe 'datadog_agent::integrations::docker_daemon' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5
-                    '/etc/dd-agent/conf.d/docker.yaml'
+                    '/etc/dd-agent/conf.d/docker_daemon.yaml'
                   else
                     "#{CONF_DIR}/docker.d/conf.yaml"
                   end
 
       it { is_expected.to compile.with_all_deps }
+
       it {
         is_expected.to contain_file(conf_file).with(
           owner: DD_USER,

--- a/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_docker_daemon_spec.rb
@@ -6,8 +6,8 @@ describe 'datadog_agent::integrations::docker_daemon' do
     return
   end
 
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::elasticsearch' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/elastic.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/elastic.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/elastic.yaml'
+                  else
+                    "#{CONF_DIR}/elastic.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::elasticsearch' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_fluentd_spec.rb
+++ b/spec/classes/datadog_agent_integrations_fluentd_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::fluentd' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/fluentd.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/fluentd.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/fluentd.yaml'
+                  else
+                    "#{CONF_DIR}/fluentd.d/conf.yaml"
+                  end
 
       context 'with default parameters' do
         it { is_expected.to compile }

--- a/spec/classes/datadog_agent_integrations_fluentd_spec.rb
+++ b/spec/classes/datadog_agent_integrations_fluentd_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::fluentd' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_haproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_haproxy_spec.rb
@@ -10,11 +10,11 @@ describe 'datadog_agent::integrations::haproxy' do
         }
       end
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/haproxy.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/haproxy.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/haproxy.yaml'
+                  else
+                    "#{CONF_DIR}/haproxy.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_haproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_haproxy_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::haproxy' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
       let(:facts) do
         {

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::http_check' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/http_check.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/http_check.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/http_check.yaml'
+                  else
+                    "#{CONF_DIR}/http_check.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::http_check' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_jenkins_spec.rb
+++ b/spec/classes/datadog_agent_integrations_jenkins_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::jenkins' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_jenkins_spec.rb
+++ b/spec/classes/datadog_agent_integrations_jenkins_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::jenkins' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/jenkins.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/jenkins.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/jenkins.yaml'
+                  else
+                    "#{CONF_DIR}/jenkins.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_jmx_spec.rb
+++ b/spec/classes/datadog_agent_integrations_jmx_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::jmx' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_jmx_spec.rb
+++ b/spec/classes/datadog_agent_integrations_jmx_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::jmx' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/jmx.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/jmx.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/jmx.yaml'
+                  else
+                    "#{CONF_DIR}/jmx.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_kafka_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kafka_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::kafka' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_kafka_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kafka_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::kafka' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/kafka.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/kafka.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/kafka.yaml'
+                  else
+                    "#{CONF_DIR}/kafka.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_kong_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kong_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::kong' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_kong_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kong_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::kong' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/kong.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/kong.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/kong.yaml'
+                  else
+                    "#{CONF_DIR}/kong.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_kubernetes_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kubernetes_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::kubernetes' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/kubernetes.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/kubernetes.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/kubernetes.yaml'
+                  else
+                    "#{CONF_DIR}/kubernetes.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_kubernetes_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kubernetes_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::kubernetes' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_kubernetes_state_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kubernetes_state_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::kubernetes_state' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_kubernetes_state_spec.rb
+++ b/spec/classes/datadog_agent_integrations_kubernetes_state_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::kubernetes_state' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/kubernetes_state.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/kubernetes_state.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/kubernetes_state.yaml'
+                  else
+                    "#{CONF_DIR}/kubernetes_state.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_logs_spec.rb
+++ b/spec/classes/datadog_agent_integrations_logs_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'datadog_agent::integrations::logs' do
   context 'supported agents - v6' do
     let(:pre_condition) { "class {'::datadog_agent': agent_major_version => 6}" }
-    let(:conf_file) { "#{CONF_DIR}/logs.yaml" }
+
+    conf_file = "#{CONF_DIR}/logs.yaml"
 
     context 'with default parameters' do
       it { is_expected.to compile }

--- a/spec/classes/datadog_agent_integrations_marathon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_marathon_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::marathon' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/marathon.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/marathon.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/marathon.yaml'
+                  else
+                    "#{CONF_DIR}/marathon.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_marathon_spec.rb
+++ b/spec/classes/datadog_agent_integrations_marathon_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::marathon' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_memcache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_memcache_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::memcache' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/mcache.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/mcache.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/mcache.yaml'
+                  else
+                    "#{CONF_DIR}/mcache.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_memcache_spec.rb
+++ b/spec/classes/datadog_agent_integrations_memcache_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::memcache' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_mesos_master_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mesos_master_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::mesos_master' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_mesos_master_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mesos_master_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::mesos_master' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/mesos_master.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/mesos_master.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/mesos_master.yaml'
+                  else
+                    "#{CONF_DIR}/mesos_master.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_mongo_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mongo_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::mongo' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_mongo_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mongo_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::mongo' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/mongo.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/mongo.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/mongo.yaml'
+                  else
+                    "#{CONF_DIR}/mongo.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_mysql_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mysql_spec.rb
@@ -43,71 +43,71 @@ describe 'datadog_agent::integrations::mysql' do
           it { is_expected.to contain_file(conf_file).with_content(%r{replication: 0}) }
           it { is_expected.to contain_file(conf_file).with_content(%r{galera_cluster: 0}) }
         end
-
-        context 'with parameters set' do
-          let(:params) do
-            {
-              password: 'foobar',
-              host: 'mysql1',
-              user: 'baz',
-              sock: '/tmp/mysql.foo.sock',
-              replication: '1',
-              galera_cluster: '1',
-            }
-          end
-
-          it { is_expected.to contain_file(conf_file).with_content(%r{pass: foobar}) }
-          it { is_expected.to contain_file(conf_file).with_content(%r{server: mysql1}) }
-          it { is_expected.to contain_file(conf_file).with_content(%r{user: baz}) }
-          it { is_expected.to contain_file(conf_file).with_content(%r{sock: /tmp/mysql.foo.sock}) }
-          it { is_expected.to contain_file(conf_file).with_content(%r{replication: 1}) }
-          it { is_expected.to contain_file(conf_file).with_content(%r{galera_cluster: 1}) }
-        end
-
-        context 'with tags parameter array' do
-          let(:params) do
-            {
-              password: 'foobar',
-              tags: ['foo', 'bar', 'baz'],
-            }
-          end
-
-          it { is_expected.to contain_file(conf_file).with_content(%r{tags:[^-]+- foo\s+- bar\s+- baz\s*?[^-]}m) }
-        end
-
-        context 'tags not array' do
-          let(:params) do
-            {
-              password: 'foobar',
-              tags: 'aoeu',
-            }
-          end
-
-          it { is_expected.not_to compile }
-        end
-      end
-    end
-
-    context 'with queries parameter set' do
-      let(:params) do
-        {
-          password: 'foobar',
-          queries: [
-            {
-              'query'  => 'SELECT TIMESTAMPDIFF(second,MAX(create_time),NOW()) as last_accessed FROM requests',
-              'metric' => 'app.seconds_since_last_request',
-              'type'   => 'gauge',
-              'field'  => 'last_accessed',
-            },
-          ],
-        }
       end
 
-      it { is_expected.to contain_file(conf_file).with_content(%r{- query}) }
-      it { is_expected.to contain_file(conf_file).with_content(%r{query: SELECT TIMESTAMPDIFF\(second,MAX\(create_time\),NOW\(\)\) as last_accessed FROM requests}) }
-      it { is_expected.to contain_file(conf_file).with_content(%r{metric: app.seconds_since_last_request}) }
-      it { is_expected.to contain_file(conf_file).with_content(%r{type: gauge}) }
-      it { is_expected.to contain_file(conf_file).with_content(%r{field: last_accessed}) }
+      context 'with parameters set' do
+        let(:params) do
+          {
+            password: 'foobar',
+            host: 'mysql1',
+            user: 'baz',
+            sock: '/tmp/mysql.foo.sock',
+            replication: '1',
+            galera_cluster: '1',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{pass: foobar}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{server: mysql1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{user: baz}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{sock: /tmp/mysql.foo.sock}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{replication: 1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{galera_cluster: 1}) }
+      end
+
+      context 'with tags parameter array' do
+        let(:params) do
+          {
+            password: 'foobar',
+            tags: ['foo', 'bar', 'baz'],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{tags:[^-]+- foo\s+- bar\s+- baz\s*?[^-]}m) }
+      end
+
+      context 'tags not array' do
+        let(:params) do
+          {
+            password: 'foobar',
+            tags: 'aoeu',
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
+
+      context 'with queries parameter set' do
+        let(:params) do
+          {
+            password: 'foobar',
+            queries: [
+              {
+                'query'  => 'SELECT TIMESTAMPDIFF(second,MAX(create_time),NOW()) as last_accessed FROM requests',
+                'metric' => 'app.seconds_since_last_request',
+                'type'   => 'gauge',
+                'field'  => 'last_accessed',
+              },
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{- query}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{query: SELECT TIMESTAMPDIFF\(second,MAX\(create_time\),NOW\(\)\) as last_accessed FROM requests}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{metric: app.seconds_since_last_request}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{type: gauge}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{field: last_accessed}) }
+      end
     end
   end
 end

--- a/spec/classes/datadog_agent_integrations_mysql_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mysql_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::mysql' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_mysql_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mysql_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::mysql' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/mysql.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/mysql.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/mysql.yaml'
+                  else
+                    "#{CONF_DIR}/mysql.d/conf.yaml"
+                  end
 
       context 'with default parameters' do
         it { is_expected.to compile }

--- a/spec/classes/datadog_agent_integrations_network_spec.rb
+++ b/spec/classes/datadog_agent_integrations_network_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::network' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_network_spec.rb
+++ b/spec/classes/datadog_agent_integrations_network_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::network' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/network.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/network.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/network.yaml'
+                  else
+                    "#{CONF_DIR}/network.d/conf.yaml"
+                  end
 
       context 'with default parameters' do
         it { is_expected.to compile }

--- a/spec/classes/datadog_agent_integrations_nginx_spec.rb
+++ b/spec/classes/datadog_agent_integrations_nginx_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::nginx' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_nginx_spec.rb
+++ b/spec/classes/datadog_agent_integrations_nginx_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::nginx' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/nginx.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/nginx.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/nginx.yaml'
+                  else
+                    "#{CONF_DIR}/nginx.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_ntp_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ntp_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::ntp' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_ntp_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ntp_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::ntp' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/ntp.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/ntp.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/ntp.yaml'
+                  else
+                    "#{CONF_DIR}/ntp.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_pgbouncer_spec.rb
+++ b/spec/classes/datadog_agent_integrations_pgbouncer_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::pgbouncer' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_pgbouncer_spec.rb
+++ b/spec/classes/datadog_agent_integrations_pgbouncer_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::pgbouncer' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/pgbouncer.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/pgbouncer.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/pgbouncer.yaml'
+                  else
+                    "#{CONF_DIR}/pgbouncer.d/conf.yaml"
+                  end
 
       context 'with default parameters' do
         let(:params) do

--- a/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
+++ b/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::php_fpm' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
+++ b/spec/classes/datadog_agent_integrations_php_fpm_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::php_fpm' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/php_fpm.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/php_fpm.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/php_fpm.yaml'
+                  else
+                    "#{CONF_DIR}/php_fpm.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_postfix_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postfix_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::postfix' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_postfix_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postfix_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::postfix' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/postfix.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/postfix.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/postfix.yaml'
+                  else
+                    "#{CONF_DIR}/postfix.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_postgres_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postgres_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::postgres' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/postgres.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/postgres.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/postgres.yaml'
+                  else
+                    "#{CONF_DIR}/postgres.d/conf.yaml"
+                  end
 
       context 'with default parameters' do
         it { is_expected.to compile }

--- a/spec/classes/datadog_agent_integrations_postgres_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postgres_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::postgres' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_process_spec.rb
+++ b/spec/classes/datadog_agent_integrations_process_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::process' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/process.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/process.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/process.yaml'
+                  else
+                    "#{CONF_DIR}/process.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_process_spec.rb
+++ b/spec/classes/datadog_agent_integrations_process_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::process' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
+++ b/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::rabbitmq' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/rabbitmq.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/rabbitmq.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/rabbitmq.yaml'
+                  else
+                    "#{CONF_DIR}/rabbitmq.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
+++ b/spec/classes/datadog_agent_integrations_rabbitmq_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::rabbitmq' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::redis' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/redisdb.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/redisdb.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/redisdb.yaml'
+                  else
+                    "#{CONF_DIR}/redisdb.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_redis_spec.rb
+++ b/spec/classes/datadog_agent_integrations_redis_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::redis' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_riak_spec.rb
+++ b/spec/classes/datadog_agent_integrations_riak_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::riak' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_riak_spec.rb
+++ b/spec/classes/datadog_agent_integrations_riak_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::riak' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/riak.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/riak.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/riak.yaml'
+                  else
+                    "#{CONF_DIR}/riak.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_snmp_spec.rb
+++ b/spec/classes/datadog_agent_integrations_snmp_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::snmp' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/snmp.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/snmp.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/snmp.yaml'
+                  else
+                    "#{CONF_DIR}/snmp.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_snmp_spec.rb
+++ b/spec/classes/datadog_agent_integrations_snmp_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::snmp' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_solr_spec.rb
+++ b/spec/classes/datadog_agent_integrations_solr_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::solr' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_solr_spec.rb
+++ b/spec/classes/datadog_agent_integrations_solr_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::solr' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/solr.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/solr.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/solr.yaml'
+                  else
+                    "#{CONF_DIR}/solr.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_ssh_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ssh_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::ssh' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/ssh.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/ssh_check.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/ssh.yaml'
+                  else
+                    "#{CONF_DIR}/ssh_check.d/conf.yaml"
+                  end
 
       context 'with default parameters' do
         it { is_expected.to compile }

--- a/spec/classes/datadog_agent_integrations_ssh_spec.rb
+++ b/spec/classes/datadog_agent_integrations_ssh_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::ssh' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_supervisrd_spec.rb
+++ b/spec/classes/datadog_agent_integrations_supervisrd_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::supervisord' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_supervisrd_spec.rb
+++ b/spec/classes/datadog_agent_integrations_supervisrd_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::supervisord' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/supervisord.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/supervisord.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/supervisord.yaml'
+                  else
+                    "#{CONF_DIR}/supervisord.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_system_core_spec.rb
+++ b/spec/classes/datadog_agent_integrations_system_core_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::system_core' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_system_core_spec.rb
+++ b/spec/classes/datadog_agent_integrations_system_core_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::system_core' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/system_core.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/system_core.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/system_core.yaml'
+                  else
+                    "#{CONF_DIR}/system_core.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::tcp_check' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::tcp_check' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/tcp_check.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/tcp_check.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/tcp_check.yaml'
+                  else
+                    "#{CONF_DIR}/tcp_check.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_tomcat_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tomcat_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::tomcat' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_tomcat_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tomcat_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::tomcat' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/tomcat.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/tomcat.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/tomcat.yaml'
+                  else
+                    "#{CONF_DIR}/tomcat.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_twemproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_twemproxy_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::twemproxy' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/twemproxy.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/twemproxy.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/twemproxy.yaml'
+                  else
+                    "#{CONF_DIR}/twemproxy.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_twemproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_twemproxy_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::twemproxy' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_varnish_spec.rb
+++ b/spec/classes/datadog_agent_integrations_varnish_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::varnish' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/varnish.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/varnish.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/varnish.yaml'
+                  else
+                    "#{CONF_DIR}/varnish.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_varnish_spec.rb
+++ b/spec/classes/datadog_agent_integrations_varnish_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::varnish' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_integrations_zk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_zk_spec.rb
@@ -5,11 +5,11 @@ describe 'datadog_agent::integrations::zk' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
-      if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/zk.yaml' }
-      else
-        let(:conf_file) { "#{CONF_DIR}/zk.d/conf.yaml" }
-      end
+      conf_file = if agent_major_version == 5
+                    '/etc/dd-agent/conf.d/zk.yaml'
+                  else
+                    "#{CONF_DIR}/zk.d/conf.yaml"
+                  end
 
       it { is_expected.to compile.with_all_deps }
       it {

--- a/spec/classes/datadog_agent_integrations_zk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_zk_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integrations::zk' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       conf_file = if agent_major_version == 5

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -13,7 +13,8 @@ describe 'datadog_agent::reports' do
         dogapi_version: 'installed',
       }
     end
-    let(:conf_file) { '/etc/datadog-agent/datadog-reports.yaml' }
+
+    conf_file = '/etc/datadog-agent/datadog-reports.yaml'
 
     ALL_OS.each do |operatingsystem|
       describe "datadog_agent class common actions on #{operatingsystem}" do
@@ -75,7 +76,8 @@ describe 'datadog_agent::reports' do
         dogapi_version: '1.2.2',
       }
     end
-    let(:conf_file) { '/etc/datadog-agent/datadog-reports.yaml' }
+
+    conf_file = '/etc/datadog-agent/datadog-reports.yaml'
 
     describe 'datadog_agent class dogapi version override' do
       let(:facts) do
@@ -120,7 +122,6 @@ describe 'datadog_agent::reports' do
 
       }
     end
-    let(:conf_file) { '/etc/datadog-agent/datadog-reports.yaml' }
 
     describe 'datadog_agent class puppet gem provider override' do
       let(:facts) do
@@ -158,7 +159,8 @@ describe 'datadog_agent::reports' do
         datadog_site: 'datadoghq.eu',
       }
     end
-    let(:conf_file) { '/etc/datadog-agent/datadog-reports.yaml' }
+
+    conf_file = '/etc/datadog-agent/datadog-reports.yaml'
 
     describe 'datadog_agent class dogapi version override' do
       let(:facts) do

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -5,12 +5,13 @@ describe 'datadog_agent::integration' do
     ALL_SUPPORTED_AGENTS.each do |agent_major_version|
       let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
       if agent_major_version == 5
-        let(:conf_file) { '/etc/dd-agent/conf.d/test.yaml' }
-
+        conf_file = '/etc/dd-agent/conf.d/test.yaml'
       else
-        let(:conf_dir) { "#{CONF_DIR}/test.d" }
-        let(:conf_file) { "#{conf_dir}/conf.yaml" }
+        conf_dir = "#{CONF_DIR}/test.d"
+        conf_file = "#{conf_dir}/conf.yaml"
       end
+
+      let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
 
       let(:title) { 'test' }
 

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
 describe 'datadog_agent::integration' do
-  context 'supported agents' do
-    ALL_SUPPORTED_AGENTS.each do |agent_major_version|
-      let(:pre_condition) { "class {'::datadog_agent': agent_major_version => #{agent_major_version}}" }
+  ALL_SUPPORTED_AGENTS.each do |agent_major_version|
+    context 'supported agents' do
       if agent_major_version == 5
         conf_file = '/etc/dd-agent/conf.d/test.yaml'
       else

--- a/spec/defines/datadog_agent__integration_spec.rb
+++ b/spec/defines/datadog_agent__integration_spec.rb
@@ -14,9 +14,7 @@ describe 'datadog_agent::integration' do
 
       let(:title) { 'test' }
 
-      gem_spec = Gem.loaded_specs['puppet']
-
-      if agent_major_version == 5
+      if agent_major_version > 5
         it { is_expected.to contain_file(conf_dir.to_s).that_comes_before("File[#{conf_file}]") }
       end
       it { is_expected.to contain_file(conf_file.to_s).that_notifies("Service[#{SERVICE_NAME}]") }
@@ -33,11 +31,7 @@ describe 'datadog_agent::integration' do
         end
 
         it { is_expected.to compile }
-        if gem_spec.version >= Gem::Version.new('4.0.0')
-          it { is_expected.to contain_file(conf_file.to_s).with_content(%r{---\ninit_config: \ninstances:\n- one: two\n}) }
-        else
-          it { is_expected.to contain_file(conf_file.to_s).with_content(%r{--- \n  init_config: \n  instances: \n    - one: two}) }
-        end
+        it { is_expected.to contain_file(conf_file.to_s).with_content(%r{---\s?\n\s*init_config:\s?\n\s*instances:\s?\n\s*- one: two}) }
         it { is_expected.to contain_file(conf_file).with_ensure('file') }
       end
 
@@ -54,11 +48,7 @@ describe 'datadog_agent::integration' do
         end
 
         it { is_expected.to compile }
-        if gem_spec.version >= Gem::Version.new('4.0.0')
-          it { is_expected.to contain_file(conf_file).with_content(%r{logs:\n- one\n- two}) }
-        else
-          it { is_expected.to contain_file(conf_file).with_content(%r{logs:\n  - one\n  - two}) }
-        end
+        it { is_expected.to contain_file(conf_file).with_content(%r{logs:\n\s*- one\n\s*- two}) }
         it { is_expected.to contain_file(conf_file).with_ensure('file') }
       end
 


### PR DESCRIPTION
### What does this PR do?

- Create one context per Agent version in a loop, instead of a single context looping through all the Agent versions. Since the tests run once the context is done creating, only Agent 7 (the latest in the loop) got tested before.
- Fix the tests that were broken.
- Changed one error message that was useful to me when debugging this.
- Do not use `let` in tests for variables that don't need lazy evaluation.

### Motivation

We weren't testing Agent 5/6 😅 
