### PR TITLE
Allow specifying an agent_flavor to install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -244,7 +244,7 @@ class datadog_agent(
   String $datadog_site = $datadog_agent::params::datadog_site,
   String $host = '',
   String $api_key = 'your_API_key',
-  String $agent_flavor = $datadog_agent::params::package_name,
+  Enum['datadog-agent', 'datadog-iot-agent'] $agent_flavor = $datadog_agent::params::package_name,
   Boolean $collect_ec2_tags = false,
   Boolean $collect_gce_tags = false,
   Boolean $collect_instance_metadata = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,8 @@
 #       Force the hostname to whatever you want. (default: auto-detected)
 #   $api_key:
 #       Your DataDog API Key. Please replace with your key value.
+#   $agent_flavor:
+#       Linux-only. The Agent flavor to install, eg: "datadog-agent" or "datadog-iot-agent".
 #   $collect_ec2_tags
 #       Collect AWS EC2 custom tags as agent tags.
 #       Boolean. Default: false
@@ -242,6 +244,7 @@ class datadog_agent(
   String $datadog_site = $datadog_agent::params::datadog_site,
   String $host = '',
   String $api_key = 'your_API_key',
+  String $agent_flavor = $datadog_agent::params::package_name,
   Boolean $collect_ec2_tags = false,
   Boolean $collect_gce_tags = false,
   Boolean $collect_instance_metadata = true,
@@ -423,6 +426,7 @@ class datadog_agent(
         class { 'datadog_agent::ubuntu':
           agent_major_version   => $_agent_major_version,
           agent_version         => $agent_version,
+          agent_flavor          => $agent_flavor,
           agent_repo_uri        => $agent_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
@@ -432,6 +436,7 @@ class datadog_agent(
       'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux' : {
         class { 'datadog_agent::redhat':
           agent_major_version => $_agent_major_version,
+          agent_flavor        => $agent_flavor,
           agent_repo_uri      => $agent_repo_uri,
           manage_repo         => $manage_repo,
           agent_version       => $agent_version,
@@ -456,6 +461,7 @@ class datadog_agent(
       'OpenSuSE', 'SLES' : {
         class { 'datadog_agent::suse' :
           agent_major_version => $_agent_major_version,
+          agent_flavor        => $agent_flavor,
           agent_repo_uri      => $agent_repo_uri,
           agent_version       => $agent_version,
         }
@@ -463,8 +469,8 @@ class datadog_agent(
       default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
     }
   } else {
-    if ! defined(Package[$datadog_agent::params::package_name]) {
-      package { $datadog_agent::params::package_name:
+    if ! defined(Package[$agent_flavor]) {
+      package { $agent_flavor:
         ensure => present,
         source => 'Agent installation not managed by Puppet, make sure the Agent is installed beforehand.',
       }
@@ -473,6 +479,7 @@ class datadog_agent(
 
   # Declare service
   class { 'datadog_agent::service' :
+    agent_flavor     => $agent_flavor,
     service_ensure   => $service_ensure,
     service_enable   => $service_enable,
     service_provider => $service_provider,
@@ -492,7 +499,7 @@ class datadog_agent(
       owner   => $dd_user,
       group   => $dd_group,
       mode    => $datadog_agent::params::permissions_directory,
-      require => Package[$datadog_agent::params::package_name],
+      require => Package[$agent_flavor],
     }
   }
 
@@ -511,7 +518,7 @@ class datadog_agent(
       owner   => $dd_user,
       group   => $dd_group,
       mode    => $datadog_agent::params::permissions_directory,
-      require => Package[$datadog_agent::params::package_name],
+      require => Package[$agent_flavor],
     }
 
     file { $_conf_dir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -244,7 +244,7 @@ class datadog_agent(
   String $datadog_site = $datadog_agent::params::datadog_site,
   String $host = '',
   String $api_key = 'your_API_key',
-  Enum['datadog-agent', 'datadog-iot-agent'] $agent_flavor = $datadog_agent::params::package_name,
+  Enum['datadog-agent', 'Datadog Agent', 'datadog-iot-agent'] $agent_flavor = $datadog_agent::params::package_name,
   Boolean $collect_ec2_tags = false,
   Boolean $collect_gce_tags = false,
   Boolean $collect_instance_metadata = true,

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -8,6 +8,7 @@ class datadog_agent::redhat(
   Optional[String] $agent_repo_uri = undef,
   Boolean $manage_repo = true,
   String $agent_version = $datadog_agent::params::agent_version,
+  String $agent_flavor = $datadog_agent::params::package_name,
 ) inherits datadog_agent::params {
 
   if $manage_repo {
@@ -60,12 +61,12 @@ class datadog_agent::redhat(
       baseurl  => $baseurl,
     }
 
-    package { $datadog_agent::params::package_name:
+    package { $agent_flavor:
       ensure  => $agent_version,
       require => Yumrepo['datadog'],
     }
   } else {
-    package { $datadog_agent::params::package_name:
+    package { $agent_flavor:
       ensure  => $agent_version,
     }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,6 +7,7 @@ class datadog_agent::service(
   $service_ensure = 'running',
   Boolean $service_enable = true,
   Optional[String] $service_provider = undef,
+  String $agent_flavor = $datadog_agent::params::package_name,
 ) inherits datadog_agent::params {
 
   if ($::operatingsystem == 'Windows') {
@@ -24,7 +25,7 @@ class datadog_agent::service(
         provider  => $service_provider,
         hasstatus => false,
         pattern   => 'dd-agent',
-        require   => Package[$datadog_agent::params::package_name],
+        require   => Package[$agent_flavor],
       }
     } else {
       service { $datadog_agent::params::service_name:
@@ -32,7 +33,7 @@ class datadog_agent::service(
         enable    => $service_enable,
         hasstatus => false,
         pattern   => 'dd-agent',
-        require   => Package[$datadog_agent::params::package_name],
+        require   => Package[$agent_flavor],
       }
     }
   }

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -8,6 +8,7 @@ class datadog_agent::suse(
   String $agent_version = $datadog_agent::params::agent_version,
   String $release = $datadog_agent::params::apt_default_release,
   Optional[String] $agent_repo_uri = undef,
+  String $agent_flavor = $datadog_agent::params::package_name,
 ) inherits datadog_agent::params {
 
   $all_keys = [
@@ -31,7 +32,7 @@ class datadog_agent::suse(
 
   package { 'datadog-agent-base':
     ensure => absent,
-    before => Package[$datadog_agent::params::package_name],
+    before => Package[$agent_flavor],
   }
 
   # We need to install GPG keys manually since zypper will autoreject new keys
@@ -62,7 +63,7 @@ class datadog_agent::suse(
     keeppackages => 1,
   }
 
-  package { $datadog_agent::params::package_name:
+  package { $agent_flavor:
     ensure  => $agent_version,
   }
 

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -11,6 +11,7 @@ class datadog_agent::ubuntu(
   String $release = $datadog_agent::params::apt_default_release,
   Boolean $skip_apt_key_trusting = false,
   String $apt_keyserver = $datadog_agent::params::apt_keyserver,
+  String $agent_flavor = $datadog_agent::params::package_name,
 ) inherits datadog_agent::params {
 
   if $agent_version =~ /^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/ {
@@ -63,10 +64,10 @@ class datadog_agent::ubuntu(
 
   package { 'datadog-agent-base':
     ensure => absent,
-    before => Package[$datadog_agent::params::package_name],
+    before => Package[$agent_flavor],
   }
 
-  package { $datadog_agent::params::package_name:
+  package { $agent_flavor:
     ensure  => $platform_agent_version,
     require => [Apt::Source['datadog'],
                 Class['apt::update']],

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -132,6 +132,47 @@ describe 'datadog_agent' do
           .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
       end
     end
+
+    context 'default agent_flavor' do
+      let(:params) do
+        {
+          agent_version: '1:6.15.1-1',
+        }
+      end
+      let(:facts) do
+        {
+          osfamily: 'debian',
+          operatingsystem: 'Ubuntu',
+        }
+      end
+
+      it do
+        is_expected.to contain_package('datadog-agent').with(
+          ensure: 'installed',
+        )
+      end
+    end
+
+    context 'specify agent_flavor' do
+      let(:params) do
+        {
+          agent_version: '1:6.15.1-1',
+          agent_flavor: "datadog-iot-agent"
+        }
+      end
+      let(:facts) do
+        {
+          osfamily: 'debian',
+          operatingsystem: 'Ubuntu',
+        }
+      end
+
+      it do
+        is_expected.to contain_package('datadog-iot-agent').with(
+          ensure: 'installed',
+        )
+      end
+    end
   end
 
   if Gem::Version.new(Puppet.version) >= Gem::Version.new('4.10') # We don't support Windows on Puppet older than 4.10

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -169,7 +169,7 @@ describe 'datadog_agent' do
 
       it do
         is_expected.to contain_package('datadog-iot-agent').with(
-          ensure: 'installed',
+          ensure: "1:6.15.1-1",
         )
       end
     end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -148,7 +148,7 @@ describe 'datadog_agent' do
 
       it do
         is_expected.to contain_package('datadog-agent').with(
-          ensure: 'installed',
+          ensure: '1:6.15.1-1',
         )
       end
     end

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -157,7 +157,7 @@ describe 'datadog_agent' do
       let(:params) do
         {
           agent_version: '1:6.15.1-1',
-          agent_flavor: "datadog-iot-agent"
+          agent_flavor: 'datadog-iot-agent',
         }
       end
       let(:facts) do

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -169,7 +169,7 @@ describe 'datadog_agent' do
 
       it do
         is_expected.to contain_package('datadog-iot-agent').with(
-          ensure: "1:6.15.1-1",
+          ensure: '1:6.15.1-1',
         )
       end
     end


### PR DESCRIPTION
### What does this PR do?

Allow specifying an `agent_flavor` to install.

### Motivation

Make it possible to install the IoT flavor of the Agent.

### Additional notes

Caveats: If the regular Agent is installed, it will fail to install the IoT Agent until the regular Agent is uninstalled (since the two packages install the same files).