### PR TITLE
Remove ruby deprecated module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,7 +12,6 @@ fixtures:
     puppetserver_gem:
       repo: "git://github.com/puppetlabs/puppetlabs-puppetserver_gem.git"
       ref: "1.0.0"
-    ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
   forge_modules:
     yumrepo_core:
       repo: "puppetlabs/yumrepo_core"

--- a/environments/etc/Puppetfile
+++ b/environments/etc/Puppetfile
@@ -3,7 +3,6 @@ mod 'datadog_agent', :local => true
 mod 'puppetlabs-apt', '2.4.0'
 mod 'puppetlabs-concat', '4.0.0'
 mod 'puppetlabs-puppetserver_gem', '1.0.0'
-mod 'puppetlabs-ruby', '1.0.0'
 mod 'puppetlabs-stdlib', '4.24.0'
 mod 'puppetlabs-powershell', '2.3.0'
 mod 'puppetlabs-yumrepo_core', '1.0.3'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,22 @@ class datadog_agent::params {
   case $::operatingsystem {
     'Ubuntu','Debian','Raspbian' : {
       $rubydev_package            = 'ruby-dev'
+      case $::operatingsystemrelease{
+        '14.04': {
+          # Specific ruby/rubygems package name for Ubuntu 14.04
+          $ruby_package           = 'ruby'
+          $rubygems_package       = 'ruby1.9.1-full'
+        }
+        '18.04': {
+          # Specific ruby/rubygems package name for Ubuntu 18.04
+          $ruby_package           = 'ruby-full'
+          $rubygems_package       = 'rubygems'
+        }
+        default: {
+          $ruby_package           = 'ruby'
+          $rubygems_package       = 'rubygems'
+        }
+      }
       $legacy_conf_dir            = '/etc/dd-agent/conf.d'
       $conf_dir                   = '/etc/datadog-agent/conf.d'
       $dd_user                    = 'dd-agent'
@@ -40,6 +56,8 @@ class datadog_agent::params {
     }
     'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux', 'AlmaLinux', 'Rocky', 'OpenSuSE', 'SLES' : {
       $rubydev_package            = 'ruby-devel'
+      $ruby_package                = 'ruby'
+      $rubygems_package           = 'rubygems'
       $legacy_conf_dir            = '/etc/dd-agent/conf.d'
       $conf_dir                   = '/etc/datadog-agent/conf.d'
       $dd_user                    = 'dd-agent'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,7 @@ class datadog_agent::params {
     }
     'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux', 'AlmaLinux', 'Rocky', 'OpenSuSE', 'SLES' : {
       $rubydev_package            = 'ruby-devel'
-      $ruby_package                = 'ruby'
+      $ruby_package               = 'ruby'
       $rubygems_package           = 'rubygems'
       $legacy_conf_dir            = '/etc/dd-agent/conf.d'
       $conf_dir                   = '/etc/datadog-agent/conf.d'

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -48,6 +48,19 @@ class datadog_agent::reports(
         }
       }
 
+      if (! defined(Package['rubygems'])) {
+        package { 'ruby': 
+          ensure => 'installed',
+          name   => $ruby_package
+        }
+
+        package { 'rubygems':
+          ensure => 'installed',
+          name   => $rubygems_package,
+          require => Package['ruby']
+        }
+      }
+
       package{ 'dogapi':
         ensure   => $dogapi_version,
         provider => $puppet_gem_provider,

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -49,14 +49,14 @@ class datadog_agent::reports(
       }
 
       if (! defined(Package['rubygems'])) {
-        package { 'ruby': 
+        package { 'ruby':
           ensure => 'installed',
-          name   => $ruby_package
+          name   => $datadog_agent::params::ruby_package
         }
 
         package { 'rubygems':
-          ensure => 'installed',
-          name   => $rubygems_package,
+          ensure  => 'installed',
+          name    => $datadog_agent::params::rubygems_package,
           require => Package['ruby']
         }
       }

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -48,13 +48,6 @@ class datadog_agent::reports(
         }
       }
 
-      if (! defined(Package['rubygems'])) {
-        # Ensure rubygems is installed
-        class { 'ruby':
-          rubygems_update => false
-        }
-      }
-
       package{ 'dogapi':
         ensure   => $dogapi_version,
         provider => $puppet_gem_provider,

--- a/metadata.json
+++ b/metadata.json
@@ -13,10 +13,6 @@
       "version_requirement": ">=4.24.0 <9.0.0"
     },
     {
-      "name": "puppetlabs/ruby",
-      "version_requirement": ">=1.0.0 <2.0.0"
-    },
-    {
       "name": "puppetlabs/concat",
       "version_requirement": ">=4.0.0 <8.0.0"
     },

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -31,7 +31,6 @@ describe 'datadog_agent::reports' do
             is_expected.to raise_error(Puppet::Error)
           end
         else
-          it { is_expected.to contain_class('ruby').with_rubygems_update(false) }
           it { is_expected.to contain_class('ruby::params') }
           it { is_expected.to contain_package('ruby').with_ensure('installed') }
           it { is_expected.to contain_package('rubygems').with_ensure('installed') }
@@ -87,7 +86,6 @@ describe 'datadog_agent::reports' do
         }
       end
 
-      it { is_expected.to contain_class('ruby').with_rubygems_update(false) }
       it { is_expected.to contain_class('ruby::params') }
       it { is_expected.to contain_package('ruby').with_ensure('installed') }
       it { is_expected.to contain_package('rubygems').with_ensure('installed') }
@@ -131,7 +129,6 @@ describe 'datadog_agent::reports' do
         }
       end
 
-      it { is_expected.to contain_class('ruby').with_rubygems_update(false) }
       it { is_expected.to contain_class('ruby::params') }
       it { is_expected.to contain_package('ruby').with_ensure('installed') }
       it { is_expected.to contain_package('rubygems').with_ensure('installed') }
@@ -170,7 +167,6 @@ describe 'datadog_agent::reports' do
         }
       end
 
-      it { is_expected.to contain_class('ruby').with_rubygems_update(false) }
       it { is_expected.to contain_class('ruby::params') }
       it { is_expected.to contain_package('ruby').with_ensure('installed') }
       it { is_expected.to contain_package('rubygems').with_ensure('installed') }
@@ -211,7 +207,6 @@ describe 'datadog_agent::reports' do
         }
       end
 
-      it { is_expected.not_to contain_class('ruby').with_rubygems_update(false) }
       it { is_expected.not_to contain_class('ruby::params') }
       it { is_expected.not_to contain_package('ruby').with_ensure('installed') }
       it { is_expected.not_to contain_package('rubygems').with_ensure('installed') }

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -31,8 +31,7 @@ describe 'datadog_agent::reports' do
             is_expected.to raise_error(Puppet::Error)
           end
         else
-          it { is_expected.to contain_class('ruby::params') }
-          it { is_expected.to contain_package('ruby').with_ensure('installed') }
+              it { is_expected.to contain_package('ruby').with_ensure('installed') }
           it { is_expected.to contain_package('rubygems').with_ensure('installed') }
 
           if DEBIAN_OS.include?(operatingsystem)
@@ -86,7 +85,6 @@ describe 'datadog_agent::reports' do
         }
       end
 
