### PR TITLE
Include 'datadog_agent' class in the catalog when using the generic i…

### DIFF
--- a/manifests/integrations/generic.pp
+++ b/manifests/integrations/generic.pp
@@ -21,6 +21,7 @@ class datadog_agent::integrations::generic(
   Optional[String] $integration_name     = undef,
   Optional[String] $integration_contents = undef,
 ) inherits datadog_agent::params {
+  include datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/${integration_name}.yaml"
   if $::datadog_agent::_agent_major_version > 5 {


### PR DESCRIPTION
…ntegration

### What does this PR do?

This commit includes the `datadog_agent` class in the catalog when using `datadog_agent::integrations::generic`.

### Motivation

When working with this integration, we received the following error:
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Comparison of: Undef Value > Integer, is not possible. Caused by 'Only Strings, Numbers, Timespans, Timestamps, and Versions are comparable'. (file: /<path>/datadog_agent/manifests/integrations/generic.pp, line: 26, column: 45) on node <host>
```

We noticed that the integration does not explicitly include `datadog_agent` in the catalog like the other integrations.

### Describe your test plan

No detailed test plan beyond testing the before and after states. Including the class fixed the issue for us and seems to be the most straightforward and consistent solution that follows the general pattern for the integrations. 
