### PR TITLE
[CECO-1804] Add remote policies

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,6 +256,9 @@
 #   $remote_updates
 #       Boolean to enable or disable Agent remote updates.
 #       Boolean. Default: false
+#   $remote_policies
+#       Boolean to enable or disable Agent remote policies.
+#       Boolean. Default: false
 #
 # Sample Usage:
 #
@@ -384,6 +387,7 @@ class datadog_agent (
   Optional[String] $windows_ddagentuser_name = undef,
   Optional[String] $windows_ddagentuser_password = undef,
   Boolean $remote_updates = $datadog_agent::params::remote_updates,
+  Boolean $remote_policies = $datadog_agent::params::remote_policies,
   Optional[Enum['host', 'docker', 'all']] $apm_instrumentation_enabled = undef,
   Optional[Array[String]] $apm_instrumentation_libraries = undef,
 ) inherits datadog_agent::params {
@@ -493,6 +497,7 @@ class datadog_agent (
           apm_instrumentation_enabled       => $apm_instrumentation_enabled,
           apm_instrumentation_libraries_str => $apm_instrumentation_libraries_str,
           remote_updates                    => $remote_updates,
+          remote_policies                   => $remote_policies,
         }
       }
       'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux','AlmaLinux','Rocky' : {
@@ -506,6 +511,7 @@ class datadog_agent (
           apm_instrumentation_enabled       => $apm_instrumentation_enabled,
           apm_instrumentation_libraries_str => $apm_instrumentation_libraries_str,
           remote_updates                    => $remote_updates,
+          remote_policies                   => $remote_policies,
         }
       }
       'OpenSuSE', 'SLES' : {
@@ -519,6 +525,7 @@ class datadog_agent (
           apm_instrumentation_enabled       => $apm_instrumentation_enabled,
           apm_instrumentation_libraries_str => $apm_instrumentation_libraries_str,
           remote_updates                    => $remote_updates,
+          remote_policies                   => $remote_policies,
         }
       }
       default: { fail("Class[datadog_agent::installer]: Unsupported operatingsystem: ${facts['os']['name']}") }
