### PR TITLE
Support for NPM on Windows

### DIFF
--- a/manifests/system_probe.pp
+++ b/manifests/system_probe.pp
@@ -1,5 +1,6 @@
 class datadog_agent::system_probe(
   Boolean $enabled = false,
+  Boolean $network_enabled = false,
   Optional[String] $log_file = undef,
   Optional[String] $sysprobe_socket = undef,
   Optional[Boolean] $enable_oom_kill = false,
@@ -39,6 +40,9 @@ class datadog_agent::system_probe(
       'sysprobe_socket' => $sysprobe_socket,
       'log_file' => $log_file,
       'enable_oom_kill' => $enable_oom_kill,
+    },
+    'network_config' => {
+      'enabled' => $network_enabled,
     }
   }
 

--- a/manifests/system_probe.pp
+++ b/manifests/system_probe.pp
@@ -10,29 +10,6 @@ class datadog_agent::system_probe(
   Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
-  if $::operatingsystem == 'Windows' {
-    # Datadog does not currently support Windows and macOS platforms for Network Performance Monitoring
-    fail('Network performance monitoring is only supported on Linux.')
-  }
-
-  if $service_provider {
-    service { $datadog_agent::params::sysprobe_service_name:
-      ensure    => $service_ensure,
-      enable    => $service_enable,
-      provider  => $service_provider,
-      hasstatus => false,
-      pattern   => 'dd-agent',
-      require   => Package[$datadog_agent::params::package_name],
-    }
-  } else {
-    service { $datadog_agent::params::sysprobe_service_name:
-      ensure    => $service_ensure,
-      enable    => $service_enable,
-      hasstatus => false,
-      pattern   => 'dd-agent',
-      require   => Package[$datadog_agent::params::package_name],
-    }
-  }
 
   $sysprobe_config = {
     'system_probe_config' => {
@@ -46,13 +23,45 @@ class datadog_agent::system_probe(
     }
   }
 
-  file { '/etc/datadog-agent/system-probe.yaml':
-    owner   => $datadog_agent::params::dd_user,
-    group   => 'dd-agent',
-    mode    => '0640',
-    content => template('datadog_agent/system_probe.yaml.erb'),
-    notify  => Service[$datadog_agent::params::sysprobe_service_name],
-    require => File['/etc/datadog-agent'],
+  if $::operatingsystem == 'Windows' {
+
+    file { 'C:/ProgramData/Datadog/system-probe.yaml':
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0640',
+      content => template('datadog_agent/system_probe.yaml.erb'),
+      require => File['C:/ProgramData/Datadog'],
+    }
+
+  } else {
+
+    if $service_provider {
+      service { $datadog_agent::params::sysprobe_service_name:
+        ensure    => $service_ensure,
+        enable    => $service_enable,
+        provider  => $service_provider,
+        hasstatus => false,
+        pattern   => 'dd-agent',
+        require   => Package[$datadog_agent::params::package_name],
+      }
+    } else {
+      service { $datadog_agent::params::sysprobe_service_name:
+        ensure    => $service_ensure,
+        enable    => $service_enable,
+        hasstatus => false,
+        pattern   => 'dd-agent',
+        require   => Package[$datadog_agent::params::package_name],
+      }
+    }
+
+    file { '/etc/datadog-agent/system-probe.yaml':
+      owner   => $datadog_agent::params::dd_user,
+      group   => $datadog_agent::params::dd_group,
+      mode    => '0640',
+      content => template('datadog_agent/system_probe.yaml.erb'),
+      notify  => Service[$datadog_agent::params::sysprobe_service_name],
+      require => File['/etc/datadog-agent'],
+    }
   }
 
 }

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -67,7 +67,7 @@ class datadog_agent::windows(
     }
 
     $hostname_option = $hostname ? { '' => {}, default => { 'HOSTNAME' => $hostname } }
-    $npm_install_option = $npm_install ? { false => {}, true => { 'NPM' => 'true' } }
+    $npm_install_option = $npm_install ? { false => {}, true => { 'ADDLOCAL' => 'MainApplication,NPM' } }
 
     package { $datadog_agent::params::package_name:
       ensure          => $ensure_version,

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -197,7 +197,7 @@ describe 'datadog_agent' do
         it do
           is_expected.to contain_package('Datadog Agent').with(
             ensure: 'installed',
-            install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'NPM' => 'true' }],
+            install_options: ['/norestart', { 'APIKEY' => 'notakey', 'HOSTNAME' => 'notahost', 'TAGS' => '""', 'ADDLOCAL' => 'MainApplication,NPM' }],
           )
         end
       end


### PR DESCRIPTION
### What does this PR do?

- Use MSI's standard `ADDLOCAL` to install optional components instead of the custom `NPM=true`.
- Allow creating the `system-probe.yaml` file on Windows as well.
- Allow setting the `network_config.enabled` option in `system-probe.yaml`.

### Motivation

Follow up to https://github.com/DataDog/puppet-datadog-agent/pull/683

The separate `$windows_npm_install` option is still needed since the class that installs the Agent and the class that configure the system-probe are separate.

`ADDLOCAL` works even if the Agent is already installed, while `NPM=true` only works for new installs. I haven't tested if Puppet will actually call the MSI again even if the same version is already installed, so this might have no effect, but we want to deprecated `NPM=true` anyway.

