### PR TITLE
Use Agent `7.64.3` in kitchen tests and explicitly cast to Integer

### DIFF
--- a/environments/etc/manifests/site.pp
+++ b/environments/etc/manifests/site.pp
@@ -1,6 +1,8 @@
 node default {
   class { 'datadog_agent':
     api_key             => 'somenonnullapikeythats32charlong',
+    # Pin the Agent version to 7.64.3 to avoid breaking changes in postint for kitchen tests
+    agent_version       => '7.64.3',
     agent_extra_options => {
       use_http => true,
     },

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -19,7 +19,7 @@ class datadog_agent::redhat (
     ]
     #In this regex, version '1:6.15.0~rc.1-1' would match as $1='1:', $2='6', $3='15', $4='0', $5='~rc.1', $6='1'
     if $agent_version =~ /([0-9]+:)?([0-9]+)\.([0-9]+)\.([0-9]+)((?:~|-)[^0-9\s-]+[^-\s]*)?(?:-([0-9]+))?/ or $agent_version == 'latest' {
-      if $agent_major_version >= 6 and ($agent_version == 'latest' or 0 + $3 > 35) {
+      if $agent_major_version >= 6 and ($agent_version == 'latest' or Integer($3, 10) > 35) {
         $keys = $all_keys[0,3]
       } else {
         $keys = $all_keys

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -19,7 +19,7 @@ class datadog_agent::suse (
   ]
   #In this regex, version '1:6.15.0~rc.1-1' would match as $1='1:', $2='6', $3='15', $4='0', $5='~rc.1', $6='1'
   if $agent_version =~ /([0-9]+:)?([0-9]+)\.([0-9]+)\.([0-9]+)((?:~|-)[^0-9\s-]+[^-\s]*)?(?:-([0-9]+))?/ or $agent_version == 'latest' {
-    if $agent_major_version >= 6 and ($agent_version == 'latest' or 0 + $3 > 35) {
+    if $agent_major_version >= 6 and ($agent_version == 'latest' or Integer($3, 10) > 35) {
       $keys_to_use = $all_keys[0,3]
     } else {
       $keys_to_use = $all_keys


### PR DESCRIPTION
### What does this PR do?

* Uses `7.64.3` pinned version for Agent kitchen tests
* Explicitly cast to Integer for version comparison

### Motivation

* Newer Agent versions have modified postint commands, preventing the service to "start" in our fake Linux VMs (containers) making the test fail
* Casting is necessary for Puppet 8 to avoid eval error:
```shell
       Error: Evaluation Error: The string '64' was automatically coerced to the numerical value 64 (file: /tmp/kitchen/modules/datadog_agent/manifests/redhat.pp, line: 22, column: 75) on node 8fa627f1eb0f.ec2.internal
```

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
