### PR TITLE
Fix nginx integration example for logs

### DIFF
--- a/manifests/integrations/nginx.pp
+++ b/manifests/integrations/nginx.pp
@@ -20,6 +20,8 @@
 #             'nginx_status_url'  => 'http://example2.com:1234/nginx_status/',
 #             'tags' => ['instance:foo'],
 #         },
+#     ],
+#     logs => [
 #         {
 #             'type' => 'file',
 #             'path' => '/var/log/nginx/access.log',


### PR DESCRIPTION
### What does this PR do?

The example is wrong for logs. The log parameters need to be under logs not instances.

### Motivation

Following the example didnt work causing confusion.

### Additional Notes

n/a

### Describe your test plan

This is just a comment/documentation no testing required but the proposed example is the correct syntax.