@@ -891,6 +898,7 @@ class datadog_agent (
       'log_file' => $agent_log_file,
       'log_level' => $log_level,
       'remote_updates' => $remote_updates,
+      'remote_policies' => $remote_policies,
       'tags' => unique(flatten(union($_local_tags, $_facts_tags, $_trusted_facts_tags))),
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class datadog_agent::params {
   $logs_enabled                   = false
   $logs_open_files_limit          = undef
   $remote_updates                 = false
+  $remote_policies                = false
   $container_collect_all          = false
   $sysprobe_service_name          = 'datadog-agent-sysprobe'
   $securityagent_service_name     = 'datadog-agent-security'

--- a/manifests/redhat_installer.pp
+++ b/manifests/redhat_installer.pp
@@ -10,6 +10,7 @@
 # @param apm_instrumentation_enabled Optional[Enum['host', 'docker', 'all']]: Enable APM instrumentation for the specified environment (host, docker, or all).
 # @param apm_instrumentation_libraries_str Optional[String]: APM instrumentation libraries as a comma-separated string.
 # @param remote_updates Boolean: Whether to enable Agent remote updates. Default: false.
+# @param remote_policies Boolean: Whether to enable Agent remote policies. Default: false.
 #
 class datadog_agent::redhat_installer (
   String $api_key = 'your_API_key',
@@ -21,6 +22,7 @@ class datadog_agent::redhat_installer (
   Optional[Enum['host', 'docker', 'all']] $apm_instrumentation_enabled = undef,
   Optional[String] $apm_instrumentation_libraries_str = undef,
   Boolean $remote_updates = $datadog_agent::params::remote_updates,
+  Boolean $remote_policies = $datadog_agent::params::remote_policies,
 ) inherits datadog_agent::params {
   # Generate installer trace ID as a random 64-bit integer (Puppet does not support 128-bit integers)
   # Note: we cannot use fqdn_rand as the seed is dependent on the node, meaning the same trace ID would be generated on each run (for the same node)
@@ -108,6 +110,7 @@ class datadog_agent::redhat_installer (
       "DD_AGENT_MAJOR_VERSION=${agent_major_version}",
       "DD_AGENT_MINOR_VERSION=${agent_minor_version}",
       "DD_REMOTE_UPDATES=${remote_updates}",
+      "DD_REMOTE_POLICIES=${remote_policies}",
       "DD_APM_INSTRUMENTATION_ENABLED=${apm_instrumentation_enabled}",
       "DD_APM_INSTRUMENTATION_LIBRARIES=${apm_instrumentation_libraries_str}",
     ],

--- a/manifests/suse_installer.pp
+++ b/manifests/suse_installer.pp
@@ -10,6 +10,7 @@
 # @param apm_instrumentation_enabled Optional[Enum['host', 'docker', 'all']]: Enable APM instrumentation for the specified environment (host, docker, or all).
 # @param apm_instrumentation_libraries_str Optional[String]: APM instrumentation libraries as a comma-separated string.
 # @param remote_updates Boolean: Whether to enable Agent remote updates. Default: false.
+# @param remote_policies Boolean: Whether to enable Agent remote policies. Default: false.
 #
 class datadog_agent::suse_installer (
   String $api_key = 'your_API_key',
@@ -21,6 +22,7 @@ class datadog_agent::suse_installer (
   Optional[Enum['host', 'docker', 'all']] $apm_instrumentation_enabled = undef,
   Optional[String] $apm_instrumentation_libraries_str = undef,
   Boolean $remote_updates = $datadog_agent::params::remote_updates,
+  Boolean $remote_policies = $datadog_agent::params::remote_policies,
 ) inherits datadog_agent::params {
   # Generate installer trace ID as a random 64-bit integer (Puppet does not support 128-bit integers)
   # Note: we cannot use fqdn_rand as the seed is dependent on the node, meaning the same trace ID would be generated on each run (for the same node)
@@ -121,6 +123,7 @@ class datadog_agent::suse_installer (
       "DD_AGENT_MAJOR_VERSION=${agent_major_version}",
       "DD_AGENT_MINOR_VERSION=${agent_minor_version}",
       "DD_REMOTE_UPDATES=${remote_updates}",
+      "DD_REMOTE_POLICIES=${remote_policies}",
       "DD_APM_INSTRUMENTATION_ENABLED=${apm_instrumentation_enabled}",
       "DD_APM_INSTRUMENTATION_LIBRARIES=${apm_instrumentation_libraries_str}",
     ],

--- a/manifests/ubuntu_installer.pp
+++ b/manifests/ubuntu_installer.pp
@@ -15,6 +15,7 @@
 # @param apm_instrumentation_enabled Optional[Enum['host', 'docker', 'all']]: Enable APM instrumentation for the specified environment (host, docker, or all).
 # @param apm_instrumentation_libraries_str Optional[String]: APM instrumentation libraries as a comma-separated string.
 # @param remote_updates Boolean: Whether to enable Agent remote updates. Default: false.
+# @param remote_policies Boolean: Whether to enable Agent remote policies. Default: false.
 #
 class datadog_agent::ubuntu_installer (
   String $api_key = 'your_API_key',
@@ -43,6 +44,7 @@ class datadog_agent::ubuntu_installer (
   Optional[Enum['host', 'docker', 'all']] $apm_instrumentation_enabled = undef,
   Optional[String] $apm_instrumentation_libraries_str = undef,
   Boolean $remote_updates = $datadog_agent::params::remote_updates,
+  Boolean $remote_policies = $datadog_agent::params::remote_policies,
 ) inherits datadog_agent::params {
   # Generate installer trace ID as a random 64-bit integer (Puppet does not support 128-bit integers)
   # Note: we cannot use fqdn_rand as the seed is dependent on the node, meaning the same trace ID would be generated on each run (for the same node)
@@ -134,6 +136,7 @@ class datadog_agent::ubuntu_installer (
       "DD_AGENT_MAJOR_VERSION=${agent_major_version}",
       "DD_AGENT_MINOR_VERSION=${agent_minor_version}",
       "DD_REMOTE_UPDATES=${remote_updates}",
+      "DD_REMOTE_POLICIES=${remote_policies}",
       "DD_APM_INSTRUMENTATION_ENABLED=${apm_instrumentation_enabled}",
       "DD_APM_INSTRUMENTATION_LIBRARIES=${apm_instrumentation_libraries_str}",
     ],


### PR DESCRIPTION
### What does this PR do?

1. Support for `DD_REMOTE_POLICIES` when using the installer, same behaviour as `DD_REMOTE_UPDATES`: 54b1765efb16b05dcf8215333bd2d6c769d26813
2. Link the `datadog-agent` service to the installer when the Agent is managed by it: 2e14d9b932e6c286a11b861e7f415cf203ee6041

### Motivation

1. Request from fleet automation team
2. Using the installer with `DD_REMOTE_UPDATES=true`, the Agent package is installed with it but the service was not started as is for a normal Agent install as in https://github.com/DataDog/puppet-datadog-agent/pull/820, I gated the service behind non-installer managed Agent installations. This commit fixes that by defining the Agent service with the `datadog-installer` flavor and reverting the previous gate (return to original code for the management of `/etc/datadog-agent/datadog.yaml` before #820 ): https://github.com/DataDog/puppet-datadog-agent/blob/9184de00540afc6a16ba13eeed7545b4ad05db33/manifests/init.pp#L782-L790

### Describe your test plan

1. Use the following `site.pp`:
    ```puppet
    class { "datadog_agent":
      api_key => "REPLACE_ME",
      datadog_site => "datad0g.com",
      manage_install => false,
      datadog_installer_enabled => true,
      remote_updates => true,
      remote_policies => true,
    }
    ```
2. Ensure the DD Agent service is running after applying your manifest: `systemctl status datadog-agent`
3. Verify `remote_policies: true` is in `datadog.yaml`
4. Add a configuration option modifying `datadog.yaml` in your `site.pp`, e.g.:
    ```puppet
    class { "datadog_agent":
      api_key => "REPLACE_ME",
      datadog_site => "datad0g.com",
      manage_install => false,
      datadog_installer_enabled => true,
      remote_updates => true,
      remote_policies => true,
      agent_extra_options => {
        foo => "bar",
      },
    }
    ```
5. Ensure the Agent service was restarted
