### PR TITLE
Use forked kitchen-docker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ group :development do
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "bcrypt_pbkdf", '= 1.0.1',                 require: false
   gem "kitchen-puppet"
-  gem "kitchen-docker", '~> 3.0.0',              require: false
+  gem "kitchen-docker", git: "https://github.com/DataDog/kitchen-docker.git", branch: 'main', require: false
   gem "kitchen-verifier-serverspec"
   gem "rexml", '~> 3.4.0',                       require: false
   gem "mixlib-shellout", "~> 2.2.7",             platforms: [:ruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/DataDog/kitchen-docker.git
-  revision: 35c3bac8c0922fced70aeab3dbba3ef467aa5b05
+  revision: ef614e7789c947825cb5774cde03b0ffbbb8563a
+  branch: main
   specs:
     kitchen-docker (3.0.0)
       test-kitchen (>= 1.0.0, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/DataDog/kitchen-docker.git
+  revision: 35c3bac8c0922fced70aeab3dbba3ef467aa5b05
+  specs:
+    kitchen-docker (3.0.0)
+      test-kitchen (>= 1.0.0, < 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -128,8 +135,6 @@ GEM
       bigdecimal (~> 3.1)
     jwt (2.10.1)
       base64
-    kitchen-docker (3.0.0)
-      test-kitchen (>= 1.0.0)
     kitchen-puppet (3.7.0)
       librarian-puppet (>= 3.0)
       net-ssh (>= 3)
@@ -518,7 +523,7 @@ DEPENDENCIES
   facterdb (~> 3.4.0)
   io-console (= 0.7.2)
   json (= 2.6.3)
-  kitchen-docker (~> 3.0.0)
+  kitchen-docker!
   kitchen-puppet
   kitchen-verifier-serverspec
   librarian-puppet (~> 5.0)


### PR DESCRIPTION
### What does this PR do?

 Use forked kitchen-docker gem, which contains fix for openssh deprecation. 

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
