### PR TITLE
Add the 'current' gpg key, only use 1 gpgkey on suse < 15

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -14,10 +14,10 @@ class datadog_agent::redhat(
   if $manage_repo {
 
     $keys = [
-        'https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
-        'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
-        'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public',
-        'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+        'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
+        'https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+        'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
+        'https://keys.datadoghq.com/DATADOG_RPM_KEY.public',
     ]
 
     case $agent_major_version {

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -14,9 +14,10 @@ class datadog_agent::redhat(
   if $manage_repo {
 
     $keys = [
-        'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+        'https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
         'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
         'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public',
+        'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
     ]
 
     case $agent_major_version {
@@ -30,7 +31,7 @@ class datadog_agent::redhat(
       }
       7 : {
         $defaulturl = "https://yum.datadoghq.com/stable/7/${::architecture}/"
-        $gpgkeys = $keys[1,2]
+        $gpgkeys = $keys[0,-2]
       }
       default: { fail('invalid agent_major_version') }
     }

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -11,12 +11,12 @@ class datadog_agent::suse(
   String $agent_flavor = $datadog_agent::params::package_name,
 ) inherits datadog_agent::params {
 
-  $current_key = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public'
+  $current_key = 'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public'
   $all_keys = [
     $current_key,
-    'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
-    'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public',
-    'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+    'https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
+    'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
+    'https://keys.datadoghq.com/DATADOG_RPM_KEY.public',
   ]
 
   case $agent_major_version {

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -62,7 +62,7 @@ class datadog_agent::suse(
     name         => 'datadog',
     gpgcheck     => 1,
     # zypper on SUSE < 15 only understands a single gpgkey value
-    gpgkey       => (Float($::operatingsystemmajrelease) >= 15.0) ? { true => join($gpgkeys, "	"), default => $current_key },
+    gpgkey       => (Float($::operatingsystemmajrelease) >= 15.0) ? { true => join($gpgkeys, "\n       "), default => $current_key },
     keeppackages => 1,
   }
 

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -11,16 +11,18 @@ class datadog_agent::suse(
   String $agent_flavor = $datadog_agent::params::package_name,
 ) inherits datadog_agent::params {
 
+  $current_key = 'https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public'
   $all_keys = [
-    'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
+    $current_key,
     'https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public',
     'https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public',
+    'https://yum.datadoghq.com/DATADOG_RPM_KEY.public',
   ]
 
   case $agent_major_version {
       5 : { fail('Agent v5 package not available in SUSE') }
       6 : { $gpgkeys = $all_keys }
-      7 : { $gpgkeys = $all_keys[1,2] }
+      7 : { $gpgkeys = $all_keys[0,-2] }
       default: { fail('invalid agent_major_version') }
   }
 
@@ -59,7 +61,8 @@ class datadog_agent::suse(
     autorefresh  => 1,
     name         => 'datadog',
     gpgcheck     => 1,
-    gpgkey       => join($gpgkeys, "	"),
+    # zypper on SUSE < 15 only understands a single gpgkey value
+    gpgkey       => (Float($::operatingsystemmajrelease) >= 15.0) ? { true => join($gpgkeys, "	"), default => $current_key },
     keeppackages => 1,
   }
 

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -27,9 +27,10 @@ describe 'datadog_agent::redhat' do
         is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
           .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
       end
     end
@@ -74,9 +75,10 @@ describe 'datadog_agent::redhat' do
         is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/6/x86_64/')
       end
     end
@@ -122,7 +124,8 @@ describe 'datadog_agent::redhat' do
         is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
        https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')
       end

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -27,10 +27,10 @@ describe 'datadog_agent::redhat' do
         is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY.public')\
           .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
       end
     end
@@ -75,10 +75,10 @@ describe 'datadog_agent::redhat' do
         is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/6/x86_64/')
       end
     end
@@ -124,9 +124,9 @@ describe 'datadog_agent::redhat' do
         is_expected.to contain_yumrepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
           .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')
       end
     end

--- a/spec/classes/datadog_agent_suse_spec.rb
+++ b/spec/classes/datadog_agent_suse_spec.rb
@@ -31,9 +31,9 @@ describe 'datadog_agent::suse' do
           .with_enabled(1)\
           .with_gpgcheck(1)\
           .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-	https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
-	https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
       end
     end
@@ -50,8 +50,8 @@ describe 'datadog_agent::suse' do
           .with_enabled(1)\
           .with_gpgcheck(1)\
           .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-	https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
       end
     end

--- a/spec/classes/datadog_agent_suse_spec.rb
+++ b/spec/classes/datadog_agent_suse_spec.rb
@@ -12,35 +12,83 @@ describe 'datadog_agent::suse' do
     }
   end
 
-  context 'agent 6' do
-    let(:params) do
+  context 'suse >= 15' do
+    let(:facts) do
       {
-        agent_major_version: 6,
+        operatingsystemmajrelease: '15',
       }
     end
 
-    it do
-      is_expected.to contain_zypprepo('datadog')
-        .with_enabled(1)\
-        .with_gpgcheck(1)\
-        .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
-        .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
+    context 'agent 6' do
+      let(:params) do
+        {
+          agent_major_version: 6,
+        }
+      end
+
+      it do
+        is_expected.to contain_zypprepo('datadog')
+          .with_enabled(1)\
+          .with_gpgcheck(1)\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public	https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
+      end
+    end
+
+    context 'agent 7' do
+      let(:params) do
+        {
+          agent_major_version: 7,
+        }
+      end
+
+      it do
+        is_expected.to contain_zypprepo('datadog')
+          .with_enabled(1)\
+          .with_gpgcheck(1)\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
+      end
     end
   end
 
-  context 'agent 7' do
-    let(:params) do
+  context 'suse < 15' do
+    let(:facts) do
       {
-        agent_major_version: 7,
+        operatingsystemmajrelease: '14',
       }
     end
 
-    it do
-      is_expected.to contain_zypprepo('datadog')
-        .with_enabled(1)\
-        .with_gpgcheck(1)\
-        .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
-        .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
+    context 'agent 6' do
+      let(:params) do
+        {
+          agent_major_version: 6,
+        }
+      end
+
+      it do
+        is_expected.to contain_zypprepo('datadog')
+          .with_enabled(1)\
+          .with_gpgcheck(1)\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
+      end
+    end
+
+    context 'agent 7' do
+      let(:params) do
+        {
+          agent_major_version: 7,
+        }
+      end
+
+      it do
+        is_expected.to contain_zypprepo('datadog')
+          .with_enabled(1)\
+          .with_gpgcheck(1)\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
+      end
     end
   end
 

--- a/spec/classes/datadog_agent_suse_spec.rb
+++ b/spec/classes/datadog_agent_suse_spec.rb
@@ -30,10 +30,10 @@ describe 'datadog_agent::suse' do
         is_expected.to contain_zypprepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
       end
     end
@@ -49,9 +49,9 @@ describe 'datadog_agent::suse' do
         is_expected.to contain_zypprepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
       end
     end
@@ -75,7 +75,7 @@ describe 'datadog_agent::suse' do
         is_expected.to contain_zypprepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
       end
     end
@@ -91,7 +91,7 @@ describe 'datadog_agent::suse' do
         is_expected.to contain_zypprepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
       end
     end

--- a/spec/classes/datadog_agent_suse_spec.rb
+++ b/spec/classes/datadog_agent_suse_spec.rb
@@ -30,7 +30,10 @@ describe 'datadog_agent::suse' do
         is_expected.to contain_zypprepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public	https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+	https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public
+	https://yum.datadoghq.com/DATADOG_RPM_KEY.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
       end
     end
@@ -46,7 +49,9 @@ describe 'datadog_agent::suse' do
         is_expected.to contain_zypprepo('datadog')
           .with_enabled(1)\
           .with_gpgcheck(1)\
-          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
+          .with_gpgkey('https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+	https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+	https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public')\
           .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
       end
     end


### PR DESCRIPTION
### What does this PR do?

The special DATADOG_RPM_KEY_CURRENT.public entry will always contain the key that is used to sign current metadata as well as newly released packages. This PR also fixes the gpgkey entry on SUSE < 15, where zypper only respects the first value.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
