### PR TITLE
Include libyaml-dev to fix psych dependency

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -22,7 +22,7 @@ platforms:
     - wget https://apt.puppet.com/puppet8-release-noble.deb
     - dpkg -i puppet8-release-noble.deb #installs the puppet-agent repo
     - apt-get update
-    - apt-get install -y puppet-agent rubygems ruby-dev make gcc
+    - apt-get install -y puppet-agent rubygems ruby-dev make gcc libyaml-dev
     - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
     - mkdir /home/kitchen/puppet
@@ -42,7 +42,7 @@ platforms:
     - wget https://apt.puppet.com/puppet8-release-jammy.deb
     - dpkg -i puppet8-release-jammy.deb #installs the puppet-agent repo
     - apt-get update
-    - apt-get install -y puppet-agent rubygems ruby-dev make gcc
+    - apt-get install -y puppet-agent rubygems ruby-dev make gcc libyaml-dev
     - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
     - mkdir /home/kitchen/puppet -p
@@ -62,7 +62,7 @@ platforms:
     - wget https://apt.puppet.com/puppet7-release-focal.deb
     - dpkg -i puppet7-release-focal.deb #installs the puppet-agent repo
     - apt-get update
-    - apt-get install -y puppet-agent rubygems ruby-dev
+    - apt-get install -y puppet-agent rubygems ruby-dev libyaml-dev
     - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
     - mkdir /home/kitchen/puppet
@@ -89,6 +89,7 @@ platforms:
     - rpm -Uvh https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
     - yum install -y puppet-agent-8.10.0 rubygems ruby-devel procps-ng
     - dnf group install -y "Development Tools"
+    - dnf install -y libyaml-devel
     - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
     - mkdir /home/kitchen/puppet -p
@@ -117,6 +118,7 @@ platforms:
     - rpm -Uvh https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
     - yum install -y puppet-agent-8.10.0 rubygems ruby-devel procps-ng
     - dnf group install -y "Development Tools" --nobest
+    - dnf install -y libyaml-devel
     - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
     - mkdir /home/kitchen/puppet -p


### PR DESCRIPTION
### What does this PR do?

* Includes `libyaml-dev` in Dockerfile

### Motivation

Fix Kitchen tests failing:
```shell
#32 33.64     current directory: /usr/share/gems/gems/psych-5.2.6/ext/psych
#32 33.64 /usr/bin/ruby -I /usr/share/rubygems extconf.rb
#32 33.64 checking for yaml.h... no
#32 33.64 yaml.h not found
[...]

33.64 In Gemfile:
33.64   kitchen-puppet was resolved to 3.7.0, which depends on
33.64     test-kitchen was resolved to 3.9.0, which depends on
33.64       irb was resolved to 1.15.2, which depends on
33.64         rdoc was resolved to 6.14.2, which depends on
33.64           psych
```

Solution is to install the dependency https://github.com/rails/rails/issues/53306#issuecomment-2412874681

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
