### PR TITLE
Quick and dirty fix for kitchen tests

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -11,7 +11,7 @@ provisioner:
   require_chef_for_busser: false
   puppet_debug: true
   puppet_verbose: true
-  custom_pre_apply_command: 'cp -r /tmp/modules/* /tmp/kitchen/modules/'
+  custom_pre_apply_command: 'cp -r /tmp/modules/* /tmp/kitchen/modules/ && sed -i "s|\$datadog_agent::params::agent_version|\"7.39.0\"|" /tmp/kitchen/modules/datadog_agent/manifests/init.pp'
 
 platforms:
   - name: centos-7-puppet-5

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -87,6 +87,7 @@ platforms:
         - zypper ar -G https://yum.puppet.com/puppet/sles/15/x86_64/ puppet-repo
         - zypper install -y puppet-agent ruby=2.5
         - gem install bundler -v '= 1.17.3'
+        - gem install net-ssh -v '= 6.1.0'
         - gem install serverspec rspec
         - ln -s /usr/bin/rspec.ruby2.5 /usr/bin/rspec
         - ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet


### PR DESCRIPTION
### What does this PR do?

Quick and dirty fix for kitchen tests. I just can't figure out how to properly pass an attribute with kitchen-puppet, so I did hard sed on the `init.pp` file. We install the 7.39.0 because since 7.40.0 agent won't start because it can't determine hostname as reported in https://github.com/DataDog/datadog-agent/issues/14152

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
