### PR TITLE
Upgrade dependencies, Ubuntu, and Puppet version ranges

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-datadog_agent",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "author": "James Turnbull <james@lovedthanlost.net>, Rob Terhaar <rob@atlanticdynamic>, Jaime Fullaondo <jaime.fullaondo@datadoghq.com>, Albert Vaca <albert.vaca@datadoghq.com>",
   "summary": "Install the Datadog monitoring agent and report Puppet runs to Datadog",
   "license": "Apache-2.0",
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.25.0 <9.0.0"
+      "version_requirement": ">=4.25.0 <10.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=4.0.0 <8.0.0"
+      "version_requirement": ">=4.0.0 <10.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=4.4.0 <9.0.0"
+      "version_requirement": ">=4.4.0 <10.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",
@@ -26,15 +26,15 @@
     },
     {
       "name": "puppetlabs/yumrepo_core",
-      "version_requirement": ">=1.0.3 < 2.0.0"
+      "version_requirement": ">=1.0.3 < 3.0.0"
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">=2.3.0 <5.0.0"
+      "version_requirement": ">=2.3.0 <7.0.0"
     },
     {
       "name": "puppet/zypprepo",
-      "version_requirement": ">=3.1.0 <4.0.0"
+      "version_requirement": ">=3.1.0 <6.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -111,7 +111,15 @@
         "17.04",
         "17.10",
         "18.04",
-        "18.10"
+        "18.10",
+        "19.04",
+        "19.10",
+        "20.04",
+        "20.10",
+        "21.04",
+        "21.10",
+        "22.04",
+        "22.10"
       ]
     },
     {
@@ -148,7 +156,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.6.0 <7.0.0"
+      "version_requirement": ">=4.6.0 <9.0.0"
     }
   ],
   "description": "This will install the Datadog monitoring agent. Sign up and get your API key at: http://www.datadoghq.com",


### PR DESCRIPTION
### What does this PR do?

- Increase the highest allowed versions of all dependencies to allow their current versions 
- Allow Puppet 8
- Indicate that newer versions of Ubuntu which are known to work are supported

### Motivation

This module is holding us back on many dependencies in which we use it. 

### Describe your test plan

Should not affect any tests. Was not able to get `pdk test unit` to work. 
