### PR TITLE
Fix legacy Facts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -381,7 +381,7 @@ class datadog_agent(
     fail("agent_major_version must be either 5, 6 or 7, not ${_agent_major_version}")
   }
 
-  if ($::operatingsystem == 'Windows' and $windows_ddagentuser_name != undef) {
+  if ($facts['os']['name'] == 'Windows' and $windows_ddagentuser_name != undef) {
     $dd_user = $windows_ddagentuser_name
   } else {
     $dd_user = $datadog_agent::params::dd_user
@@ -423,7 +423,7 @@ class datadog_agent(
 
   # Install agent
   if $manage_install {
-    case $::operatingsystem {
+    case $facts['os']['name'] {
       'Ubuntu','Debian','Raspbian' : {
         if $use_apt_backup_keyserver != undef or $apt_backup_keyserver != undef or $apt_keyserver != undef {
           notify { 'apt keyserver arguments deprecation':
@@ -477,7 +477,7 @@ class datadog_agent(
           rpm_repo_gpgcheck   => $rpm_repo_gpgcheck,
         }
       }
-      default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
+      default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${facts['os']['name']}") }
     }
   } else {
     if ! defined(Package[$agent_flavor]) {
@@ -496,7 +496,7 @@ class datadog_agent(
     service_provider => $service_provider,
   }
 
-  if ($::operatingsystem != 'Windows') {
+  if ($facts['os']['name'] != 'Windows') {
     if ($dd_groups) {
       user { $dd_user:
         groups => $dd_groups,
@@ -516,7 +516,7 @@ class datadog_agent(
 
   if $_agent_major_version == 5 {
 
-    if ($::operatingsystem == 'Windows') {
+    if ($facts['os']['name'] == 'Windows') {
       fail('Installation of agent 5 with puppet is not supported on Windows')
     }
 
@@ -752,7 +752,7 @@ class datadog_agent(
     $agent_config = deep_merge($_agent_config, $extra_config)
 
 
-    if ($::operatingsystem == 'Windows') {
+    if ($facts['os']['name'] == 'Windows') {
 
 
       file { 'C:/ProgramData/Datadog':

--- a/manifests/integrations/haproxy.pp
+++ b/manifests/integrations/haproxy.pp
@@ -18,7 +18,7 @@
 #
 class datadog_agent::integrations::haproxy(
   $creds                     = {},
-  $url                       = "http://${::ipaddress}:8080",
+  $url                       = "http://${facts['networking']['ip']}:8080",
   $options                   = {},
   Optional[Array] $instances = undef
 ) inherits datadog_agent::params {

--- a/manifests/integrations/ssh.pp
+++ b/manifests/integrations/ssh.pp
@@ -27,7 +27,7 @@
 #
 
 class datadog_agent::integrations::ssh(
-  $host              = $::fqdn,
+  $host              = $trusted['certname'],
   $port              = 22,
   $username          = $datadog_agent::dd_user,
   $password          = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class datadog_agent::params {
   $securityagent_service_name     = 'datadog-agent-security'
   $module_metadata                = load_module_metadata($module_name)
 
-  case $::operatingsystem {
+  case $facts['os']['name'] {
     'Ubuntu','Debian','Raspbian' : {
       $rubydev_package            = 'ruby-dev'
       $legacy_conf_dir            = '/etc/dd-agent/conf.d'
@@ -65,7 +65,7 @@ class datadog_agent::params {
       $permissions_protected_file = '0660' # as bug in: https://tickets.puppetlabs.com/browse/PA-2877
       $agent_binary               = 'C:/Program Files/Datadog/Datadog Agent/embedded/agent.exe'
     }
-    default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${::operatingsystem}") }
+    default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${facts['os']['name']}") }
   }
 
 }

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -25,10 +25,10 @@ class datadog_agent::redhat(
       $repo_gpgcheck = $rpm_repo_gpgcheck
     } else {
       if ($agent_repo_uri == undef) and ($agent_major_version > 5) {
-        case $::operatingsystem {
+        case $facts['os']['name'] {
           'RedHat', 'CentOS', 'OracleLinux': {
             # disable repo_gpgcheck on 8.1 because of https://bugzilla.redhat.com/show_bug.cgi?id=1792506
-            if $::operatingsystemrelease =~ /^8.1/ {
+            if $facts['os']['release']['full'] =~ /^8.1/ {
               $repo_gpgcheck = false
             } else {
               $repo_gpgcheck = true
@@ -46,15 +46,15 @@ class datadog_agent::redhat(
 
     case $agent_major_version {
       5 : {
-        $defaulturl = "https://yum.datadoghq.com/rpm/${::architecture}/"
+        $defaulturl = "https://yum.datadoghq.com/rpm/${facts['os']['architecture']}/"
         $gpgkeys = $keys
       }
       6 : {
-        $defaulturl = "https://yum.datadoghq.com/stable/6/${::architecture}/"
+        $defaulturl = "https://yum.datadoghq.com/stable/6/${facts['os']['architecture']}/"
         $gpgkeys = $keys
       }
       7 : {
-        $defaulturl = "https://yum.datadoghq.com/stable/7/${::architecture}/"
+        $defaulturl = "https://yum.datadoghq.com/stable/7/${facts['os']['architecture']}/"
         $gpgkeys = $keys
       }
       default: { fail('invalid agent_major_version') }

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -29,7 +29,7 @@ class datadog_agent::reports(
   $puppet_gem_provider = $datadog_agent::params::gem_provider,
 ) inherits datadog_agent::params {
 
-  if ($::operatingsystem == 'Windows') {
+  if ($facts['os']['name'] == 'Windows') {
 
     fail('Reporting is not yet supported from a Windows host')
 

--- a/manifests/security_agent.pp
+++ b/manifests/security_agent.pp
@@ -15,7 +15,7 @@ class datadog_agent::security_agent(
     },
   }
 
-  if $::operatingsystem == 'Windows' {
+  if $facts['os']['name'] == 'Windows' {
 
     file { 'C:/ProgramData/Datadog/security-agent.yaml':
       owner   => $datadog_agent::params::dd_user,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,7 +10,7 @@ class datadog_agent::service(
   String $agent_flavor = $datadog_agent::params::package_name,
 ) inherits datadog_agent::params {
 
-  if ($::operatingsystem == 'Windows') {
+  if ($facts['os']['name'] == 'Windows') {
       service { $datadog_agent::params::service_name:
         ensure  => $service_ensure,
         enable  => $service_enable,

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -40,7 +40,7 @@ class datadog_agent::suse(
   if ($agent_repo_uri != undef) {
     $baseurl = $agent_repo_uri
   } else {
-    $baseurl = "https://yum.datadoghq.com/suse/${release}/${agent_major_version}/${::architecture}"
+    $baseurl = "https://yum.datadoghq.com/suse/${release}/${agent_major_version}/${facts['os']['architecture']}"
   }
 
   package { 'datadog-agent-base':
@@ -78,7 +78,7 @@ class datadog_agent::suse(
     name         => 'datadog',
     gpgcheck     => 1,
     # zypper on SUSE < 15 only understands a single gpgkey value
-    gpgkey       => (Float($::operatingsystemmajrelease) >= 15.0) ? { true => join($gpgkeys, "\n       "), default => $current_key },
+    gpgkey       => (Float($facts['os']['release']['full']) >= 15.0) ? { true => join($gpgkeys, "\n       "), default => $current_key },
     # TODO: when updating zypprepo to 4.0.0, uncomment the repo_gpgcheck line
     # For now, we can leave this commented, as zypper by default does repodata
     # signature checks if the repomd.xml.asc is present, so repodata checks

--- a/manifests/system_probe.pp
+++ b/manifests/system_probe.pp
@@ -1,7 +1,7 @@
 # Class: datadog_agent::system_probe
 #
 # This class contains the Datadog agent system probe (NPM) configuration.
-# On Windows, install the NPM driver by setting 'windows_npm_install' 
+# On Windows, install the NPM driver by setting 'windows_npm_install'
 # to 'true on the datadog_agent class.
 #
 
@@ -36,7 +36,7 @@ class datadog_agent::system_probe(
     'runtime_security_config' => $runtime_security_config,
   }
 
-  if $::operatingsystem == 'Windows' {
+  if $facts['os']['name'] == 'Windows' {
     file { 'C:/ProgramData/Datadog/system-probe.yaml':
       owner   => $datadog_agent::params::dd_user,
       group   => $datadog_agent::params::dd_group,

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -62,8 +62,8 @@ class datadog_agent::ubuntu(
       }
     }
 
-    if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16') == -1) or
-        ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') == -1) {
+    if ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '16') == -1) or
+        ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['full'], '9') == -1) {
       file { $apt_trusted_d_keyring:
         mode   => '0644',
         source => "file://${apt_usr_share_keyring}",

--- a/spec/classes/datadog_agent_integrations_haproxy_spec.rb
+++ b/spec/classes/datadog_agent_integrations_haproxy_spec.rb
@@ -7,6 +7,7 @@ describe 'datadog_agent::integrations::haproxy' do
       let(:facts) do
         {
           ipaddress: '1.2.3.4',
+          networking: { 'ip' => '1.2.3.4' },
         }
       end
 

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -15,6 +15,10 @@ describe 'datadog_agent::redhat' do
           'architecture' => 'x86_64',
           'family' => 'redhat',
           'name' => 'Fedora',
+          'release' => {
+            'major' => '36',
+            'full' => '36',
+          },
         },
       }
     end
@@ -70,6 +74,10 @@ describe 'datadog_agent::redhat' do
           'architecture' => 'x86_64',
           'family' => 'redhat',
           'name' => 'Fedora',
+          'release' => {
+            'major' => '36',
+            'full' => '36',
+          },
         },
       }
     end
@@ -125,6 +133,10 @@ describe 'datadog_agent::redhat' do
           'architecture' => 'x86_64',
           'family' => 'redhat',
           'name' => 'Fedora',
+          'release' => {
+            'major' => '36',
+            'full' => '36',
+          },
         },
       }
     end
@@ -183,7 +195,10 @@ describe 'datadog_agent::redhat' do
           'architecture' => 'x86_64',
           'family' => 'redhat',
           'name' => 'RedHat',
-          'release' => { 'full' => '8.1' },
+          'release' => {
+            'major' => '8',
+            'full' => '8.1',
+          },
         },
       }
     end
@@ -222,7 +237,10 @@ describe 'datadog_agent::redhat' do
           'architecture' => 'x86_64',
           'family' => 'redhat',
           'name' => 'RedHat',
-          'release' => { 'full' => '8.2' },
+          'release' => {
+            'major' => '8',
+            'full' => '8.2',
+          },
         },
       }
     end
@@ -261,7 +279,10 @@ describe 'datadog_agent::redhat' do
           'architecture' => 'x86_64',
           'family' => 'redhat',
           'name' => 'AlmaLinux',
-          'release' => { 'full' => '8.5' },
+          'release' => {
+            'major' => '8',
+            'full' => '8.5',
+          },
         },
       }
     end
@@ -299,7 +320,10 @@ describe 'datadog_agent::redhat' do
           'architecture' => 'x86_64',
           'family' => 'redhat',
           'name' => 'Rocky',
-          'release' => { 'full' => '8.5' },
+          'release' => {
+            'major' => '8',
+            'full' => '8.5',
+          },
         },
       }
     end

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -11,6 +11,11 @@ describe 'datadog_agent::redhat' do
         osfamily: 'redhat',
         operatingsystem: 'Fedora',
         architecture: 'x86_64',
+        os: {
+          'architecture' => 'x86_64',
+          'family' => 'redhat',
+          'name' => 'Fedora',
+        },
       }
     end
 
@@ -61,6 +66,11 @@ describe 'datadog_agent::redhat' do
         osfamily: 'redhat',
         operatingsystem: 'Fedora',
         architecture: 'x86_64',
+        os: {
+          'architecture' => 'x86_64',
+          'family' => 'redhat',
+          'name' => 'Fedora',
+        },
       }
     end
 
@@ -111,6 +121,11 @@ describe 'datadog_agent::redhat' do
         osfamily: 'redhat',
         operatingsystem: 'Fedora',
         architecture: 'x86_64',
+        os: {
+          'architecture' => 'x86_64',
+          'family' => 'redhat',
+          'name' => 'Fedora',
+        },
       }
     end
 
@@ -164,6 +179,12 @@ describe 'datadog_agent::redhat' do
         operatingsystem: 'RedHat',
         operatingsystemrelease: '8.1',
         architecture: 'x86_64',
+        os: {
+          'architecture' => 'x86_64',
+          'family' => 'redhat',
+          'name' => 'RedHat',
+          'release' => { 'full' => '8.1' },
+        },
       }
     end
 
@@ -197,6 +218,12 @@ describe 'datadog_agent::redhat' do
         operatingsystem: 'RedHat',
         operatingsystemrelease: '8.2',
         architecture: 'x86_64',
+        os: {
+          'architecture' => 'x86_64',
+          'family' => 'redhat',
+          'name' => 'RedHat',
+          'release' => { 'full' => '8.2' },
+        },
       }
     end
 
@@ -230,6 +257,12 @@ describe 'datadog_agent::redhat' do
         operatingsystem: 'AlmaLinux',
         operatingsystemrelease: '8.5',
         architecture: 'x86_64',
+        os: {
+          'architecture' => 'x86_64',
+          'family' => 'redhat',
+          'name' => 'AlmaLinux',
+          'release' => { 'full' => '8.5' },
+        },
       }
     end
 
@@ -262,6 +295,12 @@ describe 'datadog_agent::redhat' do
         operatingsystem: 'Rocky',
         operatingsystemrelease: '8.5',
         architecture: 'x86_64',
+        os: {
+          'architecture' => 'x86_64',
+          'family' => 'redhat',
+          'name' => 'Rocky',
+          'release' => { 'full' => '8.5' },
+        },
       }
     end
 

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -24,9 +24,13 @@ describe 'datadog_agent::reports' do
             osfamily: getosfamily(operatingsystem),
             operatingsystemrelease: getosrelease(operatingsystem),
             os: {
+              'architecture' => 'x86_64',
               'family' => getosfamily(operatingsystem),
               'name' => operatingsystem,
-              'release' => { 'full' => getosrelease(operatingsystem) },
+              'release' => {
+                'major' => getosmajor(operatingsystem),
+                'full' => getosrelease(operatingsystem),
+              },
             },
           }
         end
@@ -90,8 +94,13 @@ describe 'datadog_agent::reports' do
           operatingsystem: 'Debian',
           osfamily: 'debian',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Debian',
+            'release' => {
+              'major' => '8',
+              'full' => '8.1',
+            },
           },
         }
       end
@@ -138,8 +147,13 @@ describe 'datadog_agent::reports' do
           operatingsystem: 'Debian',
           osfamily: 'debian',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Debian',
+            'release' => {
+              'major' => '8',
+              'full' => '8.1',
+            },
           },
         }
       end
@@ -181,8 +195,13 @@ describe 'datadog_agent::reports' do
           operatingsystem: 'Debian',
           osfamily: 'debian',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Debian',
+            'release' => {
+              'major' => '8',
+              'full' => '8.1',
+            },
           },
         }
       end
@@ -226,8 +245,13 @@ describe 'datadog_agent::reports' do
           operatingsystem: 'Debian',
           osfamily: 'debian',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Debian',
+            'release' => {
+              'major' => '8',
+              'full' => '8.1',
+            },
           },
         }
       end

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -23,6 +23,11 @@ describe 'datadog_agent::reports' do
             operatingsystem: operatingsystem,
             osfamily: getosfamily(operatingsystem),
             operatingsystemrelease: getosrelease(operatingsystem),
+            os: {
+              'family' => getosfamily(operatingsystem),
+              'name' => operatingsystem,
+              'release' => { 'full' => getosrelease(operatingsystem) },
+            },
           }
         end
 
@@ -84,6 +89,10 @@ describe 'datadog_agent::reports' do
         {
           operatingsystem: 'Debian',
           osfamily: 'debian',
+          os: {
+            'family' => 'debian',
+            'name' => 'Debian',
+          },
         }
       end
 
@@ -128,6 +137,10 @@ describe 'datadog_agent::reports' do
         {
           operatingsystem: 'Debian',
           osfamily: 'debian',
+          os: {
+            'family' => 'debian',
+            'name' => 'Debian',
+          },
         }
       end
 
@@ -167,6 +180,10 @@ describe 'datadog_agent::reports' do
         {
           operatingsystem: 'Debian',
           osfamily: 'debian',
+          os: {
+            'family' => 'debian',
+            'name' => 'Debian',
+          },
         }
       end
 
@@ -208,6 +225,10 @@ describe 'datadog_agent::reports' do
         {
           operatingsystem: 'Debian',
           osfamily: 'debian',
+          os: {
+            'family' => 'debian',
+            'name' => 'Debian',
+          },
         }
       end
 

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -8,6 +8,10 @@ describe 'datadog_agent' do
           {
             osfamily:         'Solaris',
             operatingsystem:  'Nexenta',
+            os: {
+              'family' => 'Solaris',
+              'name' => 'Nexenta',
+            },
           }
         end
 
@@ -29,6 +33,10 @@ describe 'datadog_agent' do
         {
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
+          os: {
+            'family' => 'debian',
+            'name' => 'Ubuntu',
+          },
         }
       end
 
@@ -48,6 +56,10 @@ describe 'datadog_agent' do
         {
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
+          os: {
+            'family' => 'debian',
+            'name' => 'Ubuntu',
+          },
         }
       end
 
@@ -67,6 +79,10 @@ describe 'datadog_agent' do
         {
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
+          os: {
+            'family' => 'debian',
+            'name' => 'Ubuntu',
+          },
         }
       end
 
@@ -86,6 +102,10 @@ describe 'datadog_agent' do
         {
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
+          os: {
+            'family' => 'debian',
+            'name' => 'Ubuntu',
+          },
         }
       end
 
@@ -105,6 +125,10 @@ describe 'datadog_agent' do
         {
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
+          os: {
+            'family' => 'debian',
+            'name' => 'Ubuntu',
+          },
         }
       end
 
@@ -124,6 +148,10 @@ describe 'datadog_agent' do
         {
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
+          os: {
+            'family' => 'debian',
+            'name' => 'Ubuntu',
+          },
         }
       end
 
@@ -143,6 +171,10 @@ describe 'datadog_agent' do
         {
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
+          os: {
+            'family' => 'debian',
+            'name' => 'Ubuntu',
+          },
         }
       end
 
@@ -164,6 +196,10 @@ describe 'datadog_agent' do
         {
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
+          os: {
+            'family' => 'debian',
+            'name' => 'Ubuntu',
+          },
         }
       end
 
@@ -181,6 +217,10 @@ describe 'datadog_agent' do
         {
           osfamily: 'windows',
           operatingsystem: 'Windows',
+          os: {
+            'family' => 'windows',
+            'name' => 'Windows',
+          },
         }
       end
 
@@ -228,6 +268,10 @@ describe 'datadog_agent' do
         {
           operatingsystem: operatingsystem,
           osfamily: getosfamily(operatingsystem),
+          os: {
+            'family' => getosfamily(operatingsystem),
+            'name' => operatingsystem,
+          },
         }
       end
 
@@ -270,6 +314,10 @@ describe 'datadog_agent' do
           {
             operatingsystem: operatingsystem,
             osfamily: getosfamily(operatingsystem),
+            os: {
+              'family' => getosfamily(operatingsystem),
+              'name' => operatingsystem,
+            },
           }
         end
 
@@ -1622,6 +1670,10 @@ describe 'datadog_agent' do
           {
             operatingsystem: operatingsystem,
             osfamily: getosfamily(operatingsystem),
+            os: {
+              'family' => getosfamily(operatingsystem),
+              'name' => operatingsystem,
+            },
           }
         end
 
@@ -1648,6 +1700,10 @@ describe 'datadog_agent' do
           {
             operatingsystem: operatingsystem,
             osfamily: getosfamily(operatingsystem),
+            os: {
+              'family' => getosfamily(operatingsystem),
+              'name' => operatingsystem,
+            },
           }
         end
 
@@ -2257,6 +2313,10 @@ describe 'datadog_agent' do
         {
           'operatingsystem' => 'CentOS',
           'osfamily' => 'redhat',
+          os => {
+            'family' => 'redhat',
+            'name' => 'CentOS',
+          },
         }
       end
       let(:trusted_facts) do
@@ -2300,6 +2360,10 @@ describe 'datadog_agent' do
             },
           },
           'looks.like.a.path' => 'but_its_not',
+          os => {
+            'family' => 'redhat',
+            'name' => 'CentOS',
+          },
         }
       end
 
@@ -2322,6 +2386,10 @@ describe 'datadog_agent' do
           operatingsystem: 'CentOS',
           osfamily: 'redhat',
           facts_array: ['one', 'two'],
+          os: {
+            'family' => 'redhat',
+            'name' => 'CentOS',
+          },
         }
       end
 

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -9,8 +9,13 @@ describe 'datadog_agent' do
             osfamily:         'Solaris',
             operatingsystem:  'Nexenta',
             os: {
+              'architecture' => 'x86_64',
               'family' => 'Solaris',
               'name' => 'Nexenta',
+              'release' => {
+                'major' => '3',
+                'full' => '3.0',
+              },
             },
           }
         end
@@ -34,8 +39,13 @@ describe 'datadog_agent' do
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Ubuntu',
+            'release' => {
+              'major' => '14',
+              'full' => '14.04',
+            },
           },
         }
       end
@@ -57,8 +67,13 @@ describe 'datadog_agent' do
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Ubuntu',
+            'release' => {
+              'major' => '14',
+              'full' => '14.04',
+            },
           },
         }
       end
@@ -80,8 +95,13 @@ describe 'datadog_agent' do
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Ubuntu',
+            'release' => {
+              'major' => '14',
+              'full' => '14.04',
+            },
           },
         }
       end
@@ -103,8 +123,13 @@ describe 'datadog_agent' do
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Ubuntu',
+            'release' => {
+              'major' => '14',
+              'full' => '14.04',
+            },
           },
         }
       end
