### PR TITLE
Allow defining apm filter_tags to include or exclude traces

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,6 +192,9 @@
 #   $apm_obfuscation
 #       Hash defining obfuscation rules for sensitive data. (Agent 6 and 7 only).
 #       Optional Hash. Default: undef
+#   $apm_filter_tags
+#       Hash defining filter rules for traces. (Agent 6 and 7 only).
+#       Optional Hash. Default: undef
 #   $process_enabled
 #       String to enable the process/container agent
 #       Boolean. Default: false
@@ -341,6 +344,7 @@ class datadog_agent(
   Boolean $apm_non_local_traffic = false,
   Optional[Hash[String, Float[0, 1]]] $apm_analyzed_spans = undef,
   Optional[Hash[String, Data]] $apm_obfuscation = undef,
+  Optional[Hash[String, Data]] $apm_filter_tags = undef,
   Boolean $process_enabled = $datadog_agent::params::process_default_enabled,
   Boolean $scrub_args = $datadog_agent::params::process_default_scrub_args,
   Array $custom_sensitive_words = $datadog_agent::params::process_default_custom_words,
@@ -684,6 +688,16 @@ class datadog_agent(
         $apm_obfuscation_config = {}
     }
 
+    if $apm_filter_tags {
+        $apm_filter_tags_config = {
+          'apm_config' => {
+            'filter_tags' => $apm_filter_tags
+          }
+        }
+    } else {
+        $apm_filter_tags_config = {}
+    }
+
     if $statsd_forward_host.empty {
         $statsd_forward_config = {}
     } else {
@@ -713,6 +727,7 @@ class datadog_agent(
             $agent_extra_options,
             $apm_analyzed_span_config,
             $apm_obfuscation_config,
+            $apm_filter_tags_config,
             $statsd_forward_config,
             $host_config,
             $additional_checksd_config)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,6 +195,9 @@
 #   $apm_filter_tags
 #       Hash defining filter rules for traces. (Agent 6 and 7 only).
 #       Optional Hash. Default: undef
+#   $apm_filter_tags_regex
+#       Hash defining regex filter rules for traces. (Agent 6 and 7 only).
+#       Optional Hash. Default: undef
 #   $process_enabled
 #       String to enable the process/container agent
 #       Boolean. Default: false
@@ -345,6 +348,7 @@ class datadog_agent(
   Optional[Hash[String, Float[0, 1]]] $apm_analyzed_spans = undef,
   Optional[Hash[String, Data]] $apm_obfuscation = undef,
   Optional[Hash[String, Data]] $apm_filter_tags = undef,
+  Optional[Hash[String, Data]] $apm_filter_tags_regex = undef,
   Boolean $process_enabled = $datadog_agent::params::process_default_enabled,
   Boolean $scrub_args = $datadog_agent::params::process_default_scrub_args,
   Array $custom_sensitive_words = $datadog_agent::params::process_default_custom_words,
@@ -698,6 +702,16 @@ class datadog_agent(
         $apm_filter_tags_config = {}
     }
 
+    if $apm_filter_tags_regex {
+        $apm_filter_tags_regex_config = {
+          'apm_config' => {
+            'filter_tags_regex' => $apm_filter_tags_regex
+          }
+        }
+    } else {
+        $apm_filter_tags_regex_config = {}
+    }
+
     if $statsd_forward_host.empty {
         $statsd_forward_config = {}
     } else {
@@ -728,6 +742,7 @@ class datadog_agent(
             $apm_analyzed_span_config,
             $apm_obfuscation_config,
             $apm_filter_tags_config,
+            $apm_filter_tags_regex_config,
             $statsd_forward_config,
             $host_config,
             $additional_checksd_config)


### PR DESCRIPTION

### What does this PR do?

APM allows to filter traces / SPANs based on "filters" that can be configured in the datadog.yaml file
https://docs.datadoghq.com/tracing/guide/ignoring_apm_resources/?tab=datadogyaml#trace-agent-configuration-options

### Motivation

We need to be able to configure that and the current module version doesn't allow us to do so.

### Describe your test plan

If a value (hash) is set for "apm_filter_tags" (via hiera for example), the values will be merged into the datadog configuration hash / yaml file.