### PR TITLE
[BUGFIX] Handle windows Agent pinned version above 7.46

### DIFF
--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -74,9 +74,6 @@ class datadog_agent::windows (
       }
 
       $minor_version = Integer($version_parts[1])
-      if !is_integer($minor_version) {
-        fail("Invalid minor version number: ${version_parts[1]}")
-      }
 
       if $minor_version <= 46 {
         $ensure_version = "${agent_version}.1"

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -65,8 +65,24 @@ class datadog_agent::windows (
     if $agent_version == 'latest' {
       $ensure_version = 'installed'
     } else {
-      # While artifacts contain X.Y.Z in their name, their installed Windows versions are actually X.Y.Z.1
-      $ensure_version = "${agent_version}.1"
+      # While artifacts contain X.Y.Z in their name, their installed Windows versions are actually X.Y.Z.1 before 7.47.0.
+      # After 7.47.0, the version is X.Y.Z.0.
+      # Ref: https://github.com/DataDog/datadog-agent/pull/19576
+      $version_parts = split($agent_version, '[.]') # . is a meta regex character, so we need to escape it with [].
+      if length($version_parts) < 2 {
+        fail("Invalid version format: ${agent_version}. Expected format: X.Y.Z")
+      }
+
+      $minor_version = Integer($version_parts[1])
+      if !is_integer($minor_version) {
+        fail("Invalid minor version number: ${version_parts[1]}")
+      }
+
+      if $minor_version <= 46 {
+        $ensure_version = "${agent_version}.1"
+      } else {
+        $ensure_version = "${agent_version}.0"
+      }
     }
 
     $hostname_option = $hostname ? { '' => {}, default => { 'HOSTNAME' => $hostname } }


### PR DESCRIPTION
### What does this PR do?

* Adds `.0` to Windows Agent package Puppet check after minor 47 instead of always `.1` due to https://github.com/DataDog/datadog-agent/pull/19576.
* Adds some error handling

### Motivation

* On Windows, we need to check which version is installed by referencing the full display name: https://www.puppet.com/docs/puppet/7/resources_package_windows.html#package_versions_and_upgrades-packages-real-versions. Installed packages are `X.Y.Z.0/1` while users provide `X.Y.Z`.
    * `agent_version => "7.35.1"`: Puppet sees it as `7.35.1.1`
    * `agent_version => "7.64.1"`: Puppet sees it as `7.64.1.0`
* Closes https://github.com/DataDog/puppet-datadog-agent/issues/859

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

* Pin 7.35.1 in manifest:
    * Ensure Puppet does not attempt to re-install in a loop said version, e.g. by re-running the catalog
* Pin 7.64.3 in manifest:
    * Ensure Puppet does not attempt to re-install in a loop said version, e.g. by re-running the catalog
