### PR TITLE
Support AlmaLinux and Rocky Linux with Puppet >= 7.12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,13 @@ jobs:
       RUBY_VERSION: '2.6.3'
       PUPPET_VERSION: '7.9.0'
 
+  specs-ruby26-puppet714:
+    <<: *specs
+    environment:
+      STRICT_VARIABLES: 'yes'
+      RUBY_VERSION: '2.6.3'
+      PUPPET_VERSION: '7.14.0'
+
   specs-ruby25-puppet65-windows: &windows-specs
     executor:
       name: win/default # Comes with ruby 2.6, which is not supported on Windows as of puppet 6.10.1
@@ -325,5 +332,6 @@ workflows:
       - specs-ruby26-puppet60
       - specs-ruby26-puppet65
       - specs-ruby26-puppet79
+      - specs-ruby26-puppet714
       - verify-gemfile-lock-dependencies
       - kitchen-tests

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -50,6 +50,25 @@ platforms:
         - gem install r10k -v 2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
+  - name: rocky-8-puppet-5
+    driver_config:
+      # we use a custom image that runs systemd
+      image: 'datadog/docker-library:chef_kitchen_systemd_rocky_8'
+      platform: rhel # kitchen-docker doesn't recognize rocky otherwise
+      run_command: /root/start.sh
+    driver:
+      provision_command:
+        - dnf install -y https://yum.puppetlabs.com/puppet7-release-el-8.noarch.rpm #installs the puppet-agent repo
+        - dnf install -y puppet-agent rubygems
+        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+
+        - mkdir /home/kitchen/puppet
+        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+
+        - gem install bundler -v '= 1.17.3'
+        - gem install r10k -v 2.6.7
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+
   - name: ubuntu-1604-puppet-6
     driver_config:
        # we use the official image

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -32,24 +32,6 @@ platforms:
         - gem install r10k -v 2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
-  - name: centos-8-puppet-5
-    driver_config:
-      # we use a custom image that runs systemd
-      image: 'datadog/docker-library:chef_kitchen_systemd_centos_8'
-      run_command: /root/start.sh
-    driver:
-      provision_command:
-        - dnf install -y https://yum.puppetlabs.com/puppet5-release-el-8.noarch.rpm #installs the puppet-agent repo
-        - dnf install -y puppet-agent rubygems
-        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
-
-        - mkdir /home/kitchen/puppet
-        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-
-        - gem install bundler -v '= 1.17.3'
-        - gem install r10k -v 2.6.7
-        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
-
   - name: rocky-8-puppet-5
     driver_config:
       # we use a custom image that runs systemd

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -441,7 +441,7 @@ class datadog_agent(
           skip_apt_key_trusting => $skip_apt_key_trusting,
         }
       }
-      'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux' : {
+      'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux','AlmaLinux','Rocky' : {
         class { 'datadog_agent::redhat':
           agent_major_version => $_agent_major_version,
           agent_flavor        => $agent_flavor,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class datadog_agent::params {
       $permissions_protected_file = '0600'
       $agent_binary               = '/opt/datadog-agent/bin/agent/agent'
     }
-    'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux', 'OpenSuSE', 'SLES' : {
+    'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux', 'AlmaLinux', 'Rocky', 'OpenSuSE', 'SLES' : {
       $rubydev_package            = 'ruby-devel'
       $legacy_conf_dir            = '/etc/dd-agent/conf.d'
       $conf_dir                   = '/etc/datadog-agent/conf.d'

--- a/metadata.json
+++ b/metadata.json
@@ -64,6 +64,18 @@
       ]
     },
     {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "6",

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -219,4 +219,66 @@ describe 'datadog_agent::redhat' do
       end
     end
   end
+
+  context 'almalinux 8', if: min_puppet_version('7.12.0') do
+    let(:facts) do
+      {
+        osfamily: 'redhat',
+        operatingsystem: 'AlmaLinux',
+        operatingsystemrelease: '8.5',
+        architecture: 'x86_64',
+      }
+    end
+
+    # it should install the repo
+    context 'with manage_repo => true' do
+      let(:params) do
+        {
+          manage_repo: true, agent_major_version: 7
+        }
+      end
+
+      it do
+        is_expected.to contain_yumrepo('datadog')
+          .with_enabled(1)\
+          .with_gpgcheck(1)\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+          .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
+          .with_repo_gpgcheck(true)
+      end
+    end
+  end
+
+  context 'rocky 8', if: min_puppet_version('7.12.0') do
+    let(:facts) do
+      {
+        osfamily: 'redhat',
+        operatingsystem: 'Rocky',
+        operatingsystemrelease: '8.5',
+        architecture: 'x86_64',
+      }
+    end
+
+    # it should install the repo
+    context 'with manage_repo => true' do
+      let(:params) do
+        {
+          manage_repo: true, agent_major_version: 7
+        }
+      end
+
+      it do
+        is_expected.to contain_yumrepo('datadog')
+          .with_enabled(1)\
+          .with_gpgcheck(1)\
+          .with_gpgkey('https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public')\
+          .with_baseurl('https://yum.datadoghq.com/stable/7/x86_64/')\
+          .with_repo_gpgcheck(true)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 DEBIAN_OS = ['Ubuntu', 'Debian'].freeze
-REDHAT_OS = ['RedHat', 'CentOS', 'Fedora', 'Amazon', 'Scientific', 'OracleLinux'].freeze
+REDHAT_OS = ['RedHat', 'CentOS', 'Fedora', 'Amazon', 'Scientific', 'OracleLinux', 'AlmaLinux', 'Rocky'].freeze
 WINDOWS_OS = ['Windows'].freeze
 
 if RSpec::Support::OS.windows?
@@ -24,6 +24,10 @@ else
   PACKAGE_NAME               = 'datadog-agent'.freeze
   PERMISSIONS_FILE           = '0644'.freeze
   PERMISSIONS_PROTECTED_FILE = '0600'.freeze
+end
+
+def min_puppet_version(version)
+  Gem.loaded_specs['puppet'].version > Gem::Version.new(version)
 end
 
 def getosfamily(operatingsystem)


### PR DESCRIPTION
### What does this PR do?

Adds support for AlmaLinux and Rocky Linux with Puppet >= 7.12.0.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
