### PR TITLE
Fix Puppet CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,6 +240,19 @@ jobs:
       STRICT_VARIABLES: 'yes'
       RUBY_VERSION: '2.6.3'
       PUPPET_VERSION: '6.5.0'
+  specs-ruby26-puppet79:
+    <<: *specs
+    environment:
+      STRICT_VARIABLES: 'yes'
+      RUBY_VERSION: '2.6.3'
+      PUPPET_VERSION: '7.9.0'
+
+  specs-ruby26-puppet714:
+    <<: *specs
+    environment:
+      STRICT_VARIABLES: 'yes'
+      RUBY_VERSION: '2.6.3'
+      PUPPET_VERSION: '7.14.0'
 
   specs-ruby26-puppet725:
     <<: *specs
@@ -357,6 +370,8 @@ workflows:
       - specs-ruby25-puppet65-windows
       - specs-ruby26-puppet60
       - specs-ruby26-puppet65
+      - specs-ruby26-puppet79
+      - specs-ruby26-puppet714
       - specs-ruby26-puppet725
       - verify-gemfile-lock-dependencies
       - kitchen-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,19 +241,12 @@ jobs:
       RUBY_VERSION: '2.6.3'
       PUPPET_VERSION: '6.5.0'
 
-  specs-ruby26-puppet79:
+  specs-ruby26-puppet725:
     <<: *specs
     environment:
       STRICT_VARIABLES: 'yes'
       RUBY_VERSION: '2.6.3'
-      PUPPET_VERSION: '7.9.0'
-
-  specs-ruby26-puppet714:
-    <<: *specs
-    environment:
-      STRICT_VARIABLES: 'yes'
-      RUBY_VERSION: '2.6.3'
-      PUPPET_VERSION: '7.14.0'
+      PUPPET_VERSION: '7.25.0'
 
   specs-ruby25-puppet65-windows: &windows-specs
     executor:
@@ -364,7 +357,6 @@ workflows:
       - specs-ruby25-puppet65-windows
       - specs-ruby26-puppet60
       - specs-ruby26-puppet65
-      - specs-ruby26-puppet79
-      - specs-ruby26-puppet714
+      - specs-ruby26-puppet725
       - verify-gemfile-lock-dependencies
       - kitchen-tests

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,8 +14,12 @@ fixtures:
       ref: "1.0.0"
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
   forge_modules:
-    yumrepo_core: "puppetlabs/yumrepo_core"
-    powershell: "puppetlabs/powershell"
+    yumrepo_core:
+      repo: "puppetlabs/yumrepo_core"
+      ref: "1.2.0"
+    powershell:
+      repo: "puppetlabs/powershell"
+      ref: "4.1.0"
     zypprepo:
       repo: "puppet/zypprepo"
       ref: "3.1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 # Each version of Puppet recommends a specific version of Ruby. Try to fetch the Puppet version that
 # matches our Ruby (unless PUPPET_VERSION is defined).
 matching_puppet_version = ruby_version > Gem::Version.new('2.5') ? (ruby_version > Gem::Version.new('2.7') ? '7.0.0' : '6.0.1') : '4.10.2'
-gem "puppet", "~> #{ENV.fetch('PUPPET_VERSION', matching_puppet_version)}"
+puppet_version = ENV.fetch('PUPPET_VERSION', matching_puppet_version)
+gem "puppet", "~> #{puppet_version}"
 
 ruby_version_segments = ruby_version.segments
 minor_version = ruby_version_segments[0..1].join('.')
@@ -13,6 +14,7 @@ minor_version = ruby_version_segments[0..1].join('.')
 group :development do
   gem "rake", "~> 12.3.3"                                          if ruby_version < Gem::Version.new('2.6.0') # last version for ruby < 2.6
   gem "xmlrpc"                                                     if ruby_version >= Gem::Version.new('2.3')
+  gem "concurrent-ruby", '= 1.1.10'                                if Gem::Requirement.create([' >= 6.9.0', '<7.25.0']).satisfied_by?(Gem::Version.new(puppet_version)) # Add this beucause until Puppet 7.25 concurrent-ruby 1.22 break puppet
   gem "ruby-pwsh", '~> 0.3.0',                                     platforms: [:mswin, :mingw, :x64_mingw]
   gem "fast_gettext", '1.1.0',                                     require: false if ruby_version < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                              require: false if ruby_version >= Gem::Version.new('2.1.0')

