### PR TITLE
Rpm repo proxy support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -229,6 +229,26 @@
 #       The `undef` value also translates to `false` on RHEL/CentOS 8.1 because
 #       of a bug in libdnf: https://bugzilla.redhat.com/show_bug.cgi?id=1792506
 #       Boolean. Default: undef
+#   $rpm_repo_proxy_url
+#       Wether or not to use a proxy server for RPM repositories.
+#       Applies to Red Hat platforms. When set to `undef`, or `rpm_repo_proxy_port` is `undef`,
+#       no proxy is used to download packages from the repo. 
+#       String. Default: undef
+#   $rpm_repo_proxy_port
+#       Which port to use with a proxy server for RPM repositories.
+#       Applies to Red Hat platforms. When set to `undef`, or `rpm_repo_proxy_url` is `undef`,
+#       no proxy is used to download packages from the repo.
+#       Numerical. Default: undef
+#   $rpm_repo_proxy_password
+#       Whether to use a password for proxy connections for RPM repositories.
+#       Applies to Red Hat platforms. When set to `undef`, no password is used
+#       for proxy connections to download packages from the repo. 
+#       String. Default: undef
+#   $rpm_repo_proxy_username
+#       Whether to use a username for proxy connections for RPM repositories.
+#       Applies to Red Hat platforms. When set to `undef`, no username is specified
+#       for proxy connections to download packages from the repo. 
+#       String. Default: undef
 #   $apt_release
 #       The distribution channel to be used for the APT repo. Eg: 'stable' or 'beta'.
 #       String. Default: stable
