### PR TITLE
Add windows_npm_install option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -339,6 +339,7 @@ class datadog_agent(
   Enum['present', 'absent'] $win_ensure = 'present', #TODO: Implement uninstall also for apt and rpm install methods
   Optional[String] $service_provider = undef,
   Optional[String] $agent_version = $datadog_agent::params::agent_version,
+  Optional[Boolean] $windows_npm_install = undef,
 ) inherits datadog_agent::params {
 
   #In this regex, version '1:6.15.0~rc.1-1' would match as $1='1:', $2='6', $3='15', $4='0', $5='~rc.1', $6='1'
@@ -445,7 +446,8 @@ class datadog_agent(
           api_key             => $api_key,
           hostname            => $host,
           tags                => $local_tags,
-          ensure              => $win_ensure
+          ensure              => $win_ensure,
+          npm_install         => $windows_npm_install,
         }
         if ($win_ensure == absent) {
           return() #Config files will remain unchanged on uninstall

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -339,7 +339,7 @@ class datadog_agent(
   Enum['present', 'absent'] $win_ensure = 'present', #TODO: Implement uninstall also for apt and rpm install methods
   Optional[String] $service_provider = undef,
   Optional[String] $agent_version = $datadog_agent::params::agent_version,
-  Optional[Boolean] $windows_npm_install = undef,
+  Boolean $windows_npm_install = false,
 ) inherits datadog_agent::params {
 
   #In this regex, version '1:6.15.0~rc.1-1' would match as $1='1:', $2='6', $3='15', $4='0', $5='~rc.1', $6='1'

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -66,13 +66,14 @@ class datadog_agent::windows(
       $ensure_version = $agent_version
     }
 
+    $hostname_option = $hostname ? { '' => {}, default => { 'HOSTNAME' => $hostname } }
     $npm_install_option = $npm_install ? { undef => {}, true => { 'NPM' => 'true' }, false => { 'NPM' => 'false' } }
 
     package { $datadog_agent::params::package_name:
       ensure          => $ensure_version,
       provider        => 'windows',
       source          => $msi_full_path,
-      install_options => ['/norestart', {'APIKEY' => $api_key, 'HOSTNAME' => $hostname, 'TAGS' => $tags_quote_wrap} + $npm_install_option]
+      install_options => ['/norestart', {'APIKEY' => $api_key, 'TAGS' => $tags_quote_wrap} + $npm_install_option + $hostname_option]
     }
 
   } else {

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -14,7 +14,7 @@ class datadog_agent::windows(
   String $tags_join = join($tags,','),
   String $tags_quote_wrap = "\"${tags_join}\"",
   Enum['present', 'absent'] $ensure = 'present',
-  Optional[Boolean] $npm_install = undef,
+  Boolean $npm_install = false,
 ) inherits datadog_agent::params {
 
   $msi_full_path = "${msi_location}/datadog-agent-${agent_major_version}-${agent_version}.amd64.msi"
@@ -67,7 +67,7 @@ class datadog_agent::windows(
     }
 
     $hostname_option = $hostname ? { '' => {}, default => { 'HOSTNAME' => $hostname } }
-    $npm_install_option = $npm_install ? { undef => {}, true => { 'NPM' => 'true' }, false => { 'NPM' => 'false' } }
+    $npm_install_option = $npm_install ? { false => {}, true => { 'NPM' => 'true' } }
 
     package { $datadog_agent::params::package_name:
       ensure          => $ensure_version,

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -14,6 +14,7 @@ class datadog_agent::windows(
   String $tags_join = join($tags,','),
   String $tags_quote_wrap = "\"${tags_join}\"",
   Enum['present', 'absent'] $ensure = 'present',
+  Optional[Boolean] $npm_install = undef,
 ) inherits datadog_agent::params {
 
   $msi_full_path = "${msi_location}/datadog-agent-${agent_major_version}-${agent_version}.amd64.msi"
@@ -65,11 +66,13 @@ class datadog_agent::windows(
       $ensure_version = $agent_version
     }
 
+    $npm_install_option = $npm_install ? { undef => {}, true => { 'NPM' => 'true' }, false => { 'NPM' => 'false' } }
+
     package { $datadog_agent::params::package_name:
       ensure          => $ensure_version,
       provider        => 'windows',
       source          => $msi_full_path,
-      install_options => ['/norestart', {'APIKEY' => $api_key, 'HOSTNAME' => $hostname, 'TAGS' => $tags_quote_wrap}]
+      install_options => ['/norestart', {'APIKEY' => $api_key, 'HOSTNAME' => $hostname, 'TAGS' => $tags_quote_wrap} + $npm_install_option]
     }
 
   } else {

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -134,6 +134,65 @@ describe 'datadog_agent' do
     end
   end
 
+  context 'windows NPM' do
+    let(:facts) do
+      {
+        osfamily: 'windows',
+        operatingsystem: 'Windows',
+      }
+    end
+
+    describe "with NPM enabled" do
+      let(:params) do
+        {
+          agent_major_version: 7,
+          windows_npm_install: true,
+          api_key: 'notakey',
+          host: 'notahost',
+        }
+      end
+      it do
+        is_expected.to contain_package('Datadog Agent').with({
+          'ensure': 'installed',
+          'install_options': [ '/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'true' } ]
+        })
+      end
+    end
+
+    describe "with NPM disabled" do
+      let(:params) do
+        {
+          agent_major_version: 7,
+          windows_npm_install: false,
+          api_key: 'notakey',
+          host: 'notahost',
+        }
+      end
+      it do
+        is_expected.to contain_package('Datadog Agent').with({
+          'ensure': 'installed',
+          'install_options': [ '/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'false' } ]
+        })
+      end
+    end
+
+    describe "with NPM undef" do
+      let(:params) do
+        {
+          agent_major_version: 7,
+          api_key: 'notakey',
+          host: 'notahost',
+        }
+      end
+      it do
+        is_expected.to contain_package('Datadog Agent').with({
+          'ensure': 'installed',
+          'install_options': [ '/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""' } ]
+        })
+      end
+    end
+  end
+
   # Test all supported OSes
   context 'all supported operating systems' do
     ALL_OS.each do |operatingsystem|

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -142,7 +142,7 @@ describe 'datadog_agent' do
       }
     end
 
-    describe "with NPM enabled" do
+    describe 'with NPM enabled' do
       let(:params) do
         {
           agent_major_version: 7,
@@ -151,15 +151,16 @@ describe 'datadog_agent' do
           host: 'notahost',
         }
       end
+
       it do
-        is_expected.to contain_package('Datadog Agent').with({
-          'ensure': 'installed',
-          'install_options': [ '/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'true' } ]
-        })
+        is_expected.to contain_package('Datadog Agent').with(
+          ensure: 'installed',
+          install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'true' }],
+        )
       end
     end
 
-    describe "with NPM disabled" do
+    describe 'with NPM disabled' do
       let(:params) do
         {
           agent_major_version: 7,
@@ -168,15 +169,16 @@ describe 'datadog_agent' do
           host: 'notahost',
         }
       end
+
       it do
-        is_expected.to contain_package('Datadog Agent').with({
-          'ensure': 'installed',
-          'install_options': [ '/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'false' } ]
-        })
+        is_expected.to contain_package('Datadog Agent').with(
+          ensure: 'installed',
+          install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'false' }],
+        )
       end
     end
 
-    describe "with NPM undef" do
+    describe 'with NPM undef' do
       let(:params) do
         {
           agent_major_version: 7,
@@ -184,11 +186,12 @@ describe 'datadog_agent' do
           host: 'notahost',
         }
       end
+
       it do
-        is_expected.to contain_package('Datadog Agent').with({
-          'ensure': 'installed',
-          'install_options': [ '/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""' } ]
-        })
+        is_expected.to contain_package('Datadog Agent').with(
+          ensure: 'installed',
+          install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""' }],
+        )
       end
     end
   end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -134,46 +134,48 @@ describe 'datadog_agent' do
     end
   end
 
-  context 'windows NPM' do
-    let(:facts) do
-      {
-        osfamily: 'windows',
-        operatingsystem: 'Windows',
-      }
-    end
-
-    describe 'with NPM enabled' do
-      let(:params) do
+  if Gem::Version.new(Puppet.version) >= Gem::Version.new('4.10') # We don't support Windows on Puppet older than 4.10
+    context 'windows NPM' do
+      let(:facts) do
         {
-          agent_major_version: 7,
-          windows_npm_install: true,
-          api_key: 'notakey',
-          host: 'notahost',
+          osfamily: 'windows',
+          operatingsystem: 'Windows',
         }
       end
 
-      it do
-        is_expected.to contain_package('Datadog Agent').with(
-          ensure: 'installed',
-          install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'true' }],
-        )
-      end
-    end
+      describe 'with NPM enabled' do
+        let(:params) do
+          {
+            agent_major_version: 7,
+            windows_npm_install: true,
+            api_key: 'notakey',
+            host: 'notahost',
+          }
+        end
 
-    describe 'with NPM disabled' do
-      let(:params) do
-        {
-          agent_major_version: 7,
-          api_key: 'notakey',
-          host: 'notahost',
-        }
+        it do
+          is_expected.to contain_package('Datadog Agent').with(
+            ensure: 'installed',
+            install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'true' }],
+          )
+        end
       end
 