-      it { is_expected.to contain_class('ruby::params') }
       it { is_expected.to contain_package('ruby').with_ensure('installed') }
       it { is_expected.to contain_package('rubygems').with_ensure('installed') }
 
@@ -129,7 +127,6 @@ describe 'datadog_agent::reports' do
         }
       end
 
-      it { is_expected.to contain_class('ruby::params') }
       it { is_expected.to contain_package('ruby').with_ensure('installed') }
       it { is_expected.to contain_package('rubygems').with_ensure('installed') }
 
@@ -167,7 +164,6 @@ describe 'datadog_agent::reports' do
         }
       end
 
-      it { is_expected.to contain_class('ruby::params') }
       it { is_expected.to contain_package('ruby').with_ensure('installed') }
       it { is_expected.to contain_package('rubygems').with_ensure('installed') }
 
@@ -207,7 +203,6 @@ describe 'datadog_agent::reports' do
         }
       end
 
-      it { is_expected.not_to contain_class('ruby::params') }
       it { is_expected.not_to contain_package('ruby').with_ensure('installed') }
       it { is_expected.not_to contain_package('rubygems').with_ensure('installed') }
 

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -31,7 +31,8 @@ describe 'datadog_agent::reports' do
             is_expected.to raise_error(Puppet::Error)
           end
         else
-              it { is_expected.to contain_package('ruby').with_ensure('installed') }
+
+          it { is_expected.to contain_package('ruby').with_ensure('installed') }
           it { is_expected.to contain_package('rubygems').with_ensure('installed') }
 
           if DEBIAN_OS.include?(operatingsystem)


### PR DESCRIPTION
### What does this PR do?

Remove the dependency on `puppetlabs-ruby` module
Fix #735 

<!--A brief description of the change being made with this pull request.-->

### Motivation

Remove dependency on `puppetlabs-ruby` module which is deprecated and comes with constraints on other modules we would like to upgrade

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
