### PR TITLE
delete process config file if not configured

### DIFF
--- a/manifests/integrations/process.pp
+++ b/manifests/integrations/process.pp
@@ -74,7 +74,7 @@ class datadog_agent::integrations::process(
   }
 
   file { $dst:
-    ensure  => file,
+    ensure  => $local_processes.length ? { 0 => absent, default => file},
     owner   => $datadog_agent::params::dd_user,
     group   => $datadog_agent::params::dd_group,
     mode    => $datadog_agent::params::permissions_protected_file,


### PR DESCRIPTION
### What does this PR do?

If there are no configured processes, the configuration file will be
```
---
init_config: {}
instances: []
```
The config check will return error, as 
```
=== Configuration errors ===
process: Configuration file contains no valid instances
```
### Motivation

It happens in our project, and it's annoying
### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