@@ -126,8 +151,13 @@ describe 'datadog_agent' do
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Ubuntu',
+            'release' => {
+              'major' => '14',
+              'full' => '14.04',
+            },
           },
         }
       end
@@ -149,8 +179,13 @@ describe 'datadog_agent' do
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Ubuntu',
+            'release' => {
+              'major' => '14',
+              'full' => '14.04',
+            },
           },
         }
       end
@@ -172,8 +207,13 @@ describe 'datadog_agent' do
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Ubuntu',
+            'release' => {
+              'major' => '14',
+              'full' => '14.04',
+            },
           },
         }
       end
@@ -197,8 +237,13 @@ describe 'datadog_agent' do
           osfamily: 'debian',
           operatingsystem: 'Ubuntu',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'debian',
             'name' => 'Ubuntu',
+            'release' => {
+              'major' => '14',
+              'full' => '14.04',
+            },
           },
         }
       end
@@ -218,8 +263,13 @@ describe 'datadog_agent' do
           osfamily: 'windows',
           operatingsystem: 'Windows',
           os: {
+            'architecture' => 'x86_64',
             'family' => 'windows',
             'name' => 'Windows',
+            'release' => {
+              'major' => '2019',
+              'full' => '2019 SP1',
+            },
           },
         }
       end
