### PR TITLE
Set dd_url to the correct value

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -740,7 +740,7 @@ class datadog_agent(
 
     $_agent_config = {
       'api_key' => $api_key,
-      'dd_url' => $dd_url,
+      'dd_url' => $_dd_url,
       'site' => $datadog_site,
       'cmd_port' => $cmd_port,
       'hostname_fqdn' => $hostname_fqdn,


### PR DESCRIPTION
### What does this PR do?
Fixes the dd_url config value
### Motivation
If no dd_url is given, a empty string is added to the config file of the agent. 
This results in custom metrics that are not being sent to Datadog.
With this fix, the correct value is used