### PR TITLE
Use `ensure_packages` to install `gnupg`

### DIFF
--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -34,9 +34,7 @@ class datadog_agent::ubuntu(
   }
 
   if !$skip_apt_key_trusting {
-    package { 'gnupg':
-      ensure => installed
-    }
+    ensure_packages(['gnupg'])
 
     file { $apt_usr_share_keyring:
       ensure => file,


### PR DESCRIPTION
The `apt` module requires this since v7.2.0 which would make
the module fail under certain situations on Ubuntu