--- a/environments/etc/Gemfile
+++ b/environments/etc/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gem 'semantic_puppet', '1.0.4' 
+gem 'multipart-post', '2.1.1'
+gem 'r10k', '2.6.7'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -99,7 +99,7 @@ platforms:
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
         - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-        - cd /home && bundle install
+        - cd /home && bundle.ruby2.5 install
         - cd /home/kitchen/puppet && /opt/puppetlabs/puppet/bin/r10k puppetfile install --moduledir=/tmp/modules
 
 verifier:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -100,7 +100,7 @@ platforms:
         - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
         - cd /home && bundle.ruby2.5 install
-        - cd /home/kitchen/puppet && /opt/puppetlabs/puppet/bin/r10k puppetfile install --moduledir=/tmp/modules
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
 verifier:
   name: serverspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -31,7 +31,7 @@ platforms:
 
         - gem install bundler -v '= 1.17.3'
         # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
-        - bundle install
+        - cd /home && bundle install
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
   - name: rocky-8-puppet-5

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -30,7 +30,7 @@ platforms:
 
         - gem install bundler -v '= 1.17.3'
         # multipart-post 2.2.0 breaks r10k 2.6.7, so lock it at 2.1.1 (we can't upgrade r10k because of old Ruby)
-        - gem install multipart-post:2.1.1 r10k:2.6.7
+        - gem install multipart-post:2.1.1 r10k:2.6.9
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
   - name: rocky-8-puppet-5
@@ -49,7 +49,7 @@ platforms:
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
         - gem install bundler -v '= 1.17.3'
-        - gem install multipart-post:2.1.1 r10k:2.6.7
+        - gem install multipart-post:2.1.1 r10k:2.6.9
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
   - name: ubuntu-1604-puppet-6
@@ -69,7 +69,7 @@ platforms:
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
         - gem install bundler -v '= 1.17.3'
-        - gem install multipart-post:2.1.1 r10k:2.6.7
+        - gem install multipart-post:2.1.1 r10k:2.6.9
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
         
   - name: opensuse/leap-15

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,11 +27,11 @@ platforms:
 
         - mkdir /home/kitchen/puppet
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
         - gem install bundler -v '= 1.17.3'
-        # multipart-post 2.2.0 breaks r10k 2.6.7, so lock it at 2.1.1 (we can't upgrade r10k because of old Ruby)
-        # semantic_puppet 1.1.0 does not work with Ruby < 2.7, we lock it at 1.0.4
-        - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
+        # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
+        - bundle install
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
   - name: rocky-8-puppet-5
@@ -48,11 +48,11 @@ platforms:
 
         - mkdir /home/kitchen/puppet
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
         - gem install bundler -v '= 1.17.3'
-        - bundle env
-        - gem install semantic_puppet:1.0.4
-        - gem install multipart-post:2.1.1 r10k:2.6.7 --minimal-deps
+
+        - cd /home && bundle install
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
   - name: ubuntu-1604-puppet-6
@@ -70,9 +70,10 @@ platforms:
 
         - mkdir /home/kitchen/puppet
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
         - gem install bundler -v '= 1.17.3'
-        - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
+        - cd /home && bundle install
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
         
   - name: opensuse/leap-15
@@ -96,8 +97,9 @@ platforms:
         - ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
         - mkdir /home/kitchen/puppet
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-        - /opt/puppetlabs/puppet/bin/gem install multipart-post:2.1.1 r10k:2.6.7
+        - cd /home && bundle install
         - cd /home/kitchen/puppet && /opt/puppetlabs/puppet/bin/r10k puppetfile install --moduledir=/tmp/modules
 
 verifier:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -30,7 +30,8 @@ platforms:
 
         - gem install bundler -v '= 1.17.3'
         # multipart-post 2.2.0 breaks r10k 2.6.7, so lock it at 2.1.1 (we can't upgrade r10k because of old Ruby)