@@ -269,8 +319,13 @@ describe 'datadog_agent' do
           operatingsystem: operatingsystem,
           osfamily: getosfamily(operatingsystem),
           os: {
+            'architecture' => 'x86_64',
             'family' => getosfamily(operatingsystem),
             'name' => operatingsystem,
+            'release' => {
+              'major' => getosmajor(operatingsystem),
+              'full' => getosrelease(operatingsystem),
+            },
           },
         }
       end
@@ -315,8 +370,13 @@ describe 'datadog_agent' do
             operatingsystem: operatingsystem,
             osfamily: getosfamily(operatingsystem),
             os: {
+              'architecture' => 'x86_64',
               'family' => getosfamily(operatingsystem),
               'name' => operatingsystem,
+              'release' => {
+                'major' => getosmajor(operatingsystem),
+                'full' => getosrelease(operatingsystem),
+              },
             },
           }
         end
@@ -1671,8 +1731,13 @@ describe 'datadog_agent' do
             operatingsystem: operatingsystem,
             osfamily: getosfamily(operatingsystem),
             os: {
+              'architecture' => 'x86_64',
               'family' => getosfamily(operatingsystem),
               'name' => operatingsystem,
+              'release' => {
+                'major' => getosmajor(operatingsystem),
+                'full' => getosrelease(operatingsystem),
+              },
             },
           }
         end
