### PR TITLE
Allow more recent versions of dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.24.0 <7.0.0"
+      "version_requirement": ">=4.24.0 <9.0.0"
     },
     {
       "name": "puppetlabs/ruby",
@@ -18,11 +18,11 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=4.0.0 <7.0.0"
+      "version_requirement": ">=4.0.0 <8.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=4.4.0 <8.0.0"
+      "version_requirement": ">=4.4.0 <9.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",


### PR DESCRIPTION
### What does this PR do?

Allow latest versions of: stdlib, concat, apt

### Motivation

This module is blocking us from using the most recent versions of these.

### Describe your test plan

Assuming low chance of impact. CI tests will pick up any issues. 