### PR TITLE
Fix some CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ jobs:
       RUBY_VERSION: '2.1.9'
       PUPPET_VERSION: '4.6.2'
     steps:
+      # See https://github.blog/2021-09-01-improving-git-protocol-security-github/
+      - run:
+          name: Fix git clones
+          command: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - checkout
       - run:
           name: Install Ruby version
@@ -239,6 +243,10 @@ jobs:
       name: win/default # Comes with ruby 2.6, which is not supported on Windows as of puppet 6.10.1
       shell: bash.exe
     steps:
+      # See https://github.blog/2021-09-01-improving-git-protocol-security-github/
+      - run:
+          name: Fix git clones
+          command: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - checkout
       - run:
           name: Run tests
@@ -263,6 +271,10 @@ jobs:
       STRICT_VARIABLES: 'yes'
       RUBY_VERSION: '2.5.3'
     steps:
+      # See https://github.blog/2021-09-01-improving-git-protocol-security-github/
+      - run:
+          name: Fix git clones
+          command: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - checkout
       - run:
           name: Install Ruby versions
@@ -283,6 +295,10 @@ jobs:
       STRICT_VARIABLES: 'yes'
       RUBY_VERSION: '2.5.3'
     steps:
+      # See https://github.blog/2021-09-01-improving-git-protocol-security-github/
+      - run:
+          name: Fix git clones
+          command: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - checkout
       - run:
           name: Install Ruby versions


### PR DESCRIPTION
### What does this PR do?

<!--A brief description of the change being made with this pull request.-->

As described in ["Improving Git protocol security on GitHub"](https://github.blog/2021-09-01-improving-git-protocol-security-github/), unauthenticated git clones are no longer accepted. 

This PR applies the fix described [here](https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported).

### Motivation

<!--What inspired you to submit this pull request?-->

All tests were failing.

### Additional Notes

<!--Anything else we should know when reviewing?-->

Some tests are failing, but for unrelated reasons.