### PR TITLE
Fix postgres ssl param

### DIFF
--- a/manifests/integrations/postgres.pp
+++ b/manifests/integrations/postgres.pp
@@ -88,7 +88,7 @@ class datadog_agent::integrations::postgres(
   String $dbname                         = 'postgres',
   Variant[String, Integer] $port         = '5432',
   String $username                       = 'datadog',
-  Boolean $ssl                           = false,
+  String $ssl                            = 'allow',
   Boolean $use_psycopg2                  = false,
   Boolean $collect_function_metrics      = false,
   Boolean $collect_count_metrics         = false,

--- a/manifests/integrations/postgres.pp
+++ b/manifests/integrations/postgres.pp
@@ -14,7 +14,19 @@
 #   $username
 #       The username for the datadog user
 #   $ssl
-#       Boolean to enable SSL
+#       This option determines whether or not and with what priority a secure SSL TCP/IP connection
+#         is negotiated with the server. There are six modes:
+#         - `disable`: Only tries a non-SSL connection.
+#         - `allow`: First tries a non-SSL connection; if if fails, tries an SSL connection.
+#         - `prefer`: First tries an SSL connection; if it fails, tries a non-SSL connection.
+#         - `require`: Only tries an SSL connection. If a root CA file is present, verifies the certificate in
+#                      the same way as if verify-ca was specified.
+#         - `verify-ca`: Only tries an SSL connection, and verifies that the server certificate is issued by a
+#                        trusted certificate authority (CA).
+#         - `verify-full`: Only tries an SSL connection and verifies that the server certificate is issued by a
+#                          trusted CA and that the requested server host name matches the one in the certificate.
+#
+#         For a detailed description of how these options work see https://www.postgresql.org/docs/current/libpq-ssl.html
 #   $use_psycopg2
 #       Boolean to flag connecting to postgres with psycopg2 instead of pg8000.
 #       Warning, psycopg2 doesn't support ssl mode.
@@ -72,7 +84,7 @@
 #       dbname: 'postgres'
 #       username: 'datadog'
 #       password: 'some_pass'
-#       ssl: false
+#       ssl: 'allow'
 #       custom_metrics:
 #         a_custom_query:
 #           query: 'select tag_column, %s from table'


### PR DESCRIPTION
### What does this PR do?

Fix the postgres check's `ssl` parameter, which now expects a `string` type.

### Motivation

Support request

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

Tested on Ubuntu 20.04, puppet v7.34.0