### PR TITLE
remove pycache directory during upgrades

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -441,6 +441,15 @@ class datadog_agent (
 
   # Install agent
   if $manage_install {
+    # Ensure legacy Python bytecode cache directory is removed before Agent package installation (Linux only)
+    if ($facts['os']['name'] != 'Windows' and $facts['os']['family'] != 'Darwin') {
+      file { '/opt/datadog-agent/python-scripts/__pycache__':
+        ensure  => absent,
+        recurse => true,
+        force   => true,
+        before  => Package[$agent_flavor],
+      }
+    }
     case $facts['os']['name'] {
       'Ubuntu','Debian','Raspbian' : {
         if $use_apt_backup_keyserver != undef or $apt_backup_keyserver != undef or $apt_keyserver != undef {


### PR DESCRIPTION
This PR removes /opt/datadog-agent/python-scripts/__pycache__ similarly to other installation methods.
