### PR TITLE
Doc: custom_emitters duplicated on docs init file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,9 +159,6 @@
 #   $custom_emitters
 #       Specifies a comma seperated list of non standard emitters to be used
 #       String. Default: empty
-#   $custom_emitters
-#       Specifies a comma seperated list of non standard emitters to be used
-#       String. Default: empty
 #   $agent_log_file
 #       Specifies the log file location (Agent 6 and 7 only).
 #       String. Default: empty


### PR DESCRIPTION
### What does this PR do?

Remove a duplicate parameter in the documentation of a single file.

### Motivation

Keep this file clean.

### Additional Notes

Easy fix.

### Describe your test plan

No test required.
