### PR TITLE
Mongo: Replace Deprecated Parameters

### DIFF
--- a/manifests/integrations/mongo.pp
+++ b/manifests/integrations/mongo.pp
@@ -13,16 +13,14 @@
 #       Optionally specify password for connection
 #   $port
 #       The port mongo is running on. Defaults to 27017
-#   $ssl
-#       Optionally enable SSL for connection
-#   $ssl_ca_certs
-#       Optionally specify path to SSL Certificate Authority certificates
-#   $ssl_cert_reqs
-#       Optionally require SSL client certificate for connection
-#   $ssl_certfile
-#       Optionally specify path to SSL certificate for connection
-#   $ssl_keyfile
-#       Optionally specify path to SSL private key for connection
+#   $tls
+#       Optionally enable TLS for connection
+#   $tls_ca_file
+#       Optionally specify path to SSL/TLS Certificate Authority certificates
+#   $tls_allow_invalid_certificates
+#       Optionally require SSL/TLS client certificate for connection
+#   $tls_certificate_key_file
+#       Optionally specify path to combined SSL/TLS key and certificate for connection
 #   $tags
 #       Optional array of tags
 #   $username
@@ -38,11 +36,10 @@
 #        'host'               => 'localhost',
 #        'password'           => 'mongo_password',
 #        'port'               => '27017',
-#        'ssl'                => true,
-#        'ssl_ca_certs'       => '/path/to/ca.pem',
-#        'ssl_cert_reqs'      => 'CERT_REQUIRED',
-#        'ssl_certfile'       => '/path/to/client.pem',
-#        'ssl_keyfile'        => '/path/to/key.pem',
+#        'tls'                => true,
+#        'tls_ca_file'       => '/path/to/ca.pem',
+#        'tls_allow_invalid_certificates'      => false,
+#        'tls_certificate_key_file'       => '/path/to/combined.pem',
 #        'tags'               => ['optional_tag1', 'optional_tag2'],
 #        'username'           => 'mongo_username',
 #      },

--- a/manifests/integrations/mongo.pp
+++ b/manifests/integrations/mongo.pp
@@ -2,6 +2,8 @@
 #
 # This class will install the necessary configuration for the mongo integration
 #
+# NOTE: In newer versions of the Datadog Agent, the ssl parameters will be deprecated in favor the tls variants
+#
 # Parameters:
 #   $additional_metrics
 #       Optional array of additional metrics
@@ -13,6 +15,16 @@
 #       Optionally specify password for connection
 #   $port
 #       The port mongo is running on. Defaults to 27017
+#   $ssl
+#       Optionally enable SSL for connection
+#   $ssl_ca_certs
+#       Optionally specify path to SSL Certificate Authority certificates
+#   $ssl_cert_reqs
+#       Optionally require SSL client certificate for connection
+#   $ssl_certfile
+#       Optionally specify path to SSL certificate for connection
+#   $ssl_keyfile
+#       Optionally specify path to SSL private key for connection
 #   $tls
 #       Optionally enable TLS for connection
 #   $tls_ca_file
@@ -26,7 +38,35 @@
 #   $username
 #       Optionally specify username for connection
 #
-# Sample Usage:
+# Sample Usage (Older Agent Versions):
+#
+#  class { 'datadog_agent::integrations::mongo' :
+#    servers => [
+#      {
+#        'additional_metrics' => ['top'],
+#        'database'           => 'database_name',
+#        'host'               => 'localhost',
+#        'password'           => 'mongo_password',
+#        'port'               => '27017',
+#        'ssl'                => true,
+#        'ssl_ca_certs'       => '/path/to/ca.pem',
+#        'ssl_cert_reqs'      => 'CERT_REQUIRED',
+#        'ssl_certfile'       => '/path/to/client.pem',
+#        'ssl_keyfile'        => '/path/to/key.pem',
+#        'tags'               => ['optional_tag1', 'optional_tag2'],
+#        'username'           => 'mongo_username',
+#      },
+#      {
+#        'host'               => 'localhost',
+#        'port'               => '27018',
+#        'tags'               => [],
+#        'additional_metrics' => [],
+#        'collections'        => [],
+#      },
+#    ]
+#  }
+#
+# Sample Usage (Newer Agent Versions):
 #
 #  class { 'datadog_agent::integrations::mongo' :
 #    servers => [

