### PR TITLE
Remove ntp default config file if it still exists

### DIFF
--- a/manifests/integrations/ntp.pp
+++ b/manifests/integrations/ntp.pp
@@ -61,4 +61,10 @@ class datadog_agent::integrations::ntp(
     require => Package[$datadog_agent::params::package_name],
     notify  => Service[$datadog_agent::params::service_name]
   }
+
+  # Remove potential remaining default config file
+  exec { 'remove_default_file':
+    command => "rm ${$dst}.default",
+    onlyif  => "test -e ${$dst}.default",
+  }
 }


### PR DESCRIPTION
### What does this PR do?

<!--A brief description of the change being made with this pull request.-->
Remove ntp default config file if it still exists. This scenario isn't supposed to happen but if it does it'll prevent ntp from starting twice.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
