### PR TITLE
Upgrade dependency, Ubuntu and Puppet version ranges

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=4.4.0 <9.0.0"
+      "version_requirement": ">=4.4.0 <10.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",
@@ -34,11 +34,11 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">=2.3.0 <5.0.0"
+      "version_requirement": ">=2.3.0 <6.0.0"
     },
     {
       "name": "puppet/zypprepo",
-      "version_requirement": ">=3.1.0 <4.0.0"
+      "version_requirement": ">=3.1.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -115,7 +115,9 @@
         "17.04",
         "17.10",
         "18.04",
-        "18.10"
+        "18.10",
+        "20.04",
+        "22.04"
       ]
     },
     {
@@ -152,7 +154,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.6.0 <7.0.0"
+      "version_requirement": ">=4.6.0 <8.0.0"
     }
   ],
   "description": "This will install the Datadog monitoring agent. Sign up and get your API key at: http://www.datadoghq.com",


### PR DESCRIPTION
### What does this PR do?

Upgrades upper limit of various version ranges in `metadata.json`: 
- Dependent modules
- Ubuntu
- Puppet

### Motivation

Being held back in what puppet modules we can use because of the version ranges in this module.

### Additional Notes

Until #735 is resolved several of these higher versions are unattainable because `puppetlabs-ruby` is holding back `stdlib` to < 7

### Describe your test plan

I would test with PDK but I couldn't because the PDK version set in this project is very old. I presume this is to maintain compatibility with Puppet v4. 
