### PR TITLE
Require datadog_agent instead of including it

### DIFF
--- a/environments/etc/manifests/site.pp
+++ b/environments/etc/manifests/site.pp
@@ -1,5 +1,25 @@
 node default {
+
   class { 'datadog_agent':
-    api_key => 'somenonnullapikeythats32charlong',
+    api_key             => 'somenonnullapikeythats32charlong',
+    agent_extra_options => {
+        use_http => true,
+    },
+    facts_to_tags       => ['osfamily'],
+    integrations        => {
+      'ntp' => {
+        init_config => {},
+        instances   => [{
+            offset_threshold => 30,
+        }],
+      },
+    },
   }
+
+  class { 'datadog_agent::integrations::apache':
+    url      => 'http://example.com/server-status?auto',
+    username => 'status',
+    password => 'hunter1',
+  }
+
 }

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -28,6 +28,7 @@ platforms:
         - mkdir /home/kitchen/puppet
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
+        - gem install bundler -v '= 1.17.3'
         - gem install r10k -v 2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
@@ -45,6 +46,7 @@ platforms:
         - mkdir /home/kitchen/puppet
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
+        - gem install bundler -v '= 1.17.3'
         - gem install r10k -v 2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
@@ -64,6 +66,7 @@ platforms:
         - mkdir /home/kitchen/puppet
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
+        - gem install bundler -v '= 1.17.3'
         - gem install r10k -v 2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
         
@@ -81,7 +84,8 @@ platforms:
       provision_command:
         - zypper ar -G https://yum.puppet.com/puppet/sles/15/x86_64/ puppet-repo
         - zypper install -y puppet-agent ruby=2.5
-        - gem install bundler serverspec rspec
+        - gem install bundler -v '= 1.17.3'
+        - gem install serverspec rspec
         - ln -s /usr/bin/rspec.ruby2.5 /usr/bin/rspec
         - ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
         - mkdir /home/kitchen/puppet

