### PR TITLE
Fix tcp_check for multi instances

### DIFF
--- a/manifests/integrations/tcp_check.pp
+++ b/manifests/integrations/tcp_check.pp
@@ -81,9 +81,9 @@
 #        }]
 #     }
 class datadog_agent::integrations::tcp_check (
-  String $check_name,
-  String $host,
-  String $port,
+  Optional[String] $check_name = undef,
+  Optional[String] $host       = undef,
+  Optional[String] $port       = undef,
   Integer $timeout                  = 10,
   Optional[Integer] $threshold      = undef,
   Optional[Integer] $window         = undef,

--- a/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
+++ b/spec/classes/datadog_agent_integrations_tcp_check_spec.rb
@@ -112,6 +112,45 @@ describe 'datadog_agent::integrations::tcp_check' do
 
           skip('doubly undefined behavior')
         end
+
+        context 'with multiple instances' do
+          let(:params) do
+            {
+              instances: [
+                {
+                  check_name: 'foo.bar.baz',
+                  host: 'foo.bar.baz',
+                  port: '80',
+                  timeout: 123,
+                  threshold: 456,
+                  window: 789,
+                  collect_response_time: true,
+                },
+                {
+                  check_name: 'baz.bar.foo',
+                  host: 'baz.bar.foo',
+                  port: '8080',
+                  timeout: 456,
+                  tags: ['foo', 'bar', 'baz']
+                },
+              ]
+            }
+          end
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{name: foo.bar.baz}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{host: foo.bar.baz}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{port: 80}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{timeout: 123}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{threshold: 456}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{window: 789}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{collect_response_time: true}) }
+
+          it { is_expected.to contain_file(conf_file).with_content(%r{name: baz.bar.foo}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{host: baz.bar.foo}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{port: 8080}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{timeout: 456}) }
+          it { is_expected.to contain_file(conf_file).with_content(%r{tags:\s+- foo\s+- bar\s+- baz\s*?[^-]}m) }
+        end
       end
     end
   end


### PR DESCRIPTION
### What does this PR do?

Fix bug introduced in v4 of the module which broke multi instances support in the tcp_check.

### Motivation

Fixes https://github.com/DataDog/puppet-datadog-agent/issues/849

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
