### PR TITLE
Fix Issue 804 by specifying $datadog_agent::dduser and dd_group for…

### DIFF
--- a/manifests/security_agent.pp
+++ b/manifests/security_agent.pp
@@ -20,8 +20,8 @@ class datadog_agent::security_agent (
 
   if $facts['os']['name'] == 'Windows' {
     file { 'C:/ProgramData/Datadog/security-agent.yaml':
-      owner   => $datadog_agent::params::dd_user,
-      group   => $datadog_agent::params::dd_group,
+      owner   => $datadog_agent::dd_user,
+      group   => $datadog_agent::dd_group,
       mode    => '0640',
       content => template('datadog_agent/security-agent.yaml.erb'),
       require => File['C:/ProgramData/Datadog'],

--- a/manifests/system_probe.pp
+++ b/manifests/system_probe.pp
@@ -35,8 +35,8 @@ class datadog_agent::system_probe (
 
   if $facts['os']['name'] == 'Windows' {
     file { 'C:/ProgramData/Datadog/system-probe.yaml':
-      owner   => $datadog_agent::params::dd_user,
-      group   => $datadog_agent::params::dd_group,
+      owner   => $datadog_agent::dd_user,
+      group   => $datadog_agent::dd_group,
       mode    => '0640',
       content => template('datadog_agent/system_probe.yaml.erb'),
       require => File['C:/ProgramData/Datadog'],


### PR DESCRIPTION
### What does this PR do?

Fix Issue #804 by specifying $datadog_agent::dduser and dd_group for security-agent.yml and system-probe.yaml.

### Motivation

Experiencing issue 804.

### Additional Notes

### Describe your test plan
Tested on my own domain controller node and fixes the issue.