-      it do
-        is_expected.to contain_package('Datadog Agent').with(
-          ensure: 'installed',
-          install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""' }],
-        )
+      describe 'with NPM disabled' do
+        let(:params) do
+          {
+            agent_major_version: 7,
+            api_key: 'notakey',
+            host: 'notahost',
+          }
+        end
+
+        it do
+          is_expected.to contain_package('Datadog Agent').with(
+            ensure: 'installed',
+            install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""' }],
+          )
+        end
       end
     end
   end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -164,24 +164,6 @@ describe 'datadog_agent' do
       let(:params) do
         {
           agent_major_version: 7,
-          windows_npm_install: false,
-          api_key: 'notakey',
-          host: 'notahost',
-        }
-      end
-
-      it do
-        is_expected.to contain_package('Datadog Agent').with(
-          ensure: 'installed',
-          install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'false' }],
-        )
-      end
-    end
-
-    describe 'with NPM undef' do
-      let(:params) do
-        {
-          agent_major_version: 7,
           api_key: 'notakey',
           host: 'notahost',
         }


### PR DESCRIPTION
### What does this PR do?

Adds a `windows_npm_install` option to the `datadog_agent` class that makes the installer run with `NPM=true` when enabled.

### Motivation

Add Windows NPM support for 7.27.0

### Additional Notes

Writing the tests I realized that we are passing `""` as tags to the installer if no tag is set. I'm not sure if that could cause issues.

### Describe your test plan

Added rspec test and tested manually.