--- a/templates/agent-conf.d/mongo.yaml.erb
+++ b/templates/agent-conf.d/mongo.yaml.erb
@@ -11,6 +11,21 @@ instances:
       - <%= tag %>
     <%- end -%>
   <%- end -%>
+  <%- if !server['ssl'].nil? -%>
+    ssl: <%= server['ssl'] %>
+    <%- if !server['ssl_keyfile'].nil? -%>
+    ssl_keyfile: <%= server['ssl_keyfile'] %>
+    <%- end -%>
+    <%- if !server['ssl_certfile'].nil? -%>
+    ssl_certfile: <%= server['ssl_certfile'] %>
+    <%- end -%>
+    <%- if !server['ssl_cert_reqs'].nil? -%>
+    ssl_cert_reqs: <%= server['ssl_cert_reqs'] %>
+    <%- end -%>
+    <%- if !server['ssl_ca_certs'].nil? -%>
+    ssl_ca_certs: <%= server['ssl_ca_certs'] %>
+    <%- end -%>
+  <%- end -%>
   <%- if !server['tls'].nil? -%>
     tls: <%= server['tls'] %>
     <%- if !server['tls_certificate_key_file'].nil? -%>

--- a/templates/agent-conf.d/mongo.yaml.erb
+++ b/templates/agent-conf.d/mongo.yaml.erb
@@ -11,19 +11,16 @@ instances:
       - <%= tag %>
     <%- end -%>
   <%- end -%>
-  <%- if !server['ssl'].nil? -%>
-    ssl: <%= server['ssl'] %>
-    <%- if !server['ssl_keyfile'].nil? -%>
-    ssl_keyfile: <%= server['ssl_keyfile'] %>
+  <%- if !server['tls'].nil? -%>
+    tls: <%= server['tls'] %>
+    <%- if !server['tls_certificate_key_file'].nil? -%>
+    tls_certificate_key_file: <%= server['tls_certificate_key_file'] %>
     <%- end -%>
-    <%- if !server['ssl_certfile'].nil? -%>
-    ssl_certfile: <%= server['ssl_certfile'] %>
+    <%- if !server['tls_allow_invalid_certificates'].nil? -%>
+    tls_allow_invalid_certificates: <%= server['tls_allow_invalid_certificates'] %>
     <%- end -%>
-    <%- if !server['ssl_cert_reqs'].nil? -%>
-    ssl_cert_reqs: <%= server['ssl_cert_reqs'] %>
-    <%- end -%>
-    <%- if !server['ssl_ca_certs'].nil? -%>
-    ssl_ca_certs: <%= server['ssl_ca_certs'] %>
+    <%- if !server['tls_ca_file'].nil? -%>
+    tls_ca_file: <%= server['tls_ca_file'] %>
     <%- end -%>
   <%- end -%>
   <%- if !server['additional_metrics'].nil? && server['additional_metrics'].any? -%>


### PR DESCRIPTION
### What does this PR do?

PyMongo v3.9 and v3.12 Deprecated many ssl parameters in replace of tls counterparts. This was applied to the DataDog/integrations-core repository, but needed to be updated for puppet configs.

### Motivation

My DataDog Agent was having trouble running for MongoDB, and after some investigating found it to be due to the Puppet configuration using the older terms.

### Additional Notes

For more information on the changes, see https://github.com/DataDog/integrations-core/pull/12743 and https://pymongo.readthedocs.io/en/stable/changelog.html for v3.9 and v3.12

More of a personal note, I need to acknowledge @Mstrodl who pointed out that this issue was connected to the Puppet config! She really helped me find the root of the problem and get around to making these changes!

### Describe your test plan

Run this config with an updated DataDog Agent