### PR TITLE
Enable repo_gpgcheck for RPM repositories by default

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -16,7 +16,9 @@ fixtures:
   forge_modules:
     yumrepo_core: "puppetlabs/yumrepo_core"
     powershell: "puppetlabs/powershell"
-    zypprepo: "puppet/zypprepo"
+    zypprepo:
+      repo: "puppet/zypprepo"
+      ref: "3.1.0"
   symlinks:
     custom_datadog: "#{source_dir}/spec/custom_fixtures/custom_datadog"
     datadog_agent: "#{source_dir}"

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -68,6 +68,10 @@ platforms:
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
         
   - name: opensuse/leap-15
+    # Workaround for flakes on initializing opensuse/leap-15:
+    # => SCP did not finish successfully (255):  (Net::SCP::Error)
+    transport:
+      max_ssh_sessions: 1
     driver_config:
       # we use a custom image that runs systemd
       image: 'datadog/docker-library:chef_kitchen_systemd_opensuse_leap_15'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -225,6 +225,8 @@
 #       Whether or not to perform repodata signature check for RPM repositories.
 #       Applies to Red Hat and SUSE platforms. When set to `undef`, this is activated
 #       for all Agent versions other than 5 when `agent_repo_uri` is also undefinded.
+#       The `undef` value also translates to `false` on RHEL/CentOS 8.1 because
+#       of a bug in libdnf: https://bugzilla.redhat.com/show_bug.cgi?id=1792506
 #       Boolean. Default: undef
 #   $apt_release
 #       The distribution channel to be used for the APT repo. Eg: 'stable' or 'beta'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,6 +221,11 @@
 #       RPM: https://yum.datadoghq.com/stable/7/x86_64/ (with matching agent version and architecture)
 #       Windows: https://https://s3.amazonaws.com/ddagent-windows-stable/
 #       String. Default: undef
+#   $rpm_repo_gpgcheck
+#       Whether or not to perform repodata signature check for RPM repositories.
+#       Applies to Red Hat and SUSE platforms. When set to `undef`, this is activated
+#       for all Agent versions other than 5 when `agent_repo_uri` is also undefinded.
+#       Boolean. Default: undef
 #   $apt_release
 #       The distribution channel to be used for the APT repo. Eg: 'stable' or 'beta'.
 #       String. Default: stable
