### PR TITLE
[cassandra] Reword max_returned_metrics docs

### DIFF
--- a/manifests/integrations/cassandra.pp
+++ b/manifests/integrations/cassandra.pp
@@ -1,7 +1,10 @@
 # Class: datadog_agent::integrations::cassandra
 #
 # This class will install the necessary configuration for the Cassandra
-# integration
+# integration.
+#
+# This check has a limit of 350 metrics per instance. If you require 
+# additional metrics, contact Datadog Support at https://docs.datadoghq.com/help/
 #
 # Parameters:
 #   $host:
@@ -14,8 +17,6 @@
 #       The password for the datadog user
 #   $tags
 #       Optional array of tags
-#   $max_returned_metrics
-#       Optional number of maximum returned metrics, default 350
 #
 # Sample Usage:
 #


### PR DESCRIPTION
### What does this PR do?

<!--A brief description of the change being made with this pull request.-->

Reword documentation related to `max_returned_metrics`, follow up to https://github.com/DataDog/puppet-datadog-agent/pull/751

### Motivation

<!--What inspired you to submit this pull request?-->

We want people to contact Datadog support before using this to understand the implications.