### PR TITLE
[AGENTONB-2490] Support `remote_updates` through embedded installer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -439,194 +439,95 @@ class datadog_agent (
     default:    { $_loglevel = 'INFO' }
   }
 
-  if $datadog_installer_enabled {
-    # If instrumentation is enabled and the libraries are not set, default to pinned latest versions
-    # Else, if user wants to install libraries without enabling instrumentation, use the provided libraries
-    if $apm_instrumentation_enabled and ! $apm_instrumentation_libraries {
-      $apm_instrumentation_libraries_str = join(['java:1', 'python:2', 'js:5', 'dotnet:3', 'ruby:2'], ',')
-    } elsif $apm_instrumentation_libraries {
-      $apm_instrumentation_libraries_str = join($apm_instrumentation_libraries, ',')
-    } else {
-      $apm_instrumentation_libraries_str = ''
-    }
-    # Agent version handling: the installer expects DD_AGENT_MINOR_VERSION to include the patch version.
-    # $_agent_minor_version is the minor version without the patch version.
-    # We need to add the patch version to the minor version to get the full version.
-    # If minor and patch version were not extracted (e.g. user is simply providing agent_major_version), we use an empty string for the minor version.
-    if $_agent_minor_version != undef and $_agent_patch_version != undef {
-      $_agent_minor_version_full = "${_agent_minor_version}.${_agent_patch_version}"
-    } else {
-      $_agent_minor_version_full = ''
-    }
+  # Install agent
+  if $manage_install {
     case $facts['os']['name'] {
-      'Ubuntu','Debian','Raspbian': {
-        class { 'datadog_agent::ubuntu_installer':
-          api_key                           => $api_key,
-          datadog_site                      => $datadog_site,
-          agent_major_version               => $_agent_major_version,
-          agent_minor_version               => $_agent_minor_version_full,
-          manage_agent_install              => $manage_install,
-          installer_repo_uri                => $agent_repo_uri,
-          release                           => $apt_release,
-          skip_apt_key_trusting             => $skip_apt_key_trusting,
-          apm_instrumentation_enabled       => $apm_instrumentation_enabled,
-          apm_instrumentation_libraries_str => $apm_instrumentation_libraries_str,
-          remote_updates                    => $remote_updates,
-          remote_policies                   => $remote_policies,
+      'Ubuntu','Debian','Raspbian' : {
+        if $use_apt_backup_keyserver != undef or $apt_backup_keyserver != undef or $apt_keyserver != undef {
+          notify { 'apt keyserver arguments deprecation':
+            message  => '$use_apt_backup_keyserver, $apt_backup_keyserver and $apt_keyserver are deprecated since version 3.13.0',
+            loglevel => 'warning',
+          }
+        }
+        class { 'datadog_agent::ubuntu':
+          agent_major_version   => $_agent_major_version,
+          agent_version         => $agent_full_version,
+          agent_flavor          => $agent_flavor,
+          agent_repo_uri        => $agent_repo_uri,
+          release               => $apt_release,
+          skip_apt_key_trusting => $skip_apt_key_trusting,
         }
       }
       'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux','AlmaLinux','Rocky' : {
-        class { 'datadog_agent::redhat_installer':
-          api_key                           => $api_key,
-          datadog_site                      => $datadog_site,
-          agent_major_version               => $_agent_major_version,
-          agent_minor_version               => $_agent_minor_version_full,
-          installer_repo_uri                => $agent_repo_uri,
-          rpm_repo_gpgcheck                 => $rpm_repo_gpgcheck,
-          apm_instrumentation_enabled       => $apm_instrumentation_enabled,
-          apm_instrumentation_libraries_str => $apm_instrumentation_libraries_str,
-          remote_updates                    => $remote_updates,
-          remote_policies                   => $remote_policies,
+        class { 'datadog_agent::redhat':
+          agent_major_version => $_agent_major_version,
+          agent_flavor        => $agent_flavor,
+          agent_repo_uri      => $agent_repo_uri,
+          manage_repo         => $manage_repo,
+          agent_version       => $agent_full_version,
+          rpm_repo_gpgcheck   => $rpm_repo_gpgcheck,
+        }
+      }
+      'Windows' : {
+        class { 'datadog_agent::windows' :
+          agent_major_version  => $_agent_major_version,
+          agent_repo_uri       => $agent_repo_uri,
+          agent_version        => $agent_full_version,
+          msi_location         => $win_msi_location,
+          api_key              => $api_key,
+          hostname             => $host,
+          tags                 => $local_tags,
+          ensure               => $win_ensure,
+          npm_install          => $windows_npm_install,
+          ddagentuser_name     => $windows_ddagentuser_name,
+          ddagentuser_password => $windows_ddagentuser_password,
+        }
+        if ($win_ensure == absent) {
+          return() #Config files will remain unchanged on uninstall
         }
       }
       'OpenSuSE', 'SLES' : {
-        class { 'datadog_agent::suse_installer':
-          api_key                           => $api_key,
-          datadog_site                      => $datadog_site,
-          agent_major_version               => $_agent_major_version,
-          agent_minor_version               => $_agent_minor_version_full,
-          installer_repo_uri                => $agent_repo_uri,
-          rpm_repo_gpgcheck                 => $rpm_repo_gpgcheck,
-          apm_instrumentation_enabled       => $apm_instrumentation_enabled,
-          apm_instrumentation_libraries_str => $apm_instrumentation_libraries_str,
-          remote_updates                    => $remote_updates,
-          remote_policies                   => $remote_policies,
+        class { 'datadog_agent::suse' :
+          agent_major_version => $_agent_major_version,
+          agent_flavor        => $agent_flavor,
+          agent_repo_uri      => $agent_repo_uri,
+          agent_version       => $agent_full_version,
+          rpm_repo_gpgcheck   => $rpm_repo_gpgcheck,
         }
       }
-      default: { fail("Class[datadog_agent::installer]: Unsupported operatingsystem: ${facts['os']['name']}") }
+      default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${facts['os']['name']}") }
     }
-  }
-
-  # If the agent is managed by the installer, we don't need to manage the agent installation
-  $_agent_managed_by_installer = ($datadog_installer_enabled and $remote_updates)
-
-  # Install agent
-  if ! $_agent_managed_by_installer {
-    if $manage_install {
-      case $facts['os']['name'] {
-        'Ubuntu','Debian','Raspbian' : {
-          if $use_apt_backup_keyserver != undef or $apt_backup_keyserver != undef or $apt_keyserver != undef {
-            notify { 'apt keyserver arguments deprecation':
-              message  => '$use_apt_backup_keyserver, $apt_backup_keyserver and $apt_keyserver are deprecated since version 3.13.0',
-              loglevel => 'warning',
-            }
-          }
-          class { 'datadog_agent::ubuntu':
-            agent_major_version   => $_agent_major_version,
-            agent_version         => $agent_full_version,
-            agent_flavor          => $agent_flavor,
-            agent_repo_uri        => $agent_repo_uri,
-            release               => $apt_release,
-            skip_apt_key_trusting => $skip_apt_key_trusting,
-          }
-        }
-        'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux','AlmaLinux','Rocky' : {
-          class { 'datadog_agent::redhat':
-            agent_major_version => $_agent_major_version,
-            agent_flavor        => $agent_flavor,
-            agent_repo_uri      => $agent_repo_uri,
-            manage_repo         => $manage_repo,
-            agent_version       => $agent_full_version,
-            rpm_repo_gpgcheck   => $rpm_repo_gpgcheck,
-          }
-        }
-        'Windows' : {
-          class { 'datadog_agent::windows' :
-            agent_major_version  => $_agent_major_version,
-            agent_repo_uri       => $agent_repo_uri,
-            agent_version        => $agent_full_version,
-            msi_location         => $win_msi_location,
-            api_key              => $api_key,
-            hostname             => $host,
-            tags                 => $local_tags,
-            ensure               => $win_ensure,
-            npm_install          => $windows_npm_install,
-            ddagentuser_name     => $windows_ddagentuser_name,
-            ddagentuser_password => $windows_ddagentuser_password,
-          }
-          if ($win_ensure == absent) {
-            return() #Config files will remain unchanged on uninstall
-          }
-        }
-        'OpenSuSE', 'SLES' : {
-          class { 'datadog_agent::suse' :
-            agent_major_version => $_agent_major_version,
-            agent_flavor        => $agent_flavor,
-            agent_repo_uri      => $agent_repo_uri,
-            agent_version       => $agent_full_version,
-            rpm_repo_gpgcheck   => $rpm_repo_gpgcheck,
-          }
-        }
-        default: { fail("Class[datadog_agent]: Unsupported operatingsystem: ${facts['os']['name']}") }
-      }
-    } else {
-      if ! defined(Package[$agent_flavor]) {
-        package { $agent_flavor:
-          ensure => present,
-          source => 'Agent installation not managed by Puppet, make sure the Agent is installed beforehand.',
-        }
+  } else {
+    if ! defined(Package[$agent_flavor]) {
+      package { $agent_flavor:
+        ensure => present,
+        source => 'Agent installation not managed by Puppet, make sure the Agent is installed beforehand.',
       }
     }
   }
 
   # Declare service
-  if ! $_agent_managed_by_installer {
-    class { 'datadog_agent::service' :
-      agent_flavor     => $agent_flavor,
-      service_ensure   => $service_ensure,
-      service_enable   => $service_enable,
-      service_provider => $service_provider,
-    }
-    if ($facts['os']['name'] != 'Windows') {
-      if ($dd_groups) {
-        user { $dd_user:
-          groups => $dd_groups,
-          notify => Service[$datadog_agent::params::service_name],
-        }
+  class { 'datadog_agent::service' :
+    agent_flavor     => $agent_flavor,
+    service_ensure   => $service_ensure,
+    service_enable   => $service_enable,
+    service_provider => $service_provider,
+  }
+  if ($facts['os']['name'] != 'Windows') {
+    if ($dd_groups) {
+      user { $dd_user:
+        groups => $dd_groups,
+        notify => Service[$datadog_agent::params::service_name],
       }
+    }
 
-      # required by reports even in agent5 scenario
-      file { '/etc/datadog-agent':
-        ensure  => directory,
-        owner   => $dd_user,
-        group   => $dd_group,
-        mode    => $datadog_agent::params::permissions_directory,
-        require => Package[$agent_flavor],
-      }
-    }
-  } else {
-    class { 'datadog_agent::service' :
-      # Declare service for agent managed by installer with installer flavor
-      agent_flavor     => 'datadog-installer',
-      service_ensure   => $service_ensure,
-      service_enable   => $service_enable,
-      service_provider => $service_provider,
-    }
-    if ($facts['os']['name'] != 'Windows') {
-      if ($dd_groups) {
-        user { $dd_user:
-          groups => $dd_groups,
-          notify => Service[$datadog_agent::params::service_name],
-        }
-      }
-      # required to manage config and install info files even with installer
-      file { '/etc/datadog-agent':
-        ensure  => directory,
-        owner   => $dd_user,
-        group   => $dd_group,
-        mode    => $datadog_agent::params::permissions_directory,
-        require => Package['datadog-installer'],
-      }
+    # required by reports even in agent5 scenario
+    file { '/etc/datadog-agent':
+      ensure  => directory,
+      owner   => $dd_user,
+      group   => $dd_group,
+      mode    => $datadog_agent::params::permissions_directory,
+      require => Package[$agent_flavor],
     }
   }
 
@@ -751,10 +652,7 @@ class datadog_agent (
     force   => $conf_dir_purge,
     owner   => $dd_user,
     group   => $dd_group,
-  }
-
-  if ! $_agent_managed_by_installer {
-    File[$_conf_dir] ~> Service[$datadog_agent::params::service_name]
+    notify  => Service[$datadog_agent::params::service_name],
   }
 
   $_local_tags = datadog_agent::tag6($local_tags, false, undef)
@@ -851,4 +749,51 @@ class datadog_agent (
   }
 
   create_resources('datadog_agent::integration', $local_integrations)
+
+  # Install the deprecated RPM/DEB installer if APM instrumentation is enabled
+  if $datadog_installer_enabled {
+    # If instrumentation is enabled and the libraries are not set, default to pinned latest versions
+    # Else, if user wants to install libraries without enabling instrumentation, use the provided libraries
+    if $apm_instrumentation_enabled and ! $apm_instrumentation_libraries {
+      $apm_instrumentation_libraries_str = join(['java:1', 'python:2', 'js:5', 'dotnet:3', 'ruby:2'], ',')
+    } elsif $apm_instrumentation_libraries {
+      $apm_instrumentation_libraries_str = join($apm_instrumentation_libraries, ',')
+    } else {
+      $apm_instrumentation_libraries_str = ''
+    }
+    case $facts['os']['name'] {
+      'Ubuntu','Debian','Raspbian': {
+        class { 'datadog_agent::ubuntu_installer':
+          api_key                           => $api_key,
+          datadog_site                      => $datadog_site,
+          installer_repo_uri                => $agent_repo_uri,
+          release                           => $apt_release,
+          skip_apt_key_trusting             => $skip_apt_key_trusting,
+          apm_instrumentation_enabled       => $apm_instrumentation_enabled,
+          apm_instrumentation_libraries_str => $apm_instrumentation_libraries_str,
+        }
+      }
+      'RedHat','CentOS','Fedora','Amazon','Scientific','OracleLinux','AlmaLinux','Rocky' : {
+        class { 'datadog_agent::redhat_installer':
+          api_key                           => $api_key,
+          datadog_site                      => $datadog_site,
+          installer_repo_uri                => $agent_repo_uri,
+          rpm_repo_gpgcheck                 => $rpm_repo_gpgcheck,
+          apm_instrumentation_enabled       => $apm_instrumentation_enabled,
+          apm_instrumentation_libraries_str => $apm_instrumentation_libraries_str,
+        }
+      }
+      'OpenSuSE', 'SLES' : {
+        class { 'datadog_agent::suse_installer':
+          api_key                           => $api_key,
+          datadog_site                      => $datadog_site,
+          installer_repo_uri                => $agent_repo_uri,
+          rpm_repo_gpgcheck                 => $rpm_repo_gpgcheck,
+          apm_instrumentation_enabled       => $apm_instrumentation_enabled,
+          apm_instrumentation_libraries_str => $apm_instrumentation_libraries_str,
+        }
+      }
+      default: { fail("Class[datadog_agent::installer]: Unsupported operatingsystem: ${facts['os']['name']}") }
+    }
+  }
 }

--- a/manifests/redhat_installer.pp
+++ b/manifests/redhat_installer.pp
@@ -3,26 +3,18 @@
 #
 # @param api_key String:Your DataDog API Key.
 # @param datadog_site String: The site of the Datadog intake to send Agent data to. Defaults to 'datadoghq.com'.
-# @param agent_major_version Integer: The major version of the Datadog agent to install. Defaults to 7.
-# @param agent_minor_version Optional[String]: The minor version of the Datadog agent to install.
 # @param installer_repo_uri Optional[String]: The URI of the installer repository.
 # @param rpm_repo_gpgcheck Optional[Boolean]: Whether to check the GPG signature of the repository.
 # @param apm_instrumentation_enabled Optional[Enum['host', 'docker', 'all']]: Enable APM instrumentation for the specified environment (host, docker, or all).
 # @param apm_instrumentation_libraries_str Optional[String]: APM instrumentation libraries as a comma-separated string.
-# @param remote_updates Boolean: Whether to enable Agent remote updates. Default: false.
-# @param remote_policies Boolean: Whether to enable Agent remote policies. Default: false.
 #
 class datadog_agent::redhat_installer (
   String $api_key = 'your_API_key',
   String $datadog_site = $datadog_agent::params::datadog_site,
-  Integer $agent_major_version = $datadog_agent::params::default_agent_major_version,
-  Optional[String] $agent_minor_version = undef,
   Optional[String] $installer_repo_uri = undef,
   Optional[Boolean] $rpm_repo_gpgcheck = undef,
   Optional[Enum['host', 'docker', 'all']] $apm_instrumentation_enabled = undef,
   Optional[String] $apm_instrumentation_libraries_str = undef,
-  Boolean $remote_updates = $datadog_agent::params::remote_updates,
-  Boolean $remote_policies = $datadog_agent::params::remote_policies,
 ) inherits datadog_agent::params {
   # Generate installer trace ID as a random 64-bit integer (Puppet does not support 128-bit integers)
   # Note: we cannot use fqdn_rand as the seed is dependent on the node, meaning the same trace ID would be generated on each run (for the same node)
@@ -107,27 +99,10 @@ class datadog_agent::redhat_installer (
     environment => [
       "DD_SITE=${datadog_site}",
       "DD_API_KEY=${api_key}",
-      "DD_AGENT_MAJOR_VERSION=${agent_major_version}",
-      "DD_AGENT_MINOR_VERSION=${agent_minor_version}",
-      "DD_REMOTE_UPDATES=${remote_updates}",
-      "DD_REMOTE_POLICIES=${remote_policies}",
       "DD_APM_INSTRUMENTATION_ENABLED=${apm_instrumentation_enabled}",
       "DD_APM_INSTRUMENTATION_LIBRARIES=${apm_instrumentation_libraries_str}",
     ],
     require     => Package['datadog-installer'],
-  }
-
-  # Check if installer owns the Datadog Agent package
-  exec {
-    'Check if installer owns the Datadog Agent package':
-      command     => '/usr/bin/datadog-installer is-installed datadog-agent',
-      environment => [
-        "DD_SITE=${datadog_site}",
-        "DD_API_KEY=${api_key}",
-      ],
-      # We allow 0, 10 (package not installed)
-      returns     => [0, 10],
-      require     => Exec['Bootstrap the installer'],
   }
 
   # Check if installer owns APM libraries
@@ -153,15 +128,10 @@ class datadog_agent::redhat_installer (
     require => Exec['Bootstrap the installer'],
   }
 
-  if $remote_updates {
-    $packages_to_install = "datadog-agent,${apm_instrumentation_libraries_str}"
-  } else {
-    $packages_to_install = $apm_instrumentation_libraries_str
-  }
   class { 'datadog_agent::installer_telemetry':
     api_key             => $api_key,
     datadog_site        => $datadog_site,
-    packages_to_install => $packages_to_install,
+    packages_to_install => $apm_instrumentation_libraries_str,
     require             => Exec['End timer'],
   }
 }

--- a/manifests/suse_installer.pp
+++ b/manifests/suse_installer.pp
@@ -3,26 +3,18 @@
 #
 # @param api_key String:Your DataDog API Key.
 # @param datadog_site String: The site of the Datadog intake to send Agent data to. Defaults to 'datadoghq.com'.
-# @param agent_major_version Integer: The major version of the Datadog agent to install. Defaults to 7.
-# @param agent_minor_version Optional[String]: The minor version of the Datadog agent to install.
 # @param installer_repo_uri Optional[String]: The URI of the installer repository.
 # @param rpm_repo_gpgcheck Optional[Boolean]: Whether to check the GPG signature of the repository.
 # @param apm_instrumentation_enabled Optional[Enum['host', 'docker', 'all']]: Enable APM instrumentation for the specified environment (host, docker, or all).
 # @param apm_instrumentation_libraries_str Optional[String]: APM instrumentation libraries as a comma-separated string.
-# @param remote_updates Boolean: Whether to enable Agent remote updates. Default: false.
-# @param remote_policies Boolean: Whether to enable Agent remote policies. Default: false.
 #
 class datadog_agent::suse_installer (
   String $api_key = 'your_API_key',
   String $datadog_site = $datadog_agent::params::datadog_site,
-  Integer $agent_major_version = $datadog_agent::params::default_agent_major_version,
-  Optional[String] $agent_minor_version = undef,
   Optional[String] $installer_repo_uri = undef,
   Optional[Boolean] $rpm_repo_gpgcheck = undef,
   Optional[Enum['host', 'docker', 'all']] $apm_instrumentation_enabled = undef,
   Optional[String] $apm_instrumentation_libraries_str = undef,
-  Boolean $remote_updates = $datadog_agent::params::remote_updates,
-  Boolean $remote_policies = $datadog_agent::params::remote_policies,
 ) inherits datadog_agent::params {
   # Generate installer trace ID as a random 64-bit integer (Puppet does not support 128-bit integers)
   # Note: we cannot use fqdn_rand as the seed is dependent on the node, meaning the same trace ID would be generated on each run (for the same node)
@@ -120,27 +112,10 @@ class datadog_agent::suse_installer (
     environment => [
       "DD_SITE=${datadog_site}",
       "DD_API_KEY=${api_key}",
-      "DD_AGENT_MAJOR_VERSION=${agent_major_version}",
-      "DD_AGENT_MINOR_VERSION=${agent_minor_version}",
-      "DD_REMOTE_UPDATES=${remote_updates}",
-      "DD_REMOTE_POLICIES=${remote_policies}",
       "DD_APM_INSTRUMENTATION_ENABLED=${apm_instrumentation_enabled}",
       "DD_APM_INSTRUMENTATION_LIBRARIES=${apm_instrumentation_libraries_str}",
     ],
     require     => Package['datadog-installer'],
-  }
-
-  # Check if installer owns the Datadog Agent package
-  exec {
-    'Check if installer owns the Datadog Agent package':
-      command     => '/usr/bin/datadog-installer is-installed datadog-agent',
-      environment => [
-        "DD_SITE=${datadog_site}",
-        "DD_API_KEY=${api_key}",
-      ],
-      # We allow 0, 10 (package not installed)
-      returns     => [0, 10],
-      require     => Exec['Bootstrap the installer'],
   }
 
   # Check if installer owns APM libraries
@@ -166,15 +141,10 @@ class datadog_agent::suse_installer (
     require => Exec['Bootstrap the installer'],
   }
 
-  if $remote_updates {
-    $packages_to_install = "datadog-agent,${apm_instrumentation_libraries_str}"
-  } else {
-    $packages_to_install = $apm_instrumentation_libraries_str
-  }
   class { 'datadog_agent::installer_telemetry':
     api_key             => $api_key,
     datadog_site        => $datadog_site,
-    packages_to_install => $packages_to_install,
+    packages_to_install => $apm_instrumentation_libraries_str,
     require             => Exec['End timer'],
   }
 }

--- a/manifests/ubuntu_installer.pp
+++ b/manifests/ubuntu_installer.pp
@@ -3,26 +3,18 @@
 #
 # @param api_key String:Your DataDog API Key.
 # @param datadog_site String: The site of the Datadog intake to send Agent data to. Defaults to 'datadoghq.com'.
-# @param agent_major_version Integer: The major version of the Datadog agent to install. Defaults to 7.
-# @param agent_minor_version Optional[String]: The minor version of the Datadog agent to install.
 # @param installer_repo_uri Optional[String]: The URI of the installer repository.
 # @param release String: The distribution channel to be used for the APT repo. Eg: 'stable' or 'beta'. Default: stable.
 # @param skip_apt_key_trusting Boolean: Skip trusting the apt key. Default is false.
-# @param manage_agent_install Boolean: Whether Puppet should manage the regular Agent installation. Default is true (inherited from $manage_install).
 # @param apt_trusted_d_keyring String: The path to the trusted keyring file.
 # @param apt_usr_share_keyring String: The path to the keyring file in /usr/share.
 # @param apt_default_keys Hash[String, String]: A hash of default APT keys and their URLs.
 # @param apm_instrumentation_enabled Optional[Enum['host', 'docker', 'all']]: Enable APM instrumentation for the specified environment (host, docker, or all).
 # @param apm_instrumentation_libraries_str Optional[String]: APM instrumentation libraries as a comma-separated string.
-# @param remote_updates Boolean: Whether to enable Agent remote updates. Default: false.
-# @param remote_policies Boolean: Whether to enable Agent remote policies. Default: false.
 #
 class datadog_agent::ubuntu_installer (
   String $api_key = 'your_API_key',
   String $datadog_site = $datadog_agent::params::datadog_site,
-  Integer $agent_major_version = $datadog_agent::params::default_agent_major_version,
-  Optional[String] $agent_minor_version = undef,
-  Boolean $manage_agent_install = true,
   Optional[String] $installer_repo_uri = undef,
   String $release = $datadog_agent::params::apt_default_release,
   Boolean $skip_apt_key_trusting = false,
@@ -43,8 +35,6 @@ class datadog_agent::ubuntu_installer (
   },
   Optional[Enum['host', 'docker', 'all']] $apm_instrumentation_enabled = undef,
   Optional[String] $apm_instrumentation_libraries_str = undef,
-  Boolean $remote_updates = $datadog_agent::params::remote_updates,
-  Boolean $remote_policies = $datadog_agent::params::remote_policies,
 ) inherits datadog_agent::params {
   # Generate installer trace ID as a random 64-bit integer (Puppet does not support 128-bit integers)
   # Note: we cannot use fqdn_rand as the seed is dependent on the node, meaning the same trace ID would be generated on each run (for the same node)
@@ -65,7 +55,7 @@ class datadog_agent::ubuntu_installer (
   }
 
   # Do not re-install keys as it is already managed in `ubuntu.pp`
-  if ! $manage_agent_install {
+  if ! $datadog_agent::manage_install {
     if !$skip_apt_key_trusting {
       stdlib::ensure_packages(['gnupg'])
 
@@ -135,27 +125,10 @@ class datadog_agent::ubuntu_installer (
     environment => [
       "DD_SITE=${datadog_site}",
       "DD_API_KEY=${api_key}",
-      "DD_AGENT_MAJOR_VERSION=${agent_major_version}",
-      "DD_AGENT_MINOR_VERSION=${agent_minor_version}",
-      "DD_REMOTE_UPDATES=${remote_updates}",
-      "DD_REMOTE_POLICIES=${remote_policies}",
       "DD_APM_INSTRUMENTATION_ENABLED=${apm_instrumentation_enabled}",
       "DD_APM_INSTRUMENTATION_LIBRARIES=${apm_instrumentation_libraries_str}",
     ],
     require     => Package['datadog-installer'],
-  }
-
-  # Check if installer owns the Datadog Agent package
-  exec {
-    'Check if installer owns the Datadog Agent package':
-      command     => '/usr/bin/datadog-installer is-installed datadog-agent',
-      environment => [
-        "DD_SITE=${datadog_site}",
-        "DD_API_KEY=${api_key}",
-      ],
-      # We allow 0, 10 (package not installed)
-      returns     => [0, 10],
-      require     => Exec['Bootstrap the installer'],
   }
 
   # Check if installer owns APM libraries
@@ -181,15 +154,10 @@ class datadog_agent::ubuntu_installer (
     require => Exec['Bootstrap the installer'],
   }
 
-  if $remote_updates {
-    $packages_to_install = "datadog-agent,${apm_instrumentation_libraries_str}"
-  } else {
-    $packages_to_install = $apm_instrumentation_libraries_str
-  }
   class { 'datadog_agent::installer_telemetry':
     api_key             => $api_key,
     datadog_site        => $datadog_site,
-    packages_to_install => $packages_to_install,
+    packages_to_install => $apm_instrumentation_libraries_str,
     require             => Exec['End timer'],
   }
 }


### PR DESCRIPTION
### What does this PR do?

* Stops managing Agent through deprecated installer and moves installer steps to the end (ensure it is done after Agent installation if there's one to avoid doing 2 keys installation on Ubuntu) c21e93c476934638b66d8e7258e6629cf573ea96
* 

### Motivation

* Same as https://github.com/DataDog/ansible-datadog/pull/665 but for Puppet


### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
