### PR TITLE
Cleanup puppetserver_gem

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class datadog_agent::params {
   $default_agent_major_version    = 7
   $agent_version                  = 'latest'
   $dogapi_version                 = 'installed'
-  $gem_provider                   = 'puppetserver_gem'
+  $gem_provider                   = 'gem'
   $conf_dir_purge                 = false
   $apt_default_release            = 'stable'
   $apm_default_enabled            = false

--- a/spec/classes/datadog_agent_reports_spec.rb
+++ b/spec/classes/datadog_agent_reports_spec.rb
@@ -61,7 +61,7 @@ describe 'datadog_agent::reports' do
           it do
             is_expected.to contain_package('dogapi')\
               .with_ensure('installed')
-              .with_provider('puppetserver_gem')
+              .with_provider('gem')
           end
 
           it do
@@ -117,7 +117,7 @@ describe 'datadog_agent::reports' do
       it do
         is_expected.to contain_package('dogapi')\
           .with_ensure('1.2.2')
-          .with_provider('puppetserver_gem')
+          .with_provider('gem')
       end
 
       it do


### PR DESCRIPTION
### What does this PR do?

`puppetserver_gem` was removed in the v4.0.0 release. This PR cleans up residual references to it as a gem provider. 

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