--- a/manifests/install_integration.pp
+++ b/manifests/install_integration.pp
@@ -5,7 +5,7 @@ define datadog_agent::install_integration (
   Boolean                   $third_party      = false,
 ){
 
-  include datadog_agent
+  require ::datadog_agent
 
   if $ensure == 'present' {
 

--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -7,7 +7,9 @@ define datadog_agent::integration (
   Enum['present', 'absent'] $ensure = 'present',
 ){
 
-  require ::datadog_agent
+  # We can't `require ::datadog_agent` from here since this class is used by the
+  # datadog_agent class, causing a dependency cycle. If using this class
+  # directly, you should define datadog_agent before datadog_agent::integration.
 
   if $::datadog_agent::_agent_major_version > 5 {
     $dst_dir = "${datadog_agent::params::conf_dir}/${integration}.d"

--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -7,7 +7,7 @@ define datadog_agent::integration (
   Enum['present', 'absent'] $ensure = 'present',
 ){
 
-  include datadog_agent
+  require ::datadog_agent
 
   if $::datadog_agent::_agent_major_version > 5 {
     $dst_dir = "${datadog_agent::params::conf_dir}/${integration}.d"

--- a/manifests/integrations/activemq_xml.pp
+++ b/manifests/integrations/activemq_xml.pp
@@ -52,7 +52,7 @@ class datadog_agent::integrations::activemq_xml(
   Optional[Array[String]] $detailed_subscribers = [],
   Optional[Array] $instances                    = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/activemq_xml.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/apache.pp
+++ b/manifests/integrations/apache.pp
@@ -33,7 +33,7 @@ class datadog_agent::integrations::apache (
   Array $tags                     = [],
   Boolean $disable_ssl_validation = false
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/apache.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/cacti.pp
+++ b/manifests/integrations/cacti.pp
@@ -18,7 +18,7 @@ class datadog_agent::integrations::cacti(
   $mysql_password = undef,
   $rrd_path = '/var/lib/cacti/rra/',
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/cacti.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/ceph.pp
+++ b/manifests/integrations/ceph.pp
@@ -17,7 +17,7 @@ class datadog_agent::integrations::ceph(
   Array $tags = [ 'name:ceph_cluster' ],
   String $ceph_cmd = '/usr/bin/ceph',
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   file { '/etc/sudoers.d/datadog_ceph':
     content => "# This file is required for dd ceph \ndd-agent ALL=(ALL) NOPASSWD:/usr/bin/ceph\n"

--- a/manifests/integrations/consul.pp
+++ b/manifests/integrations/consul.pp
@@ -33,7 +33,7 @@ class datadog_agent::integrations::consul(
   Boolean $new_leader_checks         = true,
   Optional[Array] $service_whitelist = []
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/consul.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/directory.pp
+++ b/manifests/integrations/directory.pp
@@ -65,7 +65,7 @@ class datadog_agent::integrations::directory (
   String $pattern            = '',
   Optional[Array] $instances = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if !$instances and $directory == '' {
     fail('bad directory argument and no instances hash provided')

--- a/manifests/integrations/disk.pp
+++ b/manifests/integrations/disk.pp
@@ -81,7 +81,7 @@ class datadog_agent::integrations::disk (
   Optional[String] $excluded_disk_re       = undef,  # deprecated in agent versions >6.9
   Optional[String] $excluded_mountpoint_re = undef,  # deprecated in agent versions >6.9
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   validate_legacy('Optional[String]', 'validate_re', $all_partitions, '^(no|yes)$')
 

--- a/manifests/integrations/dns_check.pp
+++ b/manifests/integrations/dns_check.pp
@@ -33,7 +33,7 @@ class datadog_agent::integrations::dns_check (
     }
   ]
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/dns_check.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/docker_daemon.pp
+++ b/manifests/integrations/docker_daemon.pp
@@ -55,7 +55,7 @@ class datadog_agent::integrations::docker_daemon(
   $collect_labels_as_tags = [],
   $event_attributes_as_tags = [],
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   exec { 'dd-agent-should-be-in-docker-group':
     command => "/usr/sbin/usermod -aG ${group} ${datadog_agent::params::dd_user}",

--- a/manifests/integrations/elasticsearch.pp
+++ b/manifests/integrations/elasticsearch.pp
@@ -37,7 +37,7 @@ class datadog_agent::integrations::elasticsearch(
   Optional[String] $username           = undef,
   Optional[Array] $instances           = undef
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   # $ssl_verify can be a bool or a string
   # https://github.com/DataDog/dd-agent/blob/master/checks.d/elastic.py#L454-L455

--- a/manifests/integrations/fluentd.pp
+++ b/manifests/integrations/fluentd.pp
@@ -21,7 +21,7 @@ class datadog_agent::integrations::fluentd(
   $monitor_agent_url = 'http://localhost:24220/api/plugins.json',
   Optional[Array] $plugin_ids = [],
 ) inherits datadog_agent::params {
-  include ::datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/fluentd.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/generic.pp
+++ b/manifests/integrations/generic.pp
@@ -21,7 +21,7 @@ class datadog_agent::integrations::generic(
   Optional[String] $integration_name     = undef,
   Optional[String] $integration_contents = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/${integration_name}.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/haproxy.pp
+++ b/manifests/integrations/haproxy.pp
@@ -22,7 +22,7 @@ class datadog_agent::integrations::haproxy(
   $options                   = {},
   Optional[Array] $instances = undef
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if !$instances and $url {
     $_instances = [{

--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -199,7 +199,7 @@ class datadog_agent::integrations::http_check (
   Optional[Array] $instances  = undef,
   $ca_certs  = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if !$instances and $url {
     $_instances = [{

--- a/manifests/integrations/jenkins.pp
+++ b/manifests/integrations/jenkins.pp
@@ -16,7 +16,7 @@
 class datadog_agent::integrations::jenkins(
   $path = '/var/lib/jenkins'
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/jenkins.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/jmx.pp
+++ b/manifests/integrations/jmx.pp
@@ -65,7 +65,7 @@ class datadog_agent::integrations::jmx(
   $init_config = {},
   $instances   = [],
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/jmx.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/kafka.pp
+++ b/manifests/integrations/kafka.pp
@@ -65,7 +65,7 @@ class datadog_agent::integrations::kafka(
   Optional[Hash[String[1], String[1]]] $tags = undef,
   Optional[Array[Hash[String[1], Data]]] $instances = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if !$instances and $host and $port {
     $servers = [{

--- a/manifests/integrations/kong.pp
+++ b/manifests/integrations/kong.pp
@@ -32,7 +32,7 @@ class datadog_agent::integrations::kong (
     }
   ]
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/kong.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/kubernetes.pp
+++ b/manifests/integrations/kubernetes.pp
@@ -30,7 +30,7 @@ class datadog_agent::integrations::kubernetes(
   $tags = [],
 
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/kubernetes.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/kubernetes_state.pp
+++ b/manifests/integrations/kubernetes_state.pp
@@ -22,7 +22,7 @@ class datadog_agent::integrations::kubernetes_state(
   $tags = [],
 
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/kubernetes_state.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/linux_proc_extras.pp
+++ b/manifests/integrations/linux_proc_extras.pp
@@ -16,7 +16,7 @@
 class datadog_agent::integrations::linux_proc_extras(
   $tags = [],
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/linux_proc_extras.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/logs.pp
+++ b/manifests/integrations/logs.pp
@@ -40,7 +40,7 @@ class datadog_agent::integrations::logs(
   Array $logs = [],
 ) inherits datadog_agent::params {
   unless $::datadog_agent::_agent_major_version == 5 {
-    include datadog_agent
+    require ::datadog_agent
 
     file { "${datadog_agent::params::conf_dir}/logs.yaml":
       ensure  => file,

--- a/manifests/integrations/marathon.pp
+++ b/manifests/integrations/marathon.pp
@@ -16,7 +16,7 @@ class datadog_agent::integrations::marathon(
   $marathon_timeout = 5,
   $url = 'http://localhost:8080'
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/marathon.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/memcache.pp
+++ b/manifests/integrations/memcache.pp
@@ -38,7 +38,7 @@ class datadog_agent::integrations::memcache (
   Variant[Boolean, String] $slabs = false,
   Optional[Array] $instances      = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if !$instances and $url {
     $_instances = [{

--- a/manifests/integrations/mesos_master.pp
+++ b/manifests/integrations/mesos_master.pp
@@ -16,7 +16,7 @@ class datadog_agent::integrations::mesos_master(
   $mesos_timeout = 10,
   $url = 'http://localhost:5050'
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if $::datadog_agent::_agent_major_version > 5 {
     $dst_dir = "${datadog_agent::params::conf_dir}/mesos.d"

--- a/manifests/integrations/mongo.pp
+++ b/manifests/integrations/mongo.pp
@@ -59,7 +59,7 @@
 class datadog_agent::integrations::mongo(
   Array $servers = [{'host' => 'localhost', 'port' => '27017'}]
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/mongo.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/mysql.pp
+++ b/manifests/integrations/mysql.pp
@@ -81,7 +81,7 @@ class datadog_agent::integrations::mysql(
   Optional[Array] $instances               = undef,
   Optional[Array] $logs                    = [],
   ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if ($host == undef and $sock == undef) or
     ($host != undef and $port == undef and $sock == undef) {

--- a/manifests/integrations/network.pp
+++ b/manifests/integrations/network.pp
@@ -25,7 +25,7 @@ class datadog_agent::integrations::network(
   String $excluded_interface_re = '',
   Boolean $combine_connection_states = true,
 ) inherits datadog_agent::params {
-  include ::datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/network.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/nginx.pp
+++ b/manifests/integrations/nginx.pp
@@ -61,7 +61,7 @@ class datadog_agent::integrations::nginx(
   Array $instances = [],
   Optional[Array] $logs = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/nginx.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/ntp.pp
+++ b/manifests/integrations/ntp.pp
@@ -30,7 +30,7 @@ class datadog_agent::integrations::ntp(
   $version          = undef,
   $timeout          = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/ntp.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/oom_kill.pp
+++ b/manifests/integrations/oom_kill.pp
@@ -22,7 +22,7 @@
 class datadog_agent::integrations::oom_kill(
   Array $instances = [],
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $dst_dir = "${datadog_agent::params::conf_dir}/oom_kill.d"
   file { $dst_dir:

--- a/manifests/integrations/pgbouncer.pp
+++ b/manifests/integrations/pgbouncer.pp
@@ -51,7 +51,7 @@ class datadog_agent::integrations::pgbouncer(
   Array $tags = [],
   Array $pgbouncers = [],
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/pgbouncer.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/php_fpm.pp
+++ b/manifests/integrations/php_fpm.pp
@@ -35,7 +35,7 @@ class datadog_agent::integrations::php_fpm(
   $instances        = undef,
   $use_fastcgi      = 'false'
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if !$instances {
     $_instances = [{

--- a/manifests/integrations/postfix.pp
+++ b/manifests/integrations/postfix.pp
@@ -34,7 +34,7 @@ class datadog_agent::integrations::postfix (
   Optional[Array] $tags      = [],
   Optional[Array] $instances = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if !$instances and $directory {
     $_instances = [{

--- a/manifests/integrations/postgres.pp
+++ b/manifests/integrations/postgres.pp
@@ -100,7 +100,7 @@ class datadog_agent::integrations::postgres(
   Hash $custom_metrics                   = {},
   Optional[Array] $instances             = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/postgres.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/process.pp
+++ b/manifests/integrations/process.pp
@@ -45,7 +45,7 @@ class datadog_agent::integrations::process(
   $init_config = {},
   Array $processes = [],
   ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if $hiera_processes {
     $local_processes = lookup({ 'name' => 'datadog_agent::integrations::process::processes', 'merge' => 'unique', 'default_value' => $processes })

--- a/manifests/integrations/rabbitmq.pp
+++ b/manifests/integrations/rabbitmq.pp
@@ -65,7 +65,7 @@ class datadog_agent::integrations::rabbitmq (
   Array $exchanges_regexes   = [],
 ) inherits datadog_agent::params {
 
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/rabbitmq.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/redis.pp
+++ b/manifests/integrations/redis.pp
@@ -53,7 +53,7 @@ class datadog_agent::integrations::redis(
   Optional[Array] $instances                = undef,
 
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if $ports == undef {
     $_ports = [ $port ]

--- a/manifests/integrations/riak.pp
+++ b/manifests/integrations/riak.pp
@@ -22,7 +22,7 @@ class datadog_agent::integrations::riak(
   String $url  = 'http://localhost:8098/stats',
   Array $tags  = [],
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/riak.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/snmp.pp
+++ b/manifests/integrations/snmp.pp
@@ -60,7 +60,7 @@ class datadog_agent::integrations::snmp (
   $snmp_v2_instances        = [],
   $snmp_v3_instances        = [],
 ) inherits datadog_agent::params {
-  include ::datadog_agent
+  require ::datadog_agent
 
   $versioned_instances = {
     1 => $snmp_v1_instances,

--- a/manifests/integrations/solr.pp
+++ b/manifests/integrations/solr.pp
@@ -36,7 +36,7 @@ class datadog_agent::integrations::solr(
   $trust_store_password = undef,
   $tags                 = {},
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/solr.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/ssh.pp
+++ b/manifests/integrations/ssh.pp
@@ -35,7 +35,7 @@ class datadog_agent::integrations::ssh(
   $private_key_file  = undef,
   $add_missing_keys  = true,
 ) inherits datadog_agent::params {
-  include ::datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/ssh.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/supervisord.pp
+++ b/manifests/integrations/supervisord.pp
@@ -44,7 +44,7 @@
 class datadog_agent::integrations::supervisord (
   $instances    = [{'servername' => 'server0', 'hostname' => 'localhost', 'port' => '9001'}],
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/supervisord.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/system_core.pp
+++ b/manifests/integrations/system_core.pp
@@ -7,7 +7,7 @@
 #
 #
 class datadog_agent::integrations::system_core inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/system_core.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/tcp_check.pp
+++ b/manifests/integrations/tcp_check.pp
@@ -97,7 +97,7 @@ class datadog_agent::integrations::tcp_check (
   Array $tags                = [],
   Optional[Array] $instances = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if !$instances and $host {
     $_instances = [{

--- a/manifests/integrations/tomcat.pp
+++ b/manifests/integrations/tomcat.pp
@@ -39,7 +39,7 @@ class datadog_agent::integrations::tomcat(
   $trust_store_password = undef,
   $tags                 = {},
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/tomcat.yaml"

--- a/manifests/integrations/twemproxy.pp
+++ b/manifests/integrations/twemproxy.pp
@@ -28,7 +28,7 @@ class datadog_agent::integrations::twemproxy(
   $port = '22222',
   $instances = undef,
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   if !$instances and $host {
     $_instances = [{

--- a/manifests/integrations/varnish.pp
+++ b/manifests/integrations/varnish.pp
@@ -26,7 +26,7 @@ class datadog_agent::integrations::varnish (
   $instance_name = undef,
   $tags          = [],
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/varnish.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/integrations/zk.pp
+++ b/manifests/integrations/zk.pp
@@ -30,7 +30,7 @@
 class datadog_agent::integrations::zk (
   $servers = [{'host' => 'localhost', 'port' => '2181'}]
 ) inherits datadog_agent::params {
-  include datadog_agent
+  require ::datadog_agent
 
   $legacy_dst = "${datadog_agent::params::legacy_conf_dir}/zk.yaml"
   if $::datadog_agent::_agent_major_version > 5 {

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -33,7 +33,7 @@ class datadog_agent::reports(
 
   } else {
 
-    include datadog_agent
+    require ::datadog_agent
 
     if $manage_dogapi_gem {
       $rubydev_package = $datadog_agent::params::rubydev_package

--- a/spec/classes/datadog_agent_integrations_zk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_zk_spec.rb
@@ -12,6 +12,9 @@ describe 'datadog_agent::integrations::zk' do
                   end
 
       it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_class('datadog_agent::params') }
+
       it {
         is_expected.to contain_file(conf_file).with(
           owner: DD_USER,


### PR DESCRIPTION
### What does this PR do?

- Make integration classes `require datadog_agent` instead of `include datadog_agent`.
- Fixed kitchen tests that bitrot and expands them a bit to cover the use of integration classes.

### Motivation

This ensures the right execution order of the classes.

### Additional Notes

Supersedes #193

This is technically a breaking change, but I can't imagine a scenario where the old behaviour is useful.

### Describe your test plan

Tests pass.