@@ -1701,8 +1766,13 @@ describe 'datadog_agent' do
             operatingsystem: operatingsystem,
             osfamily: getosfamily(operatingsystem),
             os: {
+              'architecture' => 'x86_64',
               'family' => getosfamily(operatingsystem),
               'name' => operatingsystem,
+              'release' => {
+                'major' => getosmajor(operatingsystem),
+                'full' => getosrelease(operatingsystem),
+              },
             },
           }
         end
@@ -2313,9 +2383,14 @@ describe 'datadog_agent' do
         {
           'operatingsystem' => 'CentOS',
           'osfamily' => 'redhat',
-          os => {
+          'os' => {
+            'architecture' => 'x86_64',
             'family' => 'redhat',
             'name' => 'CentOS',
+            'release' => {
+              'major' => '6',
+              'full' => '6.3',
+            },
           },
         }
       end
@@ -2360,9 +2435,14 @@ describe 'datadog_agent' do
             },
           },
           'looks.like.a.path' => 'but_its_not',
-          os => {
+          'os' => {
+            'architecture' => 'x86_64',
             'family' => 'redhat',
             'name' => 'CentOS',
+            'release' => {
+              'major' => '6',
+              'full' => '6.3',
+            },
           },
         }
       end
@@ -2387,8 +2467,13 @@ describe 'datadog_agent' do
           osfamily: 'redhat',
           facts_array: ['one', 'two'],
           os: {
+            'architecture' => 'x86_64',
             'family' => 'redhat',
             'name' => 'CentOS',
+            'release' => {
+              'major' => '6',
+              'full' => '6.3',
+            },
           },
         }
       end

