### PR TITLE
Improvements for APT keys management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -342,6 +342,11 @@ class datadog_agent(
   Hash[String[1], Data] $agent_extra_options = {},
   Optional[String] $agent_repo_uri = undef,
   Optional[Boolean] $rpm_repo_gpgcheck = undef,
+  # TODO: $use_apt_backup_keyserver, $apt_backup_keyserver and $apt_keyserver can be
+  # removed in the next major version; they're kept now for backwards compatibility
+  Optional[Boolean] $use_apt_backup_keyserver = undef,
+  Optional[String] $apt_backup_keyserver = undef,
+  Optional[String] $apt_keyserver = undef,
   String $apt_release = $datadog_agent::params::apt_default_release,
   String $win_msi_location = 'C:/Windows/temp', # Temporary directory where the msi file is downloaded, must exist
   Enum['present', 'absent'] $win_ensure = 'present', #TODO: Implement uninstall also for apt and rpm install methods
@@ -421,6 +426,12 @@ class datadog_agent(
   if $manage_install {
     case $::operatingsystem {
       'Ubuntu','Debian' : {
+        if $use_apt_backup_keyserver != undef or $apt_backup_keyserver != undef or $apt_keyserver != undef {
+          notify { 'apt keyserver arguments deprecation':
+            message  => '$use_apt_backup_keyserver, $apt_backup_keyserver and $apt_keyserver are deprecated since version 3.13.0',
+            loglevel => 'warning',
+          }
+        }
         class { 'datadog_agent::ubuntu':
           agent_major_version   => $_agent_major_version,
           agent_version         => $agent_version,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -342,9 +342,6 @@ class datadog_agent(
   Hash[String[1], Data] $agent_extra_options = {},
   Optional[String] $agent_repo_uri = undef,
   Optional[Boolean] $rpm_repo_gpgcheck = undef,
-  Optional[Boolean] $use_apt_backup_keyserver = $datadog_agent::params::use_apt_backup_keyserver,
-  String $apt_backup_keyserver = $datadog_agent::params::apt_backup_keyserver,
-  String $apt_keyserver = $datadog_agent::params::apt_keyserver,
   String $apt_release = $datadog_agent::params::apt_default_release,
   String $win_msi_location = 'C:/Windows/temp', # Temporary directory where the msi file is downloaded, must exist
   Enum['present', 'absent'] $win_ensure = 'present', #TODO: Implement uninstall also for apt and rpm install methods
@@ -424,11 +421,6 @@ class datadog_agent(
   if $manage_install {
     case $::operatingsystem {
       'Ubuntu','Debian' : {
-        if $use_apt_backup_keyserver {
-          $_apt_keyserver = $apt_backup_keyserver
-        } else {
-          $_apt_keyserver = $apt_keyserver
-        }
         class { 'datadog_agent::ubuntu':
           agent_major_version   => $_agent_major_version,
           agent_version         => $agent_version,
@@ -436,7 +428,6 @@ class datadog_agent(
           agent_repo_uri        => $agent_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
-          apt_keyserver         => $_apt_keyserver,
         }
       }
       'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux' : {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,9 +19,6 @@ class datadog_agent::params {
   $logs_enabled                   = false
   $logs_open_files_limit          = undef
   $container_collect_all          = false
-  $use_apt_backup_keyserver       = false
-  $apt_backup_keyserver           = 'hkp://pool.sks-keyservers.net:80'
-  $apt_keyserver                  = 'hkp://keyserver.ubuntu.com:80'
   $sysprobe_service_name          = 'datadog-agent-sysprobe'
   $module_metadata                = load_module_metadata($module_name)
 

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -5,13 +5,18 @@
 
 class datadog_agent::ubuntu(
   Integer $agent_major_version = $datadog_agent::params::default_agent_major_version,
-  Array[String] $apt_keys = ['A2923DFF56EDA6E76E55E492D3A80E30382E94DE', 'D75CEA17048B9ACBF186794B32637D44F14F620E'],
   String $agent_version = $datadog_agent::params::agent_version,
   Optional[String] $agent_repo_uri = undef,
   String $release = $datadog_agent::params::apt_default_release,
   Boolean $skip_apt_key_trusting = false,
-  String $apt_keyserver = $datadog_agent::params::apt_keyserver,
   String $agent_flavor = $datadog_agent::params::package_name,
+  Optional[String] $apt_trusted_d_keyring = '/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg',
+  Optional[String] $apt_usr_share_keyring = '/usr/share/keyrings/datadog-archive-keyring.gpg',
+  Optional[Hash[String, String]] $apt_default_keys = {
+    "DATADOG_APT_KEY_CURRENT.public"           => "https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public",
+    "D75CEA17048B9ACBF186794B32637D44F14F620E" => "https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public",
+    "A2923DFF56EDA6E76E55E492D3A80E30382E94DE" => "https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public",
+  },
 ) inherits datadog_agent::params {
 
   if $agent_version =~ /^[0-9]+\.[0-9]+\.[0-9]+((?:~|-)[^0-9\s-]+[^-\s]*)?$/ {
@@ -29,10 +34,32 @@ class datadog_agent::ubuntu(
   }
 
   if !$skip_apt_key_trusting {
-    $apt_keys.each |String $apt_key| {
-      apt::key { $apt_key:
-        id     => $apt_key,
-        server => $apt_keyserver,
+    file { $apt_usr_share_keyring:
+      ensure => file,
+      mode   => '0644',
+    }
+
+    $apt_default_keys.each |String $key_fingerprint, String $key_url| {
+      $key_path = "/tmp/${key_fingerprint}"
+
+      file { $key_path:
+        owner  => root,
+        group  => root,
+        mode   => '0600',
+        source => $key_url,
+      }
+
+      exec { "ensure key ${key_fingerprint} is imported in APT keyring":
+        command => "/bin/cat /tmp/${key_fingerprint} | gpg --import --batch --no-default-keyring --keyring ${apt_usr_share_keyring}",
+        unless  => "/bin/cat /tmp/${key_fingerprint} | gpg --dry-run --import --batch --no-default-keyring --keyring ${apt_usr_share_keyring} 2>&1 | grep 'unchanged: 1'",
+      }
+    }
+
+    if ($::operatingsystem == "Ubuntu" and versioncmp($::operatingsystemrelease, '16') == -1) or
+       ($::operatingsystem == "Debian" and versioncmp($::operatingsystemrelease, '9') == -1) {
+      file { $apt_trusted_d_keyring:
+        mode   => '0644',
+        source => "file://${apt_usr_share_keyring}",
       }
     }
   }
@@ -40,7 +67,7 @@ class datadog_agent::ubuntu(
   if ($agent_repo_uri != undef) {
     $location = $agent_repo_uri
   } else {
-    $location = 'https://apt.datadoghq.com/'
+    $location = "[signed-by=${apt_usr_share_keyring}] https://apt.datadoghq.com/"
   }
 
   apt::source { 'datadog-beta':

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -13,9 +13,9 @@ class datadog_agent::ubuntu(
   Optional[String] $apt_trusted_d_keyring = '/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg',
   Optional[String] $apt_usr_share_keyring = '/usr/share/keyrings/datadog-archive-keyring.gpg',
   Optional[Hash[String, String]] $apt_default_keys = {
-    "DATADOG_APT_KEY_CURRENT.public"           => "https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public",
-    "D75CEA17048B9ACBF186794B32637D44F14F620E" => "https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public",
-    "A2923DFF56EDA6E76E55E492D3A80E30382E94DE" => "https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public",
+    'DATADOG_APT_KEY_CURRENT.public'           => 'https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public',
+    'D75CEA17048B9ACBF186794B32637D44F14F620E' => 'https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public',
+    'A2923DFF56EDA6E76E55E492D3A80E30382E94DE' => 'https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public',
   },
 ) inherits datadog_agent::params {
 
@@ -55,8 +55,8 @@ class datadog_agent::ubuntu(
       }
     }
 
-    if ($::operatingsystem == "Ubuntu" and versioncmp($::operatingsystemrelease, '16') == -1) or
-       ($::operatingsystem == "Debian" and versioncmp($::operatingsystemrelease, '9') == -1) {
+    if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16') == -1) or
+        ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') == -1) {
       file { $apt_trusted_d_keyring:
         mode   => '0644',
         source => "file://${apt_usr_share_keyring}",

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -34,7 +34,7 @@ describe 'datadog_agent' do
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
-          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+main})
+          .with_content(%r{deb\s+\[signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg\]\s+https://apt.datadoghq.com/\s+stable\s+main})
       end
     end
 
@@ -53,7 +53,7 @@ describe 'datadog_agent' do
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
-          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
+          .with_content(%r{deb\s+\[signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg\]\s+https://apt.datadoghq.com/\s+stable\s+6})
       end
     end
 
@@ -72,7 +72,7 @@ describe 'datadog_agent' do
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
-          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+7})
+          .with_content(%r{deb\s+\[signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg\]\s+https://apt.datadoghq.com/\s+stable\s+7})
       end
     end
 
@@ -91,7 +91,7 @@ describe 'datadog_agent' do
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
-          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
+          .with_content(%r{deb\s+\[signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg\]\s+https://apt.datadoghq.com/\s+stable\s+6})
       end
     end
 
@@ -110,7 +110,7 @@ describe 'datadog_agent' do
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
-          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
+          .with_content(%r{deb\s+\[signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg\]\s+https://apt.datadoghq.com/\s+stable\s+6})
       end
     end
 
@@ -129,7 +129,7 @@ describe 'datadog_agent' do
 
       it do
         is_expected.to contain_file('/etc/apt/sources.list.d/datadog.list')\
-          .with_content(%r{deb\s+https://apt.datadoghq.com/\s+stable\s+6})
+          .with_content(%r{deb\s+\[signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg\]\s+https://apt.datadoghq.com/\s+stable\s+6})
       end
     end
 
@@ -1606,25 +1606,7 @@ describe 'datadog_agent' do
             end
           end
 
-          if DEBIAN_OS.include?(operatingsystem)
-            it do
-              is_expected.to contain_class('datadog_agent::ubuntu')\
-                .with_apt_keyserver('hkp://keyserver.ubuntu.com:80')
-            end
-            context 'use backup keyserver' do
-              let(:params) do
-                {
-                  use_apt_backup_keyserver: true,
-                  agent_major_version: 5,
-                }
-              end
-
-              it do
-                is_expected.to contain_class('datadog_agent::ubuntu')\
-                  .with_apt_keyserver('hkp://pool.sks-keyservers.net:80')
-              end
-            end
-          elsif REDHAT_OS.include?(operatingsystem)
+          if REDHAT_OS.include?(operatingsystem)
             it { is_expected.to contain_class('datadog_agent::redhat') }
           end
         end


### PR DESCRIPTION
### What does this PR do?

* By default, get keys from keys.datadoghq.com, not Ubuntu keyserver
* Always add the DATADOG_APT_KEY_CURRENT.public key (contains key used to sign current repodata)
* Add 'signed-by' option to all sources list lines
* On Debian >= 9 and Ubuntu >= 16, only add keys to /usr/share/keyrings/datadog-archive-keyring.gpg
* On older systems, also add the same keyring to /etc/apt/trusted.gpg.d


### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
