### PR TITLE
Allow Configuration of Puppet Reports URL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,8 @@
 #       Note: this is not for Puppet Report Tags.  See report_trusted_fact_tags
 #   $puppet_run_reports
 #       Will send results from your puppet agent runs back to the datadog service.
+#   $reports_url
+#       The URL to use when sending puppet run reports. Default: https://api.${datadog_site}
 #   $manage_dogapi_gem
 #       When reports are enabled, ensure the dogapi gem (required) is installed.
 #   $puppetmaster_user
@@ -262,6 +264,7 @@ class datadog_agent(
   Array $facts_to_tags = [],
   Array $trusted_facts_to_tags = [],
   Boolean $puppet_run_reports = false,
+  String $reports_url = "https://api.${datadog_site}",
   String $puppetmaster_user = $settings::user,
   String $puppet_gem_provider = $datadog_agent::params::gem_provider,
   Boolean $non_local_traffic = false,
@@ -809,7 +812,7 @@ class datadog_agent(
 
     class { 'datadog_agent::reports':
       api_key                   => $api_key,
-      datadog_site              => $datadog_site,
+      datadog_site              => $reports_url,
       manage_dogapi_gem         => $manage_dogapi_gem,
       puppet_gem_provider       => $puppet_gem_provider,
       dogapi_version            => $datadog_agent::params::dogapi_version,

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -6,6 +6,8 @@
 # Parameters:
 #   $api_key:
 #       Your DataDog API Key. Please replace with your key value
+#   $datadog_site:
+#       URL to use to talk to the Datadog API
 #
 # Actions:
 #
@@ -23,7 +25,7 @@ class datadog_agent::reports(
   $proxy_https = undef,
   $report_fact_tags = [],
   $report_trusted_fact_tags = [],
-  $datadog_site = 'datadoghq.com',
+  $datadog_site = 'https://api.datadoghq.com',
   $puppet_gem_provider = $datadog_agent::params::gem_provider,
 ) inherits datadog_agent::params {
 

--- a/templates/datadog-reports.yaml.erb
+++ b/templates/datadog-reports.yaml.erb
@@ -2,7 +2,7 @@
 
 ---
 :datadog_api_key: '<%= @api_key %>'
-:api_url: https://api.<%= @datadog_site %>
+:api_url: <%= @datadog_site %>
 <% if @hostname_extraction_regex -%>
 :hostname_extraction_regex: '<%= @hostname_extraction_regex %>'
 <% end -%>


### PR DESCRIPTION
### What does this PR do?

This allows for full configuration of what URL is used to ship puppet reports to datadog, while maintaining the current default configuration.

### Motivation

At a site where I'm using this module, the puppetservers cannot access the Internet except by an nginx reverse proxy. In order to use this reverse proxy, I needed to patch the module to allow me to override the full URL, not just the site name with https://api. being hardcoded onto it.

