### PR TITLE
Add test jobs using Puppet 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,13 @@ jobs:
       RUBY_VERSION: '2.6.3'
       PUPPET_VERSION: '6.5.0'
 
+  specs-ruby26-puppet79:
+    <<: *specs
+    environment:
+      STRICT_VARIABLES: 'yes'
+      RUBY_VERSION: '2.6.3'
+      PUPPET_VERSION: '7.9.0'
+
   specs-ruby25-puppet65-windows: &windows-specs
     executor:
       name: win/default # Comes with ruby 2.6, which is not supported on Windows as of puppet 6.10.1
@@ -317,5 +324,6 @@ workflows:
       - specs-ruby25-puppet65-windows
       - specs-ruby26-puppet60
       - specs-ruby26-puppet65
+      - specs-ruby26-puppet79
       - verify-gemfile-lock-dependencies
       - kitchen-tests


### PR DESCRIPTION
### What does this PR do?

Add a CircleCI job that runs tests against Puppet 7 using Ruby 2.6.

### Motivation

Increase coverage.

### Additional Notes

I tried adding Ruby 3 jobs as well but it seems that Puppet doesn't support Ruby 3 yet.
