### PR TITLE
Update puppet docs logs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,24 @@ Tips:
 1. For structured facts index into the specific fact value otherwise the entire array will come over as a string and ultimately be difficult to use.
 2. Dynamic facts such as CPU usage, Uptime, and others that are expected to change each run are not ideal for tagging.  Static facts that are expected to stay for the life of a node are best candidates for tagging.
 
+### Logs Setup
+
+To configure logs, first set `logs_enabled: true`, and it can then be configured with a class. An example is below:
+
+```
+  class { 'datadog_agent::integrations::logs' :
+    logs => [
+      {
+        'type' => 'file',
+        'path' => '/var/log/afile.log',
+      },
+      {
+        'type' => 'docker',
+      },
+    ],
+ }
+```
+
 ### Configuration variables
 
 These variables can be set in the `datadog_agent` class to control settings in the Agent. Refer to the [comments in code][8] for the full list of supported arguments.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Tips:
 1. For structured facts index into the specific fact value otherwise the entire array will come over as a string and ultimately be difficult to use.
 2. Dynamic facts such as CPU usage, Uptime, and others that are expected to change each run are not ideal for tagging.  Static facts that are expected to stay for the life of a node are best candidates for tagging.
 
-### Logs Setup
+### Log collection
 
 To configure logs, first set `logs_enabled: true`, and it can then be configured with a class. An example is below:
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Tips:
 
 ### Log collection
 
-To configure logs, first set `logs_enabled: true`, and it can then be configured with a class. An example is below:
+Collecting logs is disabled by default, enable it in your Puppet configuration file by setting `logs_enabled: true`. Additional file paths can also be configured.
 
 ```
   class { 'datadog_agent::integrations::logs' :


### PR DESCRIPTION
Add to puppet docs an example on how to configure logs utilizing the module. The exact code was pulled from sample usage in the puppet integration github page: https://github.com/DataDog/puppet-datadog-agent/blob/main/manifests/integrations/logs.pp

### What does this PR do?

Add example for puppet with logs.

### Motivation

Lead to confusion and digging through docs for customer.

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
