### PR TITLE
Support Raspbian as debian-based systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -425,7 +425,7 @@ class datadog_agent(
   # Install agent
   if $manage_install {
     case $::operatingsystem {
-      'Ubuntu','Debian' : {
+      'Ubuntu','Debian','Raspbian' : {
         if $use_apt_backup_keyserver != undef or $apt_backup_keyserver != undef or $apt_keyserver != undef {
           notify { 'apt keyserver arguments deprecation':
             message  => '$use_apt_backup_keyserver, $apt_backup_keyserver and $apt_keyserver are deprecated since version 3.13.0',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,7 @@ class datadog_agent::params {
   $module_metadata                = load_module_metadata($module_name)
 
   case $::operatingsystem {
-    'Ubuntu','Debian' : {
+    'Ubuntu','Debian','Raspbian' : {
       $rubydev_package            = 'ruby-dev'
       $legacy_conf_dir            = '/etc/dd-agent/conf.d'
       $conf_dir                   = '/etc/datadog-agent/conf.d'


### PR DESCRIPTION
### What does this PR do?

<!--A brief description of the change being made with this pull request.-->
Allows datadog-agent to be configured using puppet on systems running Raspbian

### Motivation

<!--What inspired you to submit this pull request?-->
We are trying to get a Raspberry Pi 400 set up as a machine for users to mess with. Our puppet config pulls down datadog-agent.