### PR TITLE
Upgrade msys2 to prevent PGP errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
             choco install ruby --allow-downgrade -y --version 2.5.3.101 # Keep version in sync with next command!
             export PATH=/c/tools/ruby25/bin:$PATH # Make Ruby 2.5 take precedence over the pre-installed 2.6
             ruby --version
-            choco install msys2 --allow-downgrade -y --version 20200903.0.0
+            choco install msys2 --allow-downgrade -y --version 20201109.0.0
             ridk.cmd exec pacman -S --noconfirm --needed base-devel mingw-w64-x86_64-toolchain
             gem install bundler -v 1.17.3
             rm Gemfile.lock && bundle install --path .bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
             choco install ruby --allow-downgrade -y --version 2.5.3.101 # Keep version in sync with next command!
             export PATH=/c/tools/ruby25/bin:$PATH # Make Ruby 2.5 take precedence over the pre-installed 2.6
             ruby --version
-            choco install msys2 --allow-downgrade -y --version 20201109.0.0
+            choco install msys2 --allow-downgrade -y --version 20210604.0.0
             ridk.cmd exec pacman -S --noconfirm --needed base-devel mingw-w64-x86_64-toolchain
             gem install bundler -v 1.17.3
             rm Gemfile.lock && bundle install --path .bundle


### PR DESCRIPTION
### What does this PR do?

Upgrades to newer msys2 that doesn't fail installation of mingw packages because of PGP errors.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
