### PR TITLE
Install datadog-signing-keys on Debian based platforms

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -107,4 +107,8 @@ class datadog_agent::ubuntu(
     require => [Apt::Source['datadog'],
                 Class['apt::update']],
   }
+
+  package { 'datadog-signing-keys'
+    ensure => 'latest',
+  }
 }

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -108,7 +108,7 @@ class datadog_agent::ubuntu(
                 Class['apt::update']],
   }
 
-  package { 'datadog-signing-keys'
+  package { 'datadog-signing-keys':
     ensure => 'latest',
   }
 }


### PR DESCRIPTION
### What does this PR do?

Installs the new datadog-signing-keys package.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
