### PR TITLE
(chore) [CECO-1754] Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   specs-ruby21-puppet46: &specs
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:2024.08.1
     environment:
       STRICT_VARIABLES: 'yes'
       RUBY_VERSION: '2.1.9'
@@ -15,6 +15,11 @@ jobs:
           name: Fix git clones
           command: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - checkout
+      - run:
+          name: Install RVM
+          command: |
+            gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+            \curl -sSL https://get.rvm.io | bash -s stable
       - run:
           name: Install old libssl1.0-dev
           command: |
@@ -290,7 +295,7 @@ jobs:
 
   verify-gemfile-lock-dependencies:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:2024.08.1
     environment:
       STRICT_VARIABLES: 'yes'
       RUBY_VERSION: '2.5.3'
@@ -300,6 +305,11 @@ jobs:
           name: Fix git clones
           command: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - checkout
+      - run:
+          name: Install RVM
+          command: |
+            gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+            \curl -sSL https://get.rvm.io | bash -s stable
       - run:
           name: Install Ruby versions
           command: rvm install $RUBY_VERSION
@@ -315,7 +325,7 @@ jobs:
 
   kitchen-tests:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:2024.08.1
     environment:
       STRICT_VARIABLES: 'yes'
       RUBY_VERSION: '2.5.3'
@@ -325,6 +335,11 @@ jobs:
           name: Fix git clones
           command: echo -e '[url "https://github.com/"]\n  insteadOf = "git://github.com/"' >> ~/.gitconfig
       - checkout
+      - run:
+          name: Install RVM
+          command: |
+            gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+            \curl -sSL https://get.rvm.io | bash -s stable
       - run:
           name: Install Ruby versions
           command: rvm install $RUBY_VERSION

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,13 @@ group :development do
   gem "rubocop-i18n", "~> 1.2.0"
   gem "rubocop-rspec", "~> 1.16.0"
 
+  # https://github.com/ffi/ffi/issues/1103 (pin only for Ruby >= 2.5 as this version is not compatible below. ffi 1.17 is not compatible with Ruby 2.5: https://github.com/ffi/ffi/issues/1103)
+  if ruby_version >= Gem::Version.new('2.5')
+    gem "ffi", "= 1.16.3", platforms: [:ruby]
+  else
+    gem "ffi", require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  end
+
   if ruby_version >= Gem::Version.new('2.3')
     gem "test-kitchen", '~> 2.5.4'
     gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
     fast_gettext (1.1.2)
-    ffi (1.15.4)
+    ffi (1.16.3)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -485,11 +485,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  concurrent-ruby (= 1.1.10)
   fast_gettext
+  ffi (= 1.16.3)
   kitchen-docker
   kitchen-puppet
   kitchen-verifier-serverspec
-  librarian-puppet
+  librarian-puppet (<= 4.0.1)
   mixlib-shellout (~> 2.2.7)
   puppet (~> 7.0.0)
   puppet-module-posix-default-r2.7
@@ -500,6 +502,7 @@ DEPENDENCIES
   rubocop-i18n (~> 1.2.0)
   rubocop-rspec (~> 1.16.0)
   ruby-pwsh (~> 0.3.0)
+  semantic_puppet (= 1.0.4)
   test-kitchen (~> 2.5.4)
   xmlrpc
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -92,6 +92,7 @@ platforms:
         - zypper install -y puppet-agent ruby=2.5
         - gem install bundler -v '= 1.17.3'
         - gem install net-ssh -v '= 6.1.0'
+        - gem install rspec-its -v '= 1.3.1'
         - gem install serverspec rspec
         - ln -s /usr/bin/rspec.ruby2.5 /usr/bin/rspec
         - ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet


### PR DESCRIPTION
### What does this PR do?

* Updates Ubuntu 20.04 runners to latest available image
    * This also requires installing `rvm` that is no longer present by default in the image
* Pin `ffi` version to `1.16.3` on nix-platforms as otherwise, `1.7.0` is installed that is not compatible due to a broken dependency https://github.com/ffi/ffi/issues/1103: example failure https://app.circleci.com/pipelines/github/DataDog/puppet-datadog-agent/971/workflows/6e490e10-37db-44c2-8017-d19019823699/jobs/28742
    ```shell
    Resolving dependencies.......
    ffi-1.17.0-x86_64-linux-musl requires rubygems version >= 3.3.22, which is
    incompatible with the current version, 2.7.11
    
    Exited with code exit status 5
    ```

* Pin `rspec-its` version on OpenSUSE kitchen test to avoid encountering:
    ```shell
    Step 19/27 : RUN gem install serverspec rspec
     ---> Running in affd00e6d53e
    ERROR:  Error installing serverspec:
            The last version of rspec-its (>= 0) to support your Ruby & RubyGems was 1.3.1. Try installing it with `gem install rspec-its -v 1.3.1` and then running the current command again
            rspec-its requires Ruby version > 3.0.0. The current ruby version is 2.5.0.
    ```

### Motivation

CI fails as 202201-02 is not a valid tag (was deprecated in January https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177). Available tags https://circleci.com/developer/machine/image/ubuntu-2004

- 2024.08.1
- 2024.05.1
- 2024.04.4
- 2024.01.2
- 2024.01.1
- 2023.10.1
- 2023.07.1
- 2023.04.2
- 2023.02.1
- 2022.10.1
- 202111-02
- current
- edge

Example failure: https://app.circleci.com/pipelines/github/DataDog/puppet-datadog-agent/965/workflows/28ecf2ab-351d-4b1e-a43c-5f48d2fda754/jobs/28570

### Describe your test plan

CI should be green