### PR TITLE
Backport MongoDB hosts array support to 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+# Unreleased
+
+* [BUGFIX] Backport MongoDB hosts array support from main to fix broken connection strings with modern configuration format
+
 # 3.24.0 / 2025-02-25
 
 * [BUGFIX] Fix incorrect SSL parameter data type for postgres integration ([#824])

--- a/manifests/integrations/mongo.pp
+++ b/manifests/integrations/mongo.pp
@@ -2,19 +2,26 @@
 #
 # This class will install the necessary configuration for the mongo integration
 #
+# See the sample mongo.d/conf.yaml for all available configuration options
+# https://github.com/DataDog/integrations-core/blob/master/mongo/datadog_checks/mongo/data/conf.yaml.example
+#
 # NOTE: In newer versions of the Datadog Agent, the ssl parameters will be deprecated in favor the tls variants
 #
 # Parameters:
+#   $hosts
+#       Array of hosts host (and optional port number) where the mongod instance is running
+#   $dbm
+#       Enable the Database Monitoring feature
+#   $database_autodiscovery
+#       Enable the Database Autodiscovery feature
+#   $reported_database_hostname
+#       Optional database hostname override the mongodb hostname detected by the Agent from mongodb admin command serverStatus
 #   $additional_metrics
 #       Optional array of additional metrics
 #   $database
 #       Optionally specify database to query. Defaults to 'admin'
-#   $host:
-#       The host mongo is running on. Defaults to '127.0.0.1'
 #   $password
 #       Optionally specify password for connection
-#   $port
-#       The port mongo is running on. Defaults to 27017
 #   $ssl
 #       Optionally enable SSL for connection
 #   $ssl_ca_certs
@@ -37,6 +44,12 @@
 #       Optional array of tags
 #   $username
 #       Optionally specify username for connection
+#   $host:
+#       Deprecated use $hosts instead
+#       The host mongo is running on. Defaults to '127.0.0.1'
+#   $port
+#       Deprecated use $hosts instead
+#       The port mongo is running on. Defaults to 27017
 #
 # Sample Usage (Older Agent Versions):
 #
@@ -73,19 +86,20 @@
 #      {
 #        'additional_metrics' => ['top'],
 #        'database'           => 'database_name',
-#        'host'               => 'localhost',
+#        'hosts'              => ['localhost:27017'],
 #        'password'           => 'mongo_password',
-#        'port'               => '27017',
 #        'tls'                => true,
 #        'tls_ca_file'       => '/path/to/ca.pem',
 #        'tls_allow_invalid_certificates'      => false,
 #        'tls_certificate_key_file'       => '/path/to/combined.pem',
 #        'tags'               => ['optional_tag1', 'optional_tag2'],
 #        'username'           => 'mongo_username',
+#        'dbm'                => true,
+#        'database_autodiscovery' => {'enabled' => true},
+#        'reported_database_hostname' => 'mymongodbhost',
 #      },
 #      {
-#        'host'               => 'localhost',
-#        'port'               => '27018',
+#        'hosts'              => ['localhost:27017'],
 #        'tags'               => [],
 #        'additional_metrics' => [],
 #        'collections'        => [],

--- a/spec/classes/datadog_agent_integrations_mongo_spec.rb
+++ b/spec/classes/datadog_agent_integrations_mongo_spec.rb
@@ -27,6 +27,32 @@ describe 'datadog_agent::integrations::mongo' do
         it { is_expected.to contain_file(conf_file).without_content(%r{tags:}) }
       end
 
+      context 'with one mongo host defined in hosts array' do
+        let(:params) do
+          {
+            servers: [
+              {
+                'hosts' => ['localhost:27017'],
+                'username' => 'user',
+                'password' => 'pass',
+                'database' => 'admin',
+                'dbm' => true,
+                'database_autodiscovery' => { 'enabled' => true },
+                'reported_database_hostname' => 'mongohost',
+              },
+            ],
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{- hosts:\s+- localhost:27017}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{username: user}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{password: pass}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{database: admin}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{dbm: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{database_autodiscovery:\s+enabled: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{reported_database_hostname: mongohost}) }
+      end
+
       context 'with one mongo' do
         let(:params) do
           {

--- a/templates/agent-conf.d/mongo.yaml.erb
+++ b/templates/agent-conf.d/mongo.yaml.erb
@@ -4,7 +4,24 @@ init_config:
 
 instances:
 <% @servers.each do |server| -%>
+  <% if !server['hosts'].nil? && server['hosts'].any? -%>
+  - hosts:
+    <%- server['hosts'].each do |host| -%>
+      - <%= host %>
+    <%- end -%>
+    <%- if !server['username'].nil? -%>
+      username: <%= server['username'] %>
+    <%- end -%>
+    <%- if !server['password'].nil? -%>
+      password: <%= server['password'] %>
+    <%- end -%>
+    <%- if !server['database'].nil? -%>
+      database: <%= server['database'] %>
+    <%- end -%>
+  <%- end -%>
+  <% if server['hosts'].nil? -%>
   - server: mongodb://<%= server['username'] %><%= ":" unless server['password'].nil? %><%= server['password'] %><%= "@" unless server['username'].nil? %><%= server['host'] %>:<%= server['port'] %>/<%= server['database'] %>
+  <%- end -%>
   <%- if !server['tags'].nil? && server['tags'].any? -%>
     tags:
     <%- server['tags'].each do |tag| -%>
@@ -49,5 +66,17 @@ instances:
     <%- server['collections'].each do |collection| -%>
       - <%= collection %>
     <%- end -%>
+  <%- end -%>
+  <%- if !server['dbm'].nil? -%>
+    dbm: <%= server['dbm'] %>
+  <%- end -%>
+  <%- if !server['database_autodiscovery'].nil? -%>
+    database_autodiscovery:
+    <%- if !server['database_autodiscovery']['enabled'].nil? -%>
+      enabled: <%= server['database_autodiscovery']['enabled'] %>
+    <%- end -%>
+  <%- end -%>
+  <%- if !server['reported_database_hostname'].nil? -%>
+    reported_database_hostname: <%= server['reported_database_hostname'] %>
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
### What does this PR do?

Backports the MongoDB `hosts` array support from `main` branch (PR #838, commit 9472fc7) to the `3.x` branch to fix broken connection strings when using modern MongoDB configuration format.

This resolves the issue where users providing modern `hosts` array parameters get malformed MongoDB URIs like `mongodb://user:pass@:/admin` (missing host:port).

### Motivation

**Problem:**
Organizations running the 3.x branch experience broken MongoDB monitoring when using modern configuration format. The template expects legacy `host`/`port` parameters but receives `hosts` array, causing nil values that produce malformed connection strings.

**Impact:**
- MongoDB monitoring fails with invalid connection URIs
- Users must use deprecated `host`/`port` format (inconsistent with current Datadog documentation)
- Modern MongoDB features (DBM, database autodiscovery) unavailable on 3.x

**Why backport:**
- The fix exists and is proven in `main` branch (merged Feb 26, 2025)
- There are production environments still on 3.x (less than 1 year since 4.0 released)
- Low risk, high value for 3.x users
- Maintains backward compatibility with legacy configurations

### Additional Notes

**Changes included in this backport:**

1. **Template** (`templates/agent-conf.d/mongo.yaml.erb`):
   - Dual-path rendering: checks if `hosts` parameter exists
   - Modern path: renders hosts array format (lines 7-21)
   - Legacy path: renders connection string format (lines 22-24)
   - Adds rendering for `dbm`, `database_autodiscovery`, `reported_database_hostname`

2. **Manifest** (`manifests/integrations/mongo.pp`):
   - Documents new parameters: `hosts`, `dbm`, `database_autodiscovery`, `reported_database_hostname`
   - Deprecates `host` and `port` parameters in favor of `hosts` array
   - Updates examples to show modern format
   - Adds reference to official Datadog integration documentation

3. **Tests** (`spec/classes/datadog_agent_integrations_mongo_spec.rb`):
   - Adds test context for hosts array configuration
   - Verifies modern format renders correctly
   - Tests all new parameters (dbm, database_autodiscovery, reported_database_hostname)
   - Maintains backward compatibility (existing tests unchanged)

4. **CHANGELOG** (`CHANGELOG.md`):
   - Documents backport in Unreleased section

**Backward Compatibility:**
✅ Fully backward compatible - legacy `host`/`port` configurations continue to work unchanged

**Original implementation:**
- Author: Zhengda Lu (@zhengdalu)
- Commit: 9472fc724013946bfaf92ea31564e0b26420d293
- PR: #838 (merged to main Feb 26, 2025)

### Describe your test plan

**Automated Testing:**
- ✅ pre-commit checks: PASSED
- ✅ `pdk validate --parallel`: PASSED (only expected warnings for undocumented classes)
- ✅ Full RSpec suite: 4895 examples, 0 failures, 63 pending
- ✅ Syntax validation: PASSED
- ✅ New tests verify hosts array format renders correctly
- ✅ Existing tests verify backward compatibility maintained

**Test scenarios covered:**
1. Default parameters (legacy format) - existing test
2. Legacy host/port format - existing tests
3. **NEW:** Modern hosts array format - new test
4. **NEW:** New parameters (dbm, database_autodiscovery, reported_database_hostname) - new test
5. Multiple servers - existing tests
6. Collections and additional_metrics - existing tests