--- a/spec/classes/datadog_agent_suse_spec.rb
+++ b/spec/classes/datadog_agent_suse_spec.rb
@@ -11,7 +11,12 @@ describe 'datadog_agent::suse' do
       architecture: 'x86_64',
       os: {
         'architecture' => 'x86_64',
+        'family' => 'redhat',
         'name' => 'OpenSuSE',
+        'release' => {
+          'major' => '14',
+          'full' => '14.3',
+        },
       },
     }
   end
@@ -21,7 +26,13 @@ describe 'datadog_agent::suse' do
       {
         operatingsystemmajrelease: '15',
         os: {
-          'release' => { 'major' => '15' },
+          'architecture' => 'x86_64',
+          'family' => 'redhat',
+          'name' => 'OpenSuSE',
+          'release' => {
+            'major' => '15',
+            'full' => '15.3',
+          },
         },
       }
     end
@@ -72,7 +83,13 @@ describe 'datadog_agent::suse' do
       {
         operatingsystemmajrelease: '14',
         os: {
-          'release' => { 'major' => '14' },
+          'architecture' => 'x86_64',
+          'family' => 'redhat',
+          'name' => 'OpenSuSE',
+          'release' => {
+            'major' => '14',
+            'full' => '14.3',
+          },
         },
       }
     end

