### PR TITLE
Explicit conversion to integer to avoid warning

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -365,7 +365,7 @@ class datadog_agent(
 
   #In this regex, version '1:6.15.0~rc.1-1' would match as $1='1:', $2='6', $3='15', $4='0', $5='~rc.1', $6='1'
   if $agent_version != 'latest' and $agent_version =~ /([0-9]+:)?([0-9]+)\.([0-9]+)\.([0-9]+)((?:~|-)[^0-9\s-]+[^-\s]*)?(?:-([0-9]+))?/ {
-    $_agent_major_version = 0 + $2 # Cast to integer
+    $_agent_major_version = Integer($2)
     if $agent_major_version != undef and $agent_major_version != $_agent_major_version {
       fail('Provided and deduced agent_major_version don\'t match')
     }


### PR DESCRIPTION
### What does this PR do?

Explicitly cast string to integer.

### Motivation

Avoids a warning message: `Warning: The string '6' was automatically coerced to the numerical value 6`

### Additional Notes

None.

### Describe your test plan

I have not ran the code, only read the [documentation](https://www.puppet.com/docs/puppet/7/function.html#conversion-to-integer). The built-in `Integer` function is present already in [puppet 4.6](https://github.com/puppetlabs/docs-archive/blob/main/puppet/4.6/function.md#conversion-to-integer) which is the lowest version that the latest datadog module claims to supports.
