### PR TITLE
Add agent_flavor env var for agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@ then it is safe to upgrade.
 
 * [FEATURE] Support EU site in the reporter. See [#468][]
 * [FEATURE] Add `datadog_site` for EU/USA region support. See [#464][]
+* [FEATURE] Add `agent_flavor` for selecting the IoT agent. 
 * [FEATURE] Make Agent 6 `cmd_port` configurable. See [#473][] (Thanks [@arkpoah][])
 * [FEATURE] Support backup keyservers. See [#470][]
 * [FEATURE] Support `hostname_fqdn`. See [#481][] (Thanks [@alexfouche][])

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,8 @@
 #       This option is only available with agent version >= 6.6.0.
 #   $host:
 #       Force the hostname to whatever you want. (default: auto-detected)
+#   $agent_flavor:
+#       Change the flavor of the Datadog agent to the IOT agent. (default: datadog-agent)
 #   $api_key:
 #       Your DataDog API Key. Please replace with your key value.
 #   $collect_ec2_tags
@@ -242,6 +244,7 @@ class datadog_agent(
   String $datadog_site = $datadog_agent::params::datadog_site,
   String $host = '',
   String $api_key = 'your_API_key',
+  String $agent_flavor = $datadog_agent::params::agent_flavor,
   Boolean $collect_ec2_tags = false,
   Boolean $collect_gce_tags = false,
   Boolean $collect_instance_metadata = true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@
 #
 
 class datadog_agent::params {
+  $agent_flavor                   = 'datadog-agent'
   $datadog_site                   = 'datadoghq.com'
   $dd_groups                      = undef
   $default_agent_major_version    = 7

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -15,6 +15,7 @@
 #
 class datadog_agent::reports(
   $api_key,
+  $agent_flavor = 'datadog-agent',
   $puppetmaster_user,
   $dogapi_version,
   $manage_dogapi_gem = true,

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -8,6 +8,7 @@ describe 'datadog_agent::reports' do
   context 'all supported operating systems' do
     let(:params) do
       {
+        agent_flavor: 'datadog-agent',
         api_key: 'notanapikey',
         puppetmaster_user: 'puppet',
         dogapi_version: 'installed',
@@ -115,6 +116,7 @@ describe 'datadog_agent::reports' do
   context 'specific gem provider' do
     let(:params) do
       {
+        agent_flavor: 'datadog-agent',
         api_key: 'notanapikey',
         puppetmaster_user: 'puppet',
         dogapi_version: '1.2.2',
@@ -153,6 +155,7 @@ describe 'datadog_agent::reports' do
   context 'EU site in report' do
     let(:params) do
       {
+        agent_flavor: 'datadog-agent',
         api_key: 'notanapikey',
         puppetmaster_user: 'puppet',
         dogapi_version: 'installed',
@@ -194,6 +197,7 @@ describe 'datadog_agent::reports' do
   context 'disabled ruby-manage' do
     let(:params) do
       {
+        agent_flavor: 'datadog-agent',
         api_key: 'notanapikey',
         hostname_extraction_regex: nil,
         dogapi_version: 'installed',


### PR DESCRIPTION
### What does this PR do?

Places the DD_AGENT_FLAVOR env var on the agent to choose IoT or standard agent variant. 

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
