### PR TITLE
add support for `min_collection_interval` for HTTP check

### DIFF
--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -174,7 +174,7 @@ class datadog_agent::integrations::http_check (
   $password  = undef,
   $timeout   = 1,
   $method    = 'get',
-  $min_collection_interval = 15,
+  $min_collection_interval = undef,
   $data      = undef,
   $threshold = undef,
   $window    = undef,

--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -15,6 +15,10 @@
 #   method
 #    	The (optional) HTTP method. This setting defaults to GET, though many
 #    	other HTTP methods are supported, including POST and PUT.
+#   min_collection_interval
+#    	The (optional) collection interval of the check.
+#    	default: 15
+#       https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
 #   data
 #       The (optional) data option. Data should be a string or an array of
 #       'key: value' pairs and will be sent in the body of the request.
@@ -170,6 +174,7 @@ class datadog_agent::integrations::http_check (
   $password  = undef,
   $timeout   = 1,
   $method    = 'get',
+  $min_collection_interval = 15,
   $data      = undef,
   $threshold = undef,
   $window    = undef,
@@ -204,6 +209,7 @@ class datadog_agent::integrations::http_check (
       'password'                     => $password,
       'timeout'                      => $timeout,
       'method'                       => $method,
+      'min_collection_interval'      => $min_collection_interval,
       'data'                         => $data,
       'threshold'                    => $threshold,
       'window'                       => $window,

--- a/spec/classes/datadog_agent_integrations_http_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_http_check_spec.rb
@@ -55,6 +55,7 @@ describe 'datadog_agent::integrations::http_check' do
             password: 'barpassword',
             timeout: 123,
             method: 'post',
+            min_collection_interval: 30,
             data: 'key=value',
             threshold: 456,
             window: 789,
@@ -80,6 +81,7 @@ describe 'datadog_agent::integrations::http_check' do
         it { is_expected.to contain_file(conf_file).with_content(%r{password: barpassword}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{timeout: 123}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{method: post}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{min_collection_interval: 30}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{data: key=value}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{threshold: 456}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{window: 789}) }

--- a/templates/agent-conf.d/http_check.yaml.erb
+++ b/templates/agent-conf.d/http_check.yaml.erb
@@ -12,6 +12,9 @@ instances:
 <% if instance['method'] -%>
     method: <%= instance['method'] %>
 <% end -%>
+<% if instance['min_collection_interval'] -%>
+    min_collection_interval: <%= instance['min_collection_interval'] %>
+<% end -%>
 <% if instance['data'].is_a?(String) -%>
     data: <%= instance['data'] %>
 <% elsif instance['data'].is_a?(Array) -%>


### PR DESCRIPTION
### What does this PR do?

Add HTTP_CHECK `min_collection_interval` feature

https://github.com/DataDog/puppet-datadog-agent/issues/118