### PR TITLE
Fix service restart on Windows

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,6 +13,7 @@ class datadog_agent::service(
       service { $datadog_agent::params::service_name:
         ensure  => $service_ensure,
         enable  => $service_enable,
+        restart => ['powershell', '-Command', 'Restart-Service -Force DatadogAgent'], # Force restarts dependent services
         require => Package[$datadog_agent::params::package_name]
       }
   } else {


### PR DESCRIPTION
### What does this PR do?

Fix restart when dependent services are also running by setting a custom `restart` command in the service definition.

Fixes the error:
```
A stop control has been sent to a service that other running services are dependent on.
```

