### PR TITLE
update excluded_interface_re type to String"

### DIFF
--- a/manifests/integrations/network.pp
+++ b/manifests/integrations/network.pp
@@ -24,7 +24,7 @@
 class datadog_agent::integrations::network(
   Boolean $collect_connection_state = false,
   Array[String] $excluded_interfaces = ['lo','lo0'],
-  Array $excluded_interface_re = [],
+  String $excluded_interface_re = '',
   Boolean $combine_connection_states = true,
 ) inherits datadog_agent::params {
   include ::datadog_agent


### PR DESCRIPTION
### What does this PR do?

fix the excluded_interface_re type to string as per documentation in https://github.com/DataDog/integrations-core/blob/master/network/datadog_checks/network/data/conf.yaml.default

### Motivation

Current version expected an array of strings which broke the network/conf.yaml file as datadog-agent threw an error
```
    network (2.1.2)
    ---------------
      Instance ID: network:9358677f0d90eae3 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/network.d/conf.yaml
      Total Runs: 11
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 1ms
      Last Execution Date : 2021-05-07 11:02:30 UTC (1620385350000)
      Last Successful Execution Date : Never
      Error: unhashable type: 'list'
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 897, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/network/network.py", line 105, in check
          self._exclude_iface_re = re.compile(exclude_re)
        File "/opt/datadog-agent/embedded/lib/python3.8/re.py", line 252, in compile
          return _compile(pattern, flags)
        File "/opt/datadog-agent/embedded/lib/python3.8/re.py", line 294, in _compile
          return _cache[type(pattern), pattern, flags]
      TypeError: unhashable type: 'list'
```

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
