### PR TITLE
Ensure gnupg is installed on Debian/Ubuntu

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -34,6 +34,10 @@ class datadog_agent::ubuntu(
   }
 
   if !$skip_apt_key_trusting {
+    package { 'gnupg':
+      ensure => installed
+    }
+
     file { $apt_usr_share_keyring:
       ensure => file,
       mode   => '0644',


### PR DESCRIPTION
### What does this PR do?

As we're using `gpg` in some of the commands below, we have to ensure it's installed. Since Debian 9, it seems that `apt` no longer depends on `gnupg`, but only on `gpgv`, and `gpg` isn't necessarily installed by default.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
