### PR TITLE
Use proper version string for package.ensure on Windows

### DIFF
--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -64,7 +64,7 @@ class datadog_agent::windows(
       $ensure_version = 'installed'
     } else {
       # While artifacts contain X.Y.Z in their name, their installed Windows versions are actually X.Y.Z.1
-      $ensure_version = "$agent_version.1"
+      $ensure_version = "${agent_version}.1"
     }
 
     $hostname_option = $hostname ? { '' => {}, default => { 'HOSTNAME' => $hostname } }

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -63,7 +63,8 @@ class datadog_agent::windows(
     if $agent_version == 'latest' {
       $ensure_version = 'installed'
     } else {
-      $ensure_version = $agent_version
+      # While artifacts contain X.Y.Z in their name, their installed Windows versions are actually X.Y.Z.1
+      $ensure_version = "$agent_version.1"
     }
 
     $hostname_option = $hostname ? { '' => {}, default => { 'HOSTNAME' => $hostname } }


### PR DESCRIPTION
### What does this PR do?

Fixes #730 by adding `.1` to the `package.ensure` attribute on Windows when using a pinned agent version.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