-        - gem install multipart-post:2.1.1 r10k:2.6.9
+        # semantic_puppet 1.1.0 does not work with Ruby < 2.7, so we lock it at 1.0.4
+        - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
   - name: rocky-8-puppet-5
@@ -49,7 +50,7 @@ platforms:
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
         - gem install bundler -v '= 1.17.3'
-        - gem install multipart-post:2.1.1 r10k:2.6.9
+        - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
   - name: ubuntu-1604-puppet-6
@@ -69,7 +70,7 @@ platforms:
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
         - gem install bundler -v '= 1.17.3'
-        - gem install multipart-post:2.1.1 r10k:2.6.9
+        - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
         
   - name: opensuse/leap-15

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -52,7 +52,9 @@ platforms:
 
         - bundle env
         - gem install bundler -v '= 1.17.3'
-        - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
+        - bundle env
+        - gem install semantic_puppet:1.0.4
+        - gem install multipart-post:2.1.1 r10k:2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
   - name: ubuntu-1604-puppet-6

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -29,6 +29,7 @@ platforms:
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
         - gem install bundler -v '= 1.17.3'
+        - bundle env
         # multipart-post 2.2.0 breaks r10k 2.6.7, so lock it at 2.1.1 (we can't upgrade r10k because of old Ruby)
         # semantic_puppet 1.1.0 does not work with Ruby < 2.7, we lock it at 1.0.4
         - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
@@ -49,6 +50,7 @@ platforms:
         - mkdir /home/kitchen/puppet
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
+        - bundle env
         - gem install bundler -v '= 1.17.3'
         - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -29,7 +29,6 @@ platforms:
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
         - gem install bundler -v '= 1.17.3'
-        - bundle env
         # multipart-post 2.2.0 breaks r10k 2.6.7, so lock it at 2.1.1 (we can't upgrade r10k because of old Ruby)
         # semantic_puppet 1.1.0 does not work with Ruby < 2.7, we lock it at 1.0.4
         - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
@@ -52,7 +51,6 @@ platforms:
 
         - bundle env
         - gem install bundler -v '= 1.17.3'
-        - bundle env
         - gem install semantic_puppet:1.0.4
         - gem install multipart-post:2.1.1 r10k:2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -52,7 +52,7 @@ platforms:
         - gem install bundler -v '= 1.17.3'
         - bundle env
         - gem install semantic_puppet:1.0.4
-        - gem install multipart-post:2.1.1 r10k:2.6.7
+        - gem install multipart-post:2.1.1 r10k:2.6.7 --minimal-deps
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
   - name: ubuntu-1604-puppet-6

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -30,7 +30,7 @@ platforms:
 
         - gem install bundler -v '= 1.17.3'
         # multipart-post 2.2.0 breaks r10k 2.6.7, so lock it at 2.1.1 (we can't upgrade r10k because of old Ruby)
-        # semantic_puppet 1.1.0 does not work with Ruby < 2.7, so we lock it at 1.0.4
+        # semantic_puppet 1.1.0 does not work with Ruby < 2.7, we lock it at 1.0.4
         - gem install semantic_puppet:1.0.4 multipart-post:2.1.1 r10k:2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -49,8 +49,8 @@ platforms:
         - mkdir /home/kitchen/puppet
         - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
 
-        - bundle env
         - gem install bundler -v '= 1.17.3'
+        - bundle env
         - gem install semantic_puppet:1.0.4
         - gem install multipart-post:2.1.1 r10k:2.6.7
         - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules


### PR DESCRIPTION
### What does this PR do?
Fix different issues that break the CI:
- Remove test with Puppet 7.9 and 7.14 as concurrent-ruby 1.2.2 release breaks Puppet until 7.25
- Add Puppet 7.25 test
- Pin semantic_puppet version to 1.0.4, as 1.1.0 requires ruby 2.7 and would break kitchen test
- Pin version of yum_repocore in .fixtures, since new 2.0.0 release of June 2023  breaks with older Ruby versions
<!--A brief description of the change being made with this pull request.-->

### Motivation
To have green CI 
<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
