### PR TITLE
Fix tool_version being unknown in install_info

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -400,8 +400,6 @@ class datadog_agent(
     $local_integrations = $integrations
   }
 
-  $_puppetversion = lookup({ 'name' => '::puppetversion', 'default_value' => 'unknown'})
-
   include datadog_agent::params
   case upcase($log_level) {
     'CRITICAL': { $_loglevel = 'CRITICAL' }

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -1701,7 +1701,7 @@ describe 'datadog_agent' do
           it 'adds an install_info' do
             expect(install_info['install_method']).to match(
               'tool' => 'puppet',
-              'tool_version' => %r{^puppet-(\d+\.\d+\.\d+|unknown)$},
+              'tool_version' => %r{^puppet-unknown$}, # puppetversion is not set in tests, this field has to be tested manually
               'installer_version' => %r{^datadog_module-\d+\.\d+\.\d+$},
             )
           end

--- a/templates/install_info.erb
+++ b/templates/install_info.erb
@@ -1,5 +1,5 @@
 ---
 install_method:
   tool: puppet
-  tool_version: puppet-<%= @_puppetversion %>
+  tool_version: puppet-<%= @facts['puppetversion'] or 'unknown' %>
   installer_version: datadog_module-<%= @module_metadata['version'] %>


### PR DESCRIPTION
### What does this PR do?

Get the puppet version from `facts` which seems to work.

### Motivation

The `tool_version` field was always `unknown`.