--- a/spec/classes/datadog_agent_suse_spec.rb
+++ b/spec/classes/datadog_agent_suse_spec.rb
@@ -9,6 +9,10 @@ describe 'datadog_agent::suse' do
     {
       operatingsystem: 'OpenSuSE',
       architecture: 'x86_64',
+      os: {
+        'architecture' => 'x86_64',
+        'name' => 'OpenSuSE',
+      },
     }
   end
 
@@ -16,6 +20,9 @@ describe 'datadog_agent::suse' do
     let(:facts) do
       {
         operatingsystemmajrelease: '15',
+        os: {
+          'release' => { 'major' => '15' },
+        },
       }
     end
 
@@ -64,6 +71,9 @@ describe 'datadog_agent::suse' do
     let(:facts) do
       {
         operatingsystemmajrelease: '14',
+        os: {
+          'release' => { 'major' => '14' },
+        },
       }
     end
 

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -37,8 +37,13 @@ describe 'datadog_agent::ubuntu' do
         osfamily: 'debian',
         operatingsystem: 'Ubuntu',
         os: {
+          'architecture' => 'x86_64',
           'family' => 'debian',
           'name' => 'Ubuntu',
+          'release' => {
+            'major' => '14',
+            'full' => '14.04',
+          },
         },
       }
     end