@@ -334,6 +339,7 @@ class datadog_agent(
   Boolean $container_collect_all = $datadog_agent::params::container_collect_all,
   Hash[String[1], Data] $agent_extra_options = {},
   Optional[String] $agent_repo_uri = undef,
+  Optional[Boolean] $rpm_repo_gpgcheck = undef,
   Optional[Boolean] $use_apt_backup_keyserver = $datadog_agent::params::use_apt_backup_keyserver,
   String $apt_backup_keyserver = $datadog_agent::params::apt_backup_keyserver,
   String $apt_keyserver = $datadog_agent::params::apt_keyserver,
@@ -438,6 +444,7 @@ class datadog_agent(
           agent_repo_uri      => $agent_repo_uri,
           manage_repo         => $manage_repo,
           agent_version       => $agent_version,
+          rpm_repo_gpgcheck   => $rpm_repo_gpgcheck,
         }
       }
       'Windows' : {
@@ -462,6 +469,7 @@ class datadog_agent(
           agent_flavor        => $agent_flavor,
           agent_repo_uri      => $agent_repo_uri,
           agent_version       => $agent_version,
+          rpm_repo_gpgcheck   => $rpm_repo_gpgcheck,
         }
       }
       default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -24,10 +24,23 @@ class datadog_agent::redhat(
       $repo_gpgcheck = $rpm_repo_gpgcheck
     } else {
       if ($agent_repo_uri == undef) and ($agent_major_version > 5) {
-        $repo_gpgcheck = true
+        case $::operatingsystem {
+          'RedHat', 'CentOS', 'OracleLinux': {
+            # disable repo_gpgcheck on 8.1 because of https://bugzilla.redhat.com/show_bug.cgi?id=1792506
+            if $::operatingsystemrelease =~ /^8.1/ {
+              $repo_gpgcheck = false
+            } else {
+              $repo_gpgcheck = true
+            }
+          }
+          default: {
+            $repo_gpgcheck = true
+          }
+        }
       } else {
         $repo_gpgcheck = false
       }
+
     }
 
     case $agent_major_version {

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -9,6 +9,7 @@ class datadog_agent::redhat(
   Boolean $manage_repo = true,
   String $agent_version = $datadog_agent::params::agent_version,
   String $agent_flavor = $datadog_agent::params::package_name,
+  Optional[Boolean] $rpm_repo_gpgcheck = undef,
 ) inherits datadog_agent::params {
 
   if $manage_repo {
@@ -19,6 +20,15 @@ class datadog_agent::redhat(
         'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
         'https://keys.datadoghq.com/DATADOG_RPM_KEY.public',
     ]
+    if ($rpm_repo_gpgcheck != undef) {
+      $repo_gpgcheck = $rpm_repo_gpgcheck
+    } else {
+      if ($agent_repo_uri == undef) and ($agent_major_version > 5) {
+        $repo_gpgcheck = true
+      } else {
+        $repo_gpgcheck = false
+      }
+    }
 
     case $agent_major_version {
       5 : {
@@ -55,11 +65,12 @@ class datadog_agent::redhat(
     }
 
     yumrepo {'datadog':
-      enabled  => 1,
-      gpgcheck => 1,
-      gpgkey   => join($gpgkeys, "\n       "),
-      descr    => 'Datadog, Inc.',
-      baseurl  => $baseurl,
+      enabled       => 1,
+      gpgcheck      => 1,
+      gpgkey        => join($gpgkeys, "\n       "),
+      repo_gpgcheck => $repo_gpgcheck,
+      descr         => 'Datadog, Inc.',
+      baseurl       => $baseurl,
     }
 
     package { $agent_flavor:

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -67,20 +67,20 @@ class datadog_agent::suse(
   }
 
   zypprepo { 'datadog':
-    baseurl       => $baseurl,
-    enabled       => 1,
-    autorefresh   => 1,
-    name          => 'datadog',
-    gpgcheck      => 1,
+    baseurl      => $baseurl,
+    enabled      => 1,
+    autorefresh  => 1,
+    name         => 'datadog',
+    gpgcheck     => 1,
     # zypper on SUSE < 15 only understands a single gpgkey value
-    gpgkey        => (Float($::operatingsystemmajrelease) >= 15.0) ? { true => join($gpgkeys, "\n       "), default => $current_key },
+    gpgkey       => (Float($::operatingsystemmajrelease) >= 15.0) ? { true => join($gpgkeys, "\n       "), default => $current_key },
     # TODO: when updating zypprepo to 4.0.0, uncomment the repo_gpgcheck line
     # For now, we can leave this commented, as zypper by default does repodata
     # signature checks if the repomd.xml.asc is present, so repodata checks
     # are effective for most users anyway. We'll make this explicit when we
     # update zypprepo version.
     # repo_gpgcheck => $repo_gpgcheck,
-    keeppackages  => 1,
+    keeppackages => 1,
   }
 
   package { $agent_flavor:

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -74,7 +74,12 @@ class datadog_agent::suse(
     gpgcheck      => 1,
     # zypper on SUSE < 15 only understands a single gpgkey value
     gpgkey        => (Float($::operatingsystemmajrelease) >= 15.0) ? { true => join($gpgkeys, "\n       "), default => $current_key },
-    repo_gpgcheck => $repo_gpgcheck,
+    # TODO: when updating zypprepo to 4.0.0, uncomment the repo_gpgcheck line
+    # For now, we can leave this commented, as zypper by default does repodata
+    # signature checks if the repomd.xml.asc is present, so repodata checks
+    # are effective for most users anyway. We'll make this explicit when we
+    # update zypprepo version.
+    # repo_gpgcheck => $repo_gpgcheck,
     keeppackages  => 1,
   }
 

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -154,4 +154,69 @@ describe 'datadog_agent::redhat' do
         .with_ensure('latest')
     end
   end
+
+  context 'rhel 8.1' do
+    # we expect repo_gpgcheck to be false on 8.1
+    let(:facts) do
+      {
+        osfamily: 'redhat',
+        operatingsystem: 'RedHat',
+        operatingsystemrelease: '8.1',
+        architecture: 'x86_64',
+      }
+    end
+
+    # it should install the mirror
+    context 'with manage_repo => true' do
+      let(:params) do
+        {
+          manage_repo: true, agent_major_version: 7
+        }
+      end
+
+      it do
+        is_expected.to contain_yumrepo('datadog')
+          .with_enabled(1)\
+          .with_gpgcheck(1)\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+          .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
+          .with_repo_gpgcheck(false)
+      end
+    end
+  end
+
+  context 'rhel 8.2' do
+    # we expect repo_gpgcheck to be true on 8.2 (and later)
+    let(:facts) do
+      {
+        osfamily: 'redhat',
+        operatingsystem: 'RedHat',
+        operatingsystemrelease: '8.2',
+        architecture: 'x86_64',
+      }
+    end
+
+    # it should install the mirror
+    context 'with manage_repo => true' do
+      let(:params) do
+        {
+          manage_repo: true, agent_major_version: 7
+        }
+      end
+
+      it do
+        # we expect repo_gpgcheck to be false on 8.1
+        is_expected.to contain_yumrepo('datadog')
+          .with_enabled(1)\
+          .with_gpgcheck(1)\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+          .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
+          .with_repo_gpgcheck(true)
+      end
+    end
+  end
 end

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -31,7 +31,8 @@ describe 'datadog_agent::redhat' do
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY.public')\
-          .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')
+          .with_baseurl('https://yum.datadoghq.com/rpm/x86_64/')\
+          .with_repo_gpgcheck(false)
       end
     end
     context 'with manage_repo => false' do
@@ -79,7 +80,8 @@ describe 'datadog_agent::redhat' do
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY.public')\
-          .with_baseurl('https://yum.datadoghq.com/stable/6/x86_64/')
+          .with_baseurl('https://yum.datadoghq.com/stable/6/x86_64/')\
+          .with_repo_gpgcheck(true)
       end
     end
     context 'with manage_repo => false' do
@@ -127,7 +129,8 @@ describe 'datadog_agent::redhat' do
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
-          .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')
+          .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
+          .with_repo_gpgcheck(true)
       end
     end
     context 'with manage_repo => false' do

--- a/spec/classes/datadog_agent_suse_spec.rb
+++ b/spec/classes/datadog_agent_suse_spec.rb
@@ -34,7 +34,8 @@ describe 'datadog_agent::suse' do
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY.public')\
-          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')\
+          .with_repo_gpgcheck(true)
       end
     end
 
@@ -52,7 +53,8 @@ describe 'datadog_agent::suse' do
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
-          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')\
+          .with_repo_gpgcheck(true)
       end
     end
   end
@@ -76,7 +78,8 @@ describe 'datadog_agent::suse' do
           .with_enabled(1)\
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
-          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')\
+          .with_repo_gpgcheck(true)
       end
     end
 
@@ -92,7 +95,8 @@ describe 'datadog_agent::suse' do
           .with_enabled(1)\
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
-          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')\
+          .with_repo_gpgcheck(true)
       end
     end
   end

--- a/spec/classes/datadog_agent_suse_spec.rb
+++ b/spec/classes/datadog_agent_suse_spec.rb
@@ -34,8 +34,8 @@ describe 'datadog_agent::suse' do
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY.public')\
-          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')\
-          .with_repo_gpgcheck(true)
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
+        # .with_repo_gpgcheck(true)
       end
     end
 
@@ -53,8 +53,8 @@ describe 'datadog_agent::suse' do
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
-          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')\
-          .with_repo_gpgcheck(true)
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
+        # .with_repo_gpgcheck(true)
       end
     end
   end
@@ -78,8 +78,8 @@ describe 'datadog_agent::suse' do
           .with_enabled(1)\
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
-          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')\
-          .with_repo_gpgcheck(true)
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/6/x86_64')
+        # .with_repo_gpgcheck(true)
       end
     end
 
@@ -95,8 +95,8 @@ describe 'datadog_agent::suse' do
           .with_enabled(1)\
           .with_gpgcheck(1)\
           .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public')\
-          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')\
-          .with_repo_gpgcheck(true)
+          .with_baseurl('https://yum.datadoghq.com/suse/stable/7/x86_64')
+        # .with_repo_gpgcheck(true)
       end
     end
   end


### PR DESCRIPTION
### What does this PR do?

Enable `repo_gpgcheck` for RPM repositories by default - applies to default, non-Agent 5 repositories. Users can also choose to activate this on custom repositories if they wish so.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