@@ -355,6 +375,10 @@ class datadog_agent(
   Hash[String[1], Data] $agent_extra_options = {},
   Optional[String] $agent_repo_uri = undef,
   Optional[Boolean] $rpm_repo_gpgcheck = undef,
+  Optional[String] $rpm_repo_proxy_url = undef,
+  Optional[Numerical] $rpm_repo_proxy_port = undef,
+  Optional[String] $rpm_repo_proxy_password = undef,
+  Optional[String] $rpm_repo_proxy_username = undef,
   # TODO: $use_apt_backup_keyserver, $apt_backup_keyserver and $apt_keyserver can be
   # removed in the next major version; they're kept now for backwards compatibility
   Optional[Boolean] $use_apt_backup_keyserver = undef,
@@ -462,12 +486,16 @@ class datadog_agent(
       }
       'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux','AlmaLinux','Rocky' : {
         class { 'datadog_agent::redhat':
-          agent_major_version => $_agent_major_version,
-          agent_flavor        => $agent_flavor,
-          agent_repo_uri      => $agent_repo_uri,
-          manage_repo         => $manage_repo,
-          agent_version       => $agent_full_version,
-          rpm_repo_gpgcheck   => $rpm_repo_gpgcheck,
+          agent_major_version     => $_agent_major_version,
+          agent_flavor            => $agent_flavor,
+          agent_repo_uri          => $agent_repo_uri,
+          manage_repo             => $manage_repo,
+          agent_version           => $agent_full_version,
+          rpm_repo_gpgcheck       => $rpm_repo_gpgcheck,
+          rpm_repo_proxy_url      => $rpm_repo_proxy_url,
+          rpm_repo_proxy_port     => $rpm_repo_proxy_port,
+          rpm_repo_proxy_password => $rpm_repo_proxy_password,
+          rpm_repo_proxy_username => $rpm_repo_proxy_username,
         }
       }
       'Windows' : {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -238,7 +238,7 @@
 #       Which port to use with a proxy server for RPM repositories.
 #       Applies to Red Hat platforms. When set to `undef`, or `rpm_repo_proxy_url` is `undef`,
 #       no proxy is used to download packages from the repo.
-#       Numerical. Default: undef
+#       Integer. Default: undef
 #   $rpm_repo_proxy_password
 #       Whether to use a password for proxy connections for RPM repositories.
 #       Applies to Red Hat platforms. When set to `undef`, no password is used
@@ -376,7 +376,7 @@ class datadog_agent(
   Optional[String] $agent_repo_uri = undef,
   Optional[Boolean] $rpm_repo_gpgcheck = undef,
   Optional[String] $rpm_repo_proxy_url = undef,
-  Optional[Numerical] $rpm_repo_proxy_port = undef,
+  Optional[Integer] $rpm_repo_proxy_port = undef,
   Optional[String] $rpm_repo_proxy_password = undef,
   Optional[String] $rpm_repo_proxy_username = undef,
   # TODO: $use_apt_backup_keyserver, $apt_backup_keyserver and $apt_keyserver can be

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -60,7 +60,7 @@ class datadog_agent::redhat(
     # only set any proxy variables if a proxy url and port are provided
     if ($rpm_repo_proxy_url != undef) {
       if ($rpm_repo_proxy_port != undef) {
-        $repo_proxy_url = "${rpm_repo_proxy_url}:${rpm_repo_proxy_port}"
+        $repo_proxy_url = "http://${rpm_repo_proxy_url}:${rpm_repo_proxy_port}"
         if ($rpm_repo_proxy_username != undef) {
           $repo_proxy_username = $rpm_repo_proxy_username
           if ($rpm_repo_proxy_password != undef) {

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -11,7 +11,7 @@ class datadog_agent::redhat(
   String $agent_flavor = $datadog_agent::params::package_name,
   Optional[Boolean] $rpm_repo_gpgcheck = undef,
   Optional[String] $rpm_repo_proxy_url = undef,
-  Optional[Numerical] $rpm_repo_proxy_port = undef,
+  Optional[Integer] $rpm_repo_proxy_port = undef,
   Optional[String] $rpm_repo_proxy_password = undef,
   Optional[String] $rpm_repo_proxy_username = undef,
 ) inherits datadog_agent::params {

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -10,6 +10,10 @@ class datadog_agent::redhat(
   String $agent_version = $datadog_agent::params::agent_version,
   String $agent_flavor = $datadog_agent::params::package_name,
   Optional[Boolean] $rpm_repo_gpgcheck = undef,
+  Optional[String] $rpm_repo_proxy_url = undef,
+  Optional[Numerical] $rpm_repo_proxy_port = undef,
+  Optional[String] $rpm_repo_proxy_password = undef,
+  Optional[String] $rpm_repo_proxy_username = undef,
 ) inherits datadog_agent::params {
 
   if $manage_repo {
@@ -51,7 +55,25 @@ class datadog_agent::redhat(
       } else {
         $repo_gpgcheck = false
       }
+    }
 
+    # only set any proxy variables if a proxy url and port are provided
+    if ($rpm_repo_proxy_url != undef) {
+      if ($rpm_repo_proxy_port != undef) {
+        $repo_proxy_url = "${rpm_repo_proxy_url}:${rpm_repo_proxy_port}"
+        if ($rpm_repo_proxy_username != undef) {
+          $repo_proxy_username = $rpm_repo_proxy_username
+          if ($rpm_repo_proxy_password != undef) {
+            $repo_proxy_password = $rpm_repo_proxy_password
+          } else {
+            $repo_proxy_password = absent
+          }
+        } else {
+          $repo_proxy_username = absent
+        }
+      } else {
+        $repo_proxy_url = absent
+      }
     }
 
     case $agent_major_version {
@@ -94,12 +116,15 @@ class datadog_agent::redhat(
     }
 
     yumrepo {'datadog':
-      enabled       => 1,
-      gpgcheck      => 1,
-      gpgkey        => join($gpgkeys, "\n       "),
-      repo_gpgcheck => $repo_gpgcheck,
-      descr         => 'Datadog, Inc.',
-      baseurl       => $baseurl,
+      enabled        => 1,
+      gpgcheck       => 1,
+      gpgkey         => join($gpgkeys, "\n       "),
+      repo_gpgcheck  => $repo_gpgcheck,
+      descr          => 'Datadog, Inc.',
+      baseurl        => $baseurl,
+      proxy          => $repo_proxy_url,
+      proxy_password => $repo_proxy_password,
+      proxy_username => $repo_proxy_username,
     }
 
     package { $agent_flavor:


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability to define a proxy server, proxy port, proxy username, and proxy password to be used by yum/dnf to connect to the DataDog yum repository via a proxy connection on RedHat Enterprise Linux and similar distributions.
Four new variables are introduced to capture the necessary data when the module is invoked from hiera or via class parameters. These parameters are validated before they are handed down to the yumrepo resource in the redhat.pp class.
A proxy can be used without specifying a user and password. But to use a proxy, both server and port are required.


### Motivation

The module does currently not allow to manage the yum repository for installing the client if a proxy is needed to connect to it. I would like to use the functionality of being able to manage the repo configuration and be able to specify a proxy server to use.


### Additional Notes

What does this PR do?
This PR adds functionality to provide a proxy server, proxy port, proxy username, and proxy password when using the functionality to manage the RPM repo on RHEL based systems. These parameters are validated before they are handed down to the yumrepo resource in the redhat.pp class.
The new class parameters introduced via this pull request are:
Optional[String] $rpm_repo_proxy_url = undef,
Optional[Integer] $rpm_repo_proxy_port = undef,
Optional[String] $rpm_repo_proxy_password = undef,
Optional[String] $rpm_repo_proxy_username = undef,
Documentation has been added in the class description.
Validation of parameter values has been added.


### Describe your test plan

The branch with my changes was tested and is currently used in a production environment. The proxy and port are successfully configured in the /etc/yum.repos.d/datadog.repo file on the hosts and Puppet was able to install the datadog-agent RPM using the proxy. Since our environment does not use proxy users or passwords, I am not able to fully test this. But the parameters were handed to the yumrepo resource in the redhat.pp class during testing.
Without the parameters provided to the datadog module, the datadog-agent RPM could not be installed due to the restrictions in our environment. This is the expected behavior.