@@ -86,8 +91,13 @@ describe 'datadog_agent::ubuntu' do
         osfamily: 'debian',
         operatingsystem: 'Ubuntu',
         os: {
+          'architecture' => 'x86_64',
           'family' => 'debian',
           'name' => 'Ubuntu',
+          'release' => {
+            'major' => '14',
+            'full' => '14.04',
+          },
         },
       }
     end
@@ -135,8 +145,13 @@ describe 'datadog_agent::ubuntu' do
         osfamily: 'debian',
         operatingsystem: 'Ubuntu',
         os: {
+          'architecture' => 'x86_64',
           'family' => 'debian',
           'name' => 'Ubuntu',
+          'release' => {
+            'major' => '14',
+            'full' => '14.04',
+          },
         },
       }
     end
@@ -182,9 +197,13 @@ describe 'datadog_agent::ubuntu' do
         operatingsystem: 'Ubuntu',
         operatingsystemrelease: '14.04',
         os: {
+          'architecture' => 'x86_64',
           'family' => 'debian',
           'name' => 'Ubuntu',
-          'release' => { 'full' => '14.04' },
+          'release' => {
+            'major' => '14',
+            'full' => '14.04',
+          },
         },
       }
     end
@@ -205,9 +224,13 @@ describe 'datadog_agent::ubuntu' do
         operatingsystem: 'Ubuntu',
         operatingsystemrelease: '16.04',
         os: {
+          'architecture' => 'x86_64',
           'family' => 'debian',
           'name' => 'Ubuntu',
-          'release' => { 'full' => '16.04' },
+          'release' => {
+            'major' => '16',
+            'full' => '16.04',
+          },
         },
       }
     end
@@ -228,9 +251,13 @@ describe 'datadog_agent::ubuntu' do
         operatingsystem: 'Debian',
         operatingsystemrelease: '8.0',
         os: {
+          'architecture' => 'x86_64',
           'family' => 'debian',
           'name' => 'Debian',
-          'release' => { 'full' => '8.0' },
+          'release' => {
+            'major' => '8',
+            'full' => '8.0',
+          },
         },
       }
     end
@@ -251,9 +278,13 @@ describe 'datadog_agent::ubuntu' do
         operatingsystem: 'Debian',
         operatingsystemrelease: '9.0',
         os: {
+          'architecture' => 'x86_64',
           'family' => 'debian',
           'name' => 'Debian',
-          'release' => { 'full' => '9.0' },
+          'release' => {
+            'major' => '9',
+            'full' => '9.0',
+          },
         },
       }
     end

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -36,6 +36,10 @@ describe 'datadog_agent::ubuntu' do
       {
         osfamily: 'debian',
         operatingsystem: 'Ubuntu',
+        os: {
+          'family' => 'debian',
+          'name' => 'Ubuntu',
+        },
       }
     end
 
@@ -81,6 +85,10 @@ describe 'datadog_agent::ubuntu' do
       {
         osfamily: 'debian',
         operatingsystem: 'Ubuntu',
+        os: {
+          'family' => 'debian',
+          'name' => 'Ubuntu',
+        },
       }
     end
 
@@ -126,6 +134,10 @@ describe 'datadog_agent::ubuntu' do
       {
         osfamily: 'debian',
         operatingsystem: 'Ubuntu',
+        os: {
+          'family' => 'debian',
+          'name' => 'Ubuntu',
+        },
       }
     end
 
@@ -169,6 +181,11 @@ describe 'datadog_agent::ubuntu' do
         osfamily: 'debian',
         operatingsystem: 'Ubuntu',
         operatingsystemrelease: '14.04',
+        os: {
+          'family' => 'debian',
+          'name' => 'Ubuntu',
+          'release' => { 'full' => '14.04' },
+        },
       }
     end
 
@@ -187,6 +204,11 @@ describe 'datadog_agent::ubuntu' do
         osfamily: 'debian',
         operatingsystem: 'Ubuntu',
         operatingsystemrelease: '16.04',
+        os: {
+          'family' => 'debian',
+          'name' => 'Ubuntu',
+          'release' => { 'full' => '16.04' },
+        },
       }
     end
 
@@ -205,6 +227,11 @@ describe 'datadog_agent::ubuntu' do
         osfamily: 'debian',
         operatingsystem: 'Debian',
         operatingsystemrelease: '8.0',
+        os: {
+          'family' => 'debian',
+          'name' => 'Debian',
+          'release' => { 'full' => '8.0' },
+        },
       }
     end
 
@@ -223,6 +250,11 @@ describe 'datadog_agent::ubuntu' do
         osfamily: 'debian',
         operatingsystem: 'Debian',
         operatingsystemrelease: '9.0',
+        os: {
+          'family' => 'debian',
+          'name' => 'Debian',
+          'release' => { 'full' => '9.0' },
+        },
       }
     end
 

--- a/spec/defines/datadog_agent__install_integration_spec.rb
+++ b/spec/defines/datadog_agent__install_integration_spec.rb
@@ -8,6 +8,11 @@ describe 'datadog_agent::install_integration' do
           operatingsystem: operatingsystem,
           osfamily: getosfamily(operatingsystem),
           operatingsystemrelease: getosrelease(operatingsystem),
+          os: {
+            'family' => getosfamily(operatingsystem),
+            'name' => operatingsystem,
+            'release' => { 'full' => getosrelease(operatingsystem) },
+          },
         }
       end
 

--- a/spec/defines/datadog_agent__install_integration_spec.rb
+++ b/spec/defines/datadog_agent__install_integration_spec.rb
@@ -9,9 +9,13 @@ describe 'datadog_agent::install_integration' do
           osfamily: getosfamily(operatingsystem),
           operatingsystemrelease: getosrelease(operatingsystem),
           os: {
+            'architecture' => 'x86_64',
             'family' => getosfamily(operatingsystem),
             'name' => operatingsystem,
-            'release' => { 'full' => getosrelease(operatingsystem) },
+            'release' => {
+              'major' => getosmajor(operatingsystem),
+              'full' => getosrelease(operatingsystem),
+            },
           },
         }
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,16 @@ def getosfamily(operatingsystem)
   end
 end
 
+def getosmajor(operatingsystem)
+  if DEBIAN_OS.include?(operatingsystem)
+    '14'
+  elsif REDHAT_OS.include?(operatingsystem)
+    '7'
+  else
+    '2019'
+  end
+end
+
 def getosrelease(operatingsystem)
   if DEBIAN_OS.include?(operatingsystem)
     '14.04'
@@ -61,12 +71,13 @@ RSpec.configure do |c|
     'lsbdistrelease'             => (RSpec::Support::OS.windows? ? '2019 SP1' : '14.04'),
     'lsbdistcodename'            => (RSpec::Support::OS.windows? ? '2019' : '14.04'),
     'os'                         => {
-      'name'    => (RSpec::Support::OS.windows? ? 'Windows' : 'Ubuntu'),
-      'family'  => (RSpec::Support::OS.windows? ? 'windows' : 'Debian'),
-      'release' => {
-        'major' => (RSpec::Support::OS.windows? ? '2019' : '14'),
-        'minor' => (RSpec::Support::OS.windows? ? 'SP1' : '04'),
-        'full'  => (RSpec::Support::OS.windows? ? '2019 SP1' : '14.04'),
+      'architecture' => 'x86_64',
+      'name'         => (RSpec::Support::OS.windows? ? 'Windows' : 'Ubuntu'),
+      'family'       => (RSpec::Support::OS.windows? ? 'windows' : 'Debian'),
+      'release'      => {
+        'major'      => (RSpec::Support::OS.windows? ? '2019' : '14'),
+        'minor'      => (RSpec::Support::OS.windows? ? 'SP1' : '04'),
+        'full'       => (RSpec::Support::OS.windows? ? '2019 SP1' : '14.04'),
       },
     },
   }


### PR DESCRIPTION
Since Puppet 4 “structured Facts” are available.
The “non-strucured Facts” are legacy and deprecated.
So this Commit is a Fix for that.

The legacy Facts are kept in Rspec-Tests for now, but can be deleted in
near Future.### What does this PR do?

<!--A brief description of the change being made with this pull request.-->

### Motivation
Tentative to fix CI on #790 
<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
