### PR TITLE
Allow creating more than one config file per integration

### DIFF
--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -3,19 +3,23 @@ define datadog_agent::integration (
   Optional[Hash] $init_config       = undef,
   Optional[Array] $logs             = undef,
   String $integration               = $title,
+  String $conf_file                 = 'conf',
   Enum['present', 'absent'] $ensure = 'present',
 ){
 
   include datadog_agent
 
   if $::datadog_agent::_agent_major_version > 5 {
-    $dst = "${datadog_agent::params::conf_dir}/${integration}.d/conf.yaml"
-    file { "${datadog_agent::params::conf_dir}/${integration}.d":
-      ensure => directory,
-      owner  => $datadog_agent::dd_user,
-      group  => $datadog_agent::dd_group,
-      mode   => $datadog_agent::params::permissions_directory,
-      before => File[$dst]
+    $dst_dir = "${datadog_agent::params::conf_dir}/${integration}.d"
+    $dst = "${dst_dir}/${$conf_file}.yaml"
+    if (! defined(File[$dst_dir])) {
+      file { $dst_dir:
+        ensure => directory,
+        owner  => $datadog_agent::dd_user,
+        group  => $datadog_agent::dd_group,
+        mode   => $datadog_agent::params::permissions_directory,
+        before => File[$dst]
+      }
     }
   } else {
     $dst = "${datadog_agent::params::legacy_conf_dir}/${integration}.yaml"


### PR DESCRIPTION
### What does this PR do?

Allows specifying the name of the config file to be created by `datadog_agent::integration`, so different config files with different instances can be defined from different places in the code. For example, in the following manifest we define two config files for the `postgres` integration:

```
  datadog_agent::integration { 'postgres_dbA':
    integration => 'postgres',
    conf_file => 'dbA',
    instances => [{
      host     => 'localhost',
      dbname   => 'dbA',
      username => 'dbAuser',
      password => 'dbApass',
    }],
  }

  datadog_agent::integration { 'postgres_dbB':
    integration => 'postgres',
    conf_file => 'dbB',
    instances => [{
      host     => 'localhost',
      dbname   => 'dbB',
      username => 'dbBuser',
      password => 'dbBpass',
    }],
  }
```

which results in a config file being created for each:

```
$ cat /etc/datadog-agent/conf.d/postgres.d/dbA.yaml 
---
init_config: 
instances:
- host: localhost
  dbname: dbA
  username: dbAuser
  password: dbApass
$ cat /etc/datadog-agent/conf.d/postgres.d/dbB.yaml 
---
init_config: 
instances:
- host: localhost
  dbname: dbB
  username: dbBuser
  password: dbBpass
```

### Motivation

Fixes